### PR TITLE
Added FreePBX installation script

### DIFF
--- a/ct/freepbx.sh
+++ b/ct/freepbx.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: Arian Nasr (arian-nasr)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.freepbx.org/
+
+APP="FreePBX"
+var_tags=""
+var_cpu="1"
+var_ram="1024"
+var_disk="20"
+var_os="debian"
+var_version="12"
+var_unprivileged="1"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+    header_info
+    check_container_storage
+    check_container_resources
+
+    # Check if installation is present | -f for file, -d for folder
+    if [[ ! -f /lib/systemd/system/freepbx.service ]]; then
+        msg_error "No ${APP} Installation Found!"
+        exit
+    fi
+    msg_error "Currently we don't provide an update function for this ${APP}."
+    exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"

--- a/install/freepbx-install.sh
+++ b/install/freepbx-install.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: Arian Nasr (arian-nasr)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.freepbx.org/
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc \
+  build-essential \
+  git \
+  wget \
+  libnewt-dev \
+  libssl-dev \
+  libncurses5-dev \
+  subversion \
+  libsqlite3-dev \
+  libjansson-dev \
+  libxml2-dev \
+  uuid-dev \
+  default-libmysqlclient-dev \
+  htop \
+  sngrep \
+  lame \
+  ffmpeg \
+  mpg123 \
+  vim \
+  expect \
+  openssh-server \
+  apache2 \
+  mariadb-server \
+  mariadb-client \
+  bison \
+  flex \
+  php8.2 \
+  php8.2-{curl,cli,common,mysql,gd,mbstring,intl,xml} \
+  php-pear \
+  sox \
+  sqlite3 \
+  pkg-config \
+  automake \
+  libtool \
+  autoconf \
+  unixodbc-dev \
+  uuid \
+  libasound2-dev \
+  libogg-dev \
+  libvorbis-dev \
+  libicu-dev \
+  libcurl4-openssl-dev \
+  odbc-mariadb \
+  libical-dev \
+  libneon27-dev \
+  libsrtp2-dev \
+  libspandsp-dev \
+  subversion \
+  libtool-bin \
+  python-dev-is-python3 \
+  unixodbc \
+  software-properties-common \
+  nodejs \
+  npm \
+  ipset \
+  iptables \
+  fail2ban \
+  php-soap
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Asterisk (Patience)"
+cd /usr/src
+wget -q http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-21-current.tar.gz
+tar xf asterisk-21-current.tar.gz
+cd asterisk-21.*
+$STD contrib/scripts/get_mp3_source.sh
+$STD contrib/scripts/install_prereq install
+$STD ./configure  --libdir=/usr/lib64 --with-pjproject-bundled --with-jansson-bundled
+$STD make
+$STD make install
+$STD make samples
+$STD make config
+ldconfig
+msg_ok "Installed Asterisk"
+
+msg_info "Setup Asterisk"
+groupadd asterisk
+useradd -r -d /var/lib/asterisk -g asterisk asterisk
+usermod -aG audio,dialout asterisk
+chown -R asterisk:asterisk /etc/asterisk
+chown -R asterisk:asterisk /var/{lib,log,spool}/asterisk
+chown -R asterisk:asterisk /usr/lib64/asterisk
+sed -i 's|#AST_USER|AST_USER|' /etc/default/asterisk
+sed -i 's|#AST_GROUP|AST_GROUP|' /etc/default/asterisk
+sed -i 's|;runuser|runuser|' /etc/asterisk/asterisk.conf
+sed -i 's|;rungroup|rungroup|' /etc/asterisk/asterisk.conf
+echo "/usr/lib64" >> /etc/ld.so.conf.d/x86_64-linux-gnu.conf
+ldconfig
+msg_ok "Done Setup Asterisk"
+
+msg_info "Setup Apache"
+sed -i 's/\(^upload_max_filesize = \).*/\120M/' /etc/php/8.2/apache2/php.ini
+sed -i 's/\(^memory_limit = \).*/\1256M/' /etc/php/8.2/apache2/php.ini
+sed -i 's/^\(User\|Group\).*/\1 asterisk/' /etc/apache2/apache2.conf
+sed -i 's/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+$STD a2enmod rewrite
+systemctl restart apache2
+rm /var/www/html/index.html
+msg_ok "Done Setup Apache"
+
+# Configure ODBC
+cat <<EOF > /etc/odbcinst.ini
+[MySQL]
+Description = ODBC for MySQL (MariaDB)
+Driver = /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
+FileUsage = 1
+EOF
+
+cat <<EOF > /etc/odbc.ini
+[MySQL-asteriskcdrdb]
+Description = MySQL connection to 'asteriskcdrdb' database
+Driver = MySQL
+Server = localhost
+Database = asteriskcdrdb
+Port = 3306
+Socket = /var/run/mysqld/mysqld.sock
+Option = 3
+EOF
+
+msg_info "Installing FreePBX"
+cd /usr/local/src
+wget -q http://mirror.freepbx.org/modules/packages/freepbx/freepbx-17.0-latest-EDGE.tgz
+tar zxf freepbx-17.0-latest-EDGE.tgz
+cd /usr/local/src/freepbx/
+$STD ./start_asterisk start
+# Even though the php code completes successfully, it is returning non-zero exit code, so in the next line we return true, needed for successful installation
+# For some reason the next line is outputting even when verbosity not enabled?
+$STD ./install -n || true
+$STD fwconsole ma installall
+$STD fwconsole reload
+$STD fwconsole restart
+msg_ok "Installed FreePBX"
+
+msg_info "Setup FreePBX Service"
+cat <<EOF > /etc/systemd/system/freepbx.service
+[Unit]
+Description=FreePBX VoIP Server
+After=mariadb.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/fwconsole start -q
+ExecStop=/usr/sbin/fwconsole stop -q
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable -q --now freepbx
+msg_ok "Done Setup FreePBX Service"
+
+motd_ssh
+customize
+
+# Cleanup
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/json/freepbx.json
+++ b/json/freepbx.json
@@ -1,0 +1,34 @@
+{
+    "name": "FreePBX",
+    "slug": "freepbx",
+    "categories": [
+        0
+    ],
+    "date_created": "2025-03-10",
+    "type": "ct",
+    "updateable": false,
+    "privileged": false,
+    "interface_port": 80,
+    "documentation": "https://sangomakb.atlassian.net/wiki/spaces/FP/overview?homepageId=8454359",
+    "website": "https://www.freepbx.org/",
+    "logo": "https://avatars.githubusercontent.com/u/696423?s=200&v=4",
+    "description": "FreePBX is a web-based open-source graphical user interface that manages Asterisk, a voice over IP and telephony server.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/freepbx.sh",
+            "resources": {
+                "cpu": 1,
+                "ram": 1024,
+                "hdd": 20,
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": null,
+        "password": null
+    },
+    "notes": []
+}


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  
Added FreePBX installation script based on instructions from: https://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682545/How+to+Install+FreePBX+17+on+Debian+12+with+Asterisk+21

## 🔗 Related PR / Discussion / Issue  

Link: # https://github.com/community-scripts/ProxmoxVED/pull/25

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  

Please see the two comments in freepbx-install.sh lines 145-147 as I am needing a workaround to complete the installation successfully, I don't fully comprehend why this is happening, I'd appreciate any input. The script return a non-zero exit code even though it completes successfully?
In any case the script works as is, but I'd like to be able to fix that if possible.
Here is a screenshot showing output being bypassed when verbosity disabled:
![Screenshot From 2025-03-10 19-23-50](https://github.com/user-attachments/assets/5ff97ffd-6b20-4e5c-b903-dbcbc6369ad7)