### PR TITLE
Fix port being hardcoded in debian service file

### DIFF
--- a/scripts/tools/filebrowser.sh
+++ b/scripts/tools/filebrowser.sh
@@ -150,8 +150,8 @@ After=network-online.target
 User=root
 WorkingDirectory=/usr/local/community-scripts
 ExecStartPre=/bin/touch /usr/local/community-scripts/filebrowser.db
-ExecStartPre=/usr/local/bin/filebrowser config set -a "0.0.0.0" -p 9000 -d /usr/local/community-scripts/filebrowser.db
-ExecStart=/usr/local/bin/filebrowser -r / -d /usr/local/community-scripts/filebrowser.db -p 9000
+ExecStartPre=/usr/local/bin/filebrowser config set -a "0.0.0.0" -p ${PORT} -d /usr/local/community-scripts/filebrowser.db
+ExecStart=/usr/local/bin/filebrowser -r / -d /usr/local/community-scripts/filebrowser.db -p ${PORT}
 Restart=always
 
 [Install]


### PR DESCRIPTION
The port file in filebrowser.sh was hard coded to 9000 in the Debian service file. I have changed it to ${PORT) so it reads the variable instead.

🛑 **New scripts must first be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.**  
PRs for new scripts that skip this process will be closed.

---

## ✍️ Description  
<!-- Briefly describe your changes. -->  
I updated the filebrowser.sh file to use the $PORT variable instead of hard-coding port 9000 into the Debian service file.

## 🔗 Related PR / Issue  

Link: #https://github.com/community-scripts/ProxmoxVE/issues/3096

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->
User in linked issue noticed that Filebrowser was running on port 9000 instead of the selected port. After investigating I found that the port 9000 was hard-coded into the script.
