### PR TITLE
Update immich-install.sh

### DIFF
--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -258,7 +258,7 @@ ML_DIR="${APP_DIR}/machine-learning"
 GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p "$INSTALL_DIR"
 mv "$APPLICATION-$RELEASE"/ "$SRC_DIR"
-mkdir -p "{$APP_DIR,$UPLOAD_DIR,$GEO_DIR,$ML_DIR,$INSTALL_DIR/.cache}"
+mkdir -p {$APP_DIR,$UPLOAD_DIR,$GEO_DIR,$ML_DIR,$INSTALL_DIR/.cache}
 
 cd "$SRC_DIR"/server || exit
 $STD npm ci


### PR DESCRIPTION
I have this error when trying to install--> cp: target '/opt/immich/app/': No such file or directory
 ⠙
[ERROR] in line 274: exit code 0: while executing command cp -a server/{node_modules,dist,bin,resources,package.json,package-lock.json,start*.sh} "$APP_DIR"/ curl: (22) The requested URL returned error: 400 I think removing quotations marks could solve the issue