### PR TITLE
Remove redundant globaleaks configuration variable

### DIFF
--- a/install/globaleaks-install.sh
+++ b/install/globaleaks-install.sh
@@ -16,7 +16,7 @@ msg_info "Setup GlobaLeaks"
 DISTRO_CODENAME="$(awk -F= '/^VERSION_CODENAME=/{print $2}' /etc/os-release)"
 curl -fsSL https://deb.globaleaks.org/globaleaks.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/globaleaks.gpg
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/globaleaks.gpg] http://deb.globaleaks.org $DISTRO_CODENAME/" >/etc/apt/sources.list.d/globaleaks.list
-echo -ne 'APPARMOR_SANDBOXING=0\nNETWORK_SANDBOXING=0' >/etc/default/globaleaks
+echo -ne 'APPARMOR_SANDBOXING=0' >/etc/default/globaleaks
 $STD apt update
 $STD apt -y install globaleaks
 msg_ok "Setup GlobaLeaks"


### PR DESCRIPTION
@tremor021 @MickLesk : actually while retesting i just noticed that the variable NETWORK_SANDBOXING does not exist anymore.

Iptables is already and always used to make the app be reachable va port 80 and 443 that are mapped on 8080 and 8443.

You can safely apply this patch.

Thank you so much!