### PR TITLE
Fix variable syntax in guardian-install.sh

### DIFF
--- a/install/guardian-install.sh
+++ b/install/guardian-install.sh
@@ -28,7 +28,7 @@ cd /opt/guardian/frontend
 $STD npm ci
 export DEPLOYMENT_MODE=standalone
 $STD npm run build
-msg_ok "Configured {APPLICATION}"
+msg_ok "Configured ${APPLICATION}"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/guardian-backend.service


### PR DESCRIPTION
## **Scripts wich are clearly AI generated and not further revied by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
<!-- Briefly describe your changes. -->  
Fix syntax issue for env var not displaying app name correctly

## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
