### PR TITLE
feat: add speedtest tracker for test

### DIFF
--- a/ct/speedtest-tracker.sh
+++ b/ct/speedtest-tracker.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: AlphaLawless
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/alexjustesen/speedtest-tracker
+
+APP="Speedtest-Tracker"
+var_tags="${var_tags:-monitoring}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/speedtest-tracker ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  RELEASE=$(curl -fsSL https://api.github.com/repos/alexjustesen/speedtest-tracker/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  if [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]] || [[ ! -f /opt/${APP}_version.txt ]]; then
+    msg_info "Stopping $APP"
+    systemctl stop speedtest-tracker
+    msg_ok "Stopped $APP"
+
+    msg_info "Creating Backup"
+    cp -r /opt/speedtest-tracker /opt/speedtest-tracker-backup
+    msg_ok "Backup Created"
+
+    msg_info "Updating $APP to v${RELEASE}"
+    cd /opt
+    rm -rf speedtest-tracker-update
+    curl -fsSL "https://github.com/alexjustesen/speedtest-tracker/archive/refs/tags/v${RELEASE}.tar.gz" -o v${RELEASE}.tar.gz
+    tar -xzf v${RELEASE}.tar.gz
+    mv speedtest-tracker-${RELEASE} speedtest-tracker-update
+
+    cp /opt/speedtest-tracker/.env /opt/speedtest-tracker-update/.env
+    cp -r /opt/speedtest-tracker/storage/app/* /opt/speedtest-tracker-update/storage/app/ 2>/dev/null || true
+
+    cd /opt/speedtest-tracker-update
+    export COMPOSER_ALLOW_SUPERUSER=1
+    $STD composer install --optimize-autoloader --no-dev
+    $STD npm ci
+    $STD npm run build
+    $STD php artisan migrate --force
+    $STD php artisan config:clear
+    $STD php artisan cache:clear
+    $STD php artisan view:clear
+
+    rm -rf /opt/speedtest-tracker
+    mv /opt/speedtest-tracker-update /opt/speedtest-tracker
+    chown -R www-data:www-data /opt/speedtest-tracker
+    chmod -R 755 /opt/speedtest-tracker/storage
+    chmod -R 755 /opt/speedtest-tracker/bootstrap/cache
+    msg_ok "Updated $APP to v${RELEASE}"
+
+    msg_info "Starting $APP"
+    systemctl start speedtest-tracker
+    msg_ok "Started $APP"
+
+    msg_info "Cleaning Up"
+    rm -rf /opt/v${RELEASE}.tar.gz
+    rm -rf /opt/speedtest-tracker-backup
+    msg_ok "Cleanup Completed"
+
+    echo "${RELEASE}" >/opt/${APP}_version.txt
+    msg_ok "Update Successful"
+  else
+    msg_ok "No update required. ${APP} is already at v${RELEASE}"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"

--- a/frontend/public/json/speedtest-tracker.json
+++ b/frontend/public/json/speedtest-tracker.json
@@ -1,0 +1,39 @@
+{
+    "name": "Speedtest Tracker",
+    "slug": "speedtest-tracker",
+    "categories": [
+        4
+    ],
+    "date_created": "2025-01-24",
+    "type": "ct",
+    "updateable": true,
+    "privileged": false,
+    "interface_port": 80,
+    "documentation": "https://docs.speedtest-tracker.dev",
+    "website": "https://github.com/alexjustesen/speedtest-tracker",
+    "logo": "https://raw.githubusercontent.com/alexjustesen/speedtest-tracker/main/.github/screenshots/speedtest-tracker-logo.png",
+    "config_path": "/opt/speedtest-tracker/.env",
+    "description": "Speedtest Tracker is a self-hosted application built with Laravel that monitors your internet connection's performance and uptime over time. It automatically runs speed tests using Ookla's official Speedtest CLI, capturing detailed metrics including download/upload speeds, ping, packet loss, and jitter. Features include scheduled automated tests, historical data tracking with beautiful responsive dashboards, customizable notification alerts (Discord, Slack, Telegram, email) for performance drops, multi-database support (SQLite, MySQL, PostgreSQL), data export capabilities, InfluxDB integration, multi-user support with role-based access control, and mobile-friendly interface. Perfect for tracking ISP performance, verifying advertised speeds, identifying network patterns, and maintaining accountability with your Internet Service Provider.",    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/speedtest-tracker.sh",
+            "resources": {
+                "cpu": 2,
+                "ram": 2048,
+                "hdd": 4,
+                "os": "debian",
+                "version": "13"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin@example.com",
+        "password": "password"
+    },
+    "notes": [
+        {
+            "text": "Database Default is SQLite stored at /opt/speedtest-tracker/database/database.sqlite",
+            "type": "info"
+        }
+    ]
+}

--- a/install/speedtest-tracker-install.sh
+++ b/install/speedtest-tracker-install.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: AlphaLawless
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/alexjustesen/speedtest-tracker
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  curl \
+  sudo \
+  mc \
+  git \
+  gnupg2 \
+  ca-certificates \
+  lsb-release \
+  apt-transport-https \
+  nginx \
+  sqlite3
+msg_ok "Installed Dependencies"
+
+msg_info "Installing Speedtest CLI"
+SPEEDTEST_VERSION="1.2.0"
+curl -fsSL "https://install.speedtest.net/app/cli/ookla-speedtest-${SPEEDTEST_VERSION}-linux-x86_64.tgz" -o /tmp/speedtest-cli.tgz
+tar -xzf /tmp/speedtest-cli.tgz -C /usr/bin
+rm -f /tmp/speedtest-cli.tgz
+msg_ok "Installed Speedtest CLI"
+
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="bcmath,cli,common,curl,mbstring,xml,zip,sqlite3,gd,intl,redis" setup_php
+
+msg_info "Configuring PHP-FPM runtime directory"
+mkdir -p /etc/systemd/system/php8.4-fpm.service.d/
+cat > /etc/systemd/system/php8.4-fpm.service.d/override.conf <<'EOF'
+[Service]
+RuntimeDirectory=php
+RuntimeDirectoryMode=0755
+EOF
+systemctl daemon-reload
+msg_ok "Configured PHP-FPM runtime directory"
+
+setup_composer
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Setting up Speedtest Tracker"
+RELEASE=$(curl -fsSL https://api.github.com/repos/alexjustesen/speedtest-tracker/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+cd /opt
+curl -fsSL "https://github.com/alexjustesen/speedtest-tracker/archive/refs/tags/v${RELEASE}.tar.gz" -o v${RELEASE}.tar.gz
+tar -xzf v${RELEASE}.tar.gz
+mv speedtest-tracker-${RELEASE} speedtest-tracker
+cd /opt/speedtest-tracker
+
+CONTAINER_IP=$(hostname -I | awk '{print $1}')
+APP_KEY=$(php -r "echo bin2hex(random_bytes(16));")
+cat <<EOF >/opt/speedtest-tracker/.env
+APP_NAME="Speedtest Tracker"
+APP_ENV=production
+APP_KEY=base64:$(echo -n $APP_KEY | base64)
+APP_DEBUG=false
+APP_URL=http://${CONTAINER_IP}
+
+LOG_CHANNEL=stack
+LOG_LEVEL=debug
+
+DB_CONNECTION=sqlite
+DB_DATABASE=/opt/speedtest-tracker/database/database.sqlite
+
+BROADCAST_DRIVER=log
+CACHE_DRIVER=file
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=file
+SESSION_LIFETIME=120
+
+SPEEDTEST_SCHEDULE="0 */6 * * *"
+SPEEDTEST_SERVERS=
+PRUNE_RESULTS_OLDER_THAN=0
+
+DISPLAY_TIMEZONE=UTC
+EOF
+
+mkdir -p /opt/speedtest-tracker/database
+touch /opt/speedtest-tracker/database/database.sqlite
+
+export COMPOSER_ALLOW_SUPERUSER=1
+$STD composer install --optimize-autoloader --no-dev
+
+$STD npm ci
+$STD npm run build
+
+$STD php artisan key:generate --force
+$STD php artisan migrate --force --seed
+$STD php artisan config:clear
+$STD php artisan cache:clear
+$STD php artisan view:clear
+
+chown -R www-data:www-data /opt/speedtest-tracker
+chmod -R 755 /opt/speedtest-tracker/storage
+chmod -R 755 /opt/speedtest-tracker/bootstrap/cache
+
+msg_ok "Set up Speedtest Tracker"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/speedtest-tracker.service
+[Unit]
+Description=Speedtest Tracker Queue Worker
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+Restart=always
+ExecStart=/usr/bin/php /opt/speedtest-tracker/artisan queue:work --sleep=3 --tries=3 --max-time=3600
+WorkingDirectory=/opt/speedtest-tracker
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable -q --now speedtest-tracker
+msg_ok "Created Service"
+
+msg_info "Setting up Scheduler"
+cat <<EOF >/etc/cron.d/speedtest-tracker
+* * * * * www-data cd /opt/speedtest-tracker && php artisan schedule:run >> /dev/null 2>&1
+EOF
+msg_ok "Set up Scheduler"
+
+msg_info "Configuring Nginx"
+cat <<EOF >/etc/nginx/sites-available/speedtest-tracker
+server {
+    listen 80;
+    server_name _;
+    root /opt/speedtest-tracker/public;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+
+    index index.php;
+
+    charset utf-8;
+
+    location / {
+        try_files \$uri \$uri/ /index.php?\$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    location ~ \.php$ {
+        fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}
+EOF
+
+ln -sf /etc/nginx/sites-available/speedtest-tracker /etc/nginx/sites-enabled/
+rm -f /etc/nginx/sites-enabled/default
+$STD nginx -t
+systemctl reload nginx
+msg_ok "Configured Nginx"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+rm -f /opt/v${RELEASE}.tar.gz
+cleanup_lxc
+msg_ok "Cleaned"


### PR DESCRIPTION
## ✍️ Description  

Add script for **Speedtest Tracker**.

## 🔗 Related PR / Issue  

Link: community-scripts/ProxmoxVE#118 | https://github.com/orgs/community-scripts/projects/9?pane=issue&itemId=87952053

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [X] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  

## 📋 Additional Information (optional)  

The application description in `public/json/speedtest-tracker.json` was created with AI assistance to ensure comprehensive coverage of features. If it appears too generic or verbose, I'm happy to revise it manually based on reviewer feedback.

**PHP-FPM Runtime Directory Fix:**
During testing, I encountered a persistent issue where the LXC container would fail to start PHP-FPM after reboot with the following error:
```
php-fpm8.4 -F [25-Nov-2025 20:50:47] ERROR: unable to bind listening socket for address '/run/php/php8.4-fpm.sock': No such file or directory (2)
[25-Nov-2025 20:50:47] ERROR: FPM initialization failed
```

This occurs because the `/run/php` directory is a tmpfs mount that gets cleared on reboot, and PHP-FPM doesn't automatically recreate it on startup. To resolve this, I added a systemd service override that ensures the runtime directory is created before PHP-FPM starts:

```bash
mkdir -p /etc/systemd/system/php8.4-fpm.service.d/
cat > /etc/systemd/system/php8.4-fpm.service.d/override.conf <<'EOF'
[Service]
RuntimeDirectory=php
RuntimeDirectoryMode=0755
EOF
systemctl daemon-reload
```

This is the proper systemd-native solution, as it leverages systemd's `RuntimeDirectory` directive to automatically create and manage the directory with appropriate permissions at service startup. This approach is more reliable than manual directory creation or tmpfiles.d configurations.
