### PR TITLE
Fix `verb_ip6` crash when `IPV6_METHOD` is unset

### DIFF
--- a/misc/install.func
+++ b/misc/install.func
@@ -52,7 +52,7 @@ catch_errors
 verb_ip6() {
   set_std_mode # Set STD mode based on VERBOSE
 
-  if [ "$IPV6_METHOD" == "disable" ]; then
+  if [ "${IPV6_METHOD:-}" = "disable" ]; then
     msg_info "Disabling IPv6 (this may affect some services)"
     mkdir -p /etc/sysctl.d
     $STD tee /etc/sysctl.d/99-disable-ipv6.conf >/dev/null <<EOF


### PR DESCRIPTION
## **Scripts wich are clearly AI generated and not further revied by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
Testing with `set -u`, my script crashed while calling `verb_ip6` without `IPV6_METHOD` set (`IPV6_METHOD: unbound variable`). This fix updates the condition to use `${IPV6_METHOD:-}` so if `IPV6_METHOD` is unset then it's just treated as an empty string and does nothing. 

## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
