### PR TITLE
Make sure `which` and `tar` are installed for RHEL-based OSs

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3286,7 +3286,7 @@ EOF'
     fi
 
     # Build package list - EL10+ may not have glibc-langpack-en in same form
-    local rhel_packages="curl sudo mc jq procps-ng ncurses"
+    local rhel_packages="curl sudo mc jq which tar procps-ng ncurses"
     if [[ "$rhel_version" -lt 10 ]]; then
       rhel_packages="$rhel_packages glibc-langpack-en"
     else
@@ -3298,12 +3298,12 @@ EOF'
     local install_log="/tmp/dnf_install_${CTID}.log"
     if ! pct exec "$CTID" -- bash -c "dnf install -y $rhel_packages 2>&1 | tee $install_log; exit \${PIPESTATUS[0]}" >/dev/null 2>&1; then
       # Check if it's just missing optional packages
-      if pct exec "$CTID" -- bash -c "rpm -q curl sudo mc jq procps-ng" >/dev/null 2>&1; then
+      if pct exec "$CTID" -- bash -c "rpm -q curl sudo mc jq which tar procps-ng" >/dev/null 2>&1; then
         msg_warn "Some optional packages may have failed, but core packages installed"
       else
         # Real failure - try minimal install
         msg_warn "Full package install failed, trying minimal set..."
-        if ! pct exec "$CTID" -- bash -c "dnf install -y curl sudo jq 2>&1" >/dev/null 2>&1; then
+        if ! pct exec "$CTID" -- bash -c "dnf install -y curl sudo jq which tar 2>&1" >/dev/null 2>&1; then
           msg_error "dnf/yum base packages installation failed"
           pct exec "$CTID" -- bash -c "cat $install_log 2>/dev/null" || true
           exit 1


### PR DESCRIPTION
## **Scripts wich are clearly AI generated and not further revied by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
<!-- Briefly describe your changes. -->  
For at least the almalinux 10 template `which` and `tar` are not installed by default. `tar` is required for many functions in `tools.func`. Which is used frequently for finding bin paths.
## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  

---

## 📦 Application Requirements (for new scripts)

> Required for **🆕 New script** submissions.  
> PRs that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
