### PR TITLE
Shelfmark: Add version variable

### DIFF
--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -39,8 +39,10 @@ function update_script() {
 
     cp /opt/shelfmark/start.sh /opt/start.sh.bak
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"
+    RELEASE_VERSION=$(cat "$HOME/.shelfmark")
 
     msg_info "Updating Shelfmark"
+    sed -i "s/^RELEASE_VERSION=.*/RELEASE_VERSION=$RELEASE_VERSION/" /etc/shelfmark/.env
     cd /opt/shelfmark/src/frontend
     $STD npm ci
     $STD npm run build

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -22,6 +22,7 @@ NODE_VERSION="22" setup_nodejs
 PYTHON_VERSION="3.12" setup_uv
 
 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"
+RELEASE_VERSION=$(cat "$HOME/.shelfmark")
 
 msg_info "Building Shelfmark frontend"
 cd /opt/shelfmark/src/frontend
@@ -43,6 +44,7 @@ TMP_DIR=/tmp/shelfmark
 ENABLE_LOGGING=true
 FLASK_HOST=0.0.0.0
 FLASK_PORT=8084
+RELEASE_VERSION=$RELEASE_VERSION
 # SESSION_COOKIES_SECURE=true
 # CWA_DB_PATH=
 # USE_CF_BYPASS=true


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
This PR adds the display of the currently deployed version to shelfmark. This is done by setting the `RELEASE_VERSION` environment variable.

## 🔗 Related PR / Issue  

Link: #1334

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
Even through the update script is curently broken, i was able to validate that the `RELEASE_VERSION` got updated in `/etc/shelfmark/.env`
