### PR TITLE
Make `check_container_storage()` POSIX compliant for Alpine use

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -363,7 +363,7 @@ validate_hostname() {
 
   # Split by dots and validate each label
   local IFS='.'
-  read -ra labels <<< "$hostname"
+  read -ra labels <<<"$hostname"
   for label in "${labels[@]}"; do
     # Each label: 1-63 chars, alphanumeric, hyphens allowed (not at start/end)
     if [[ -z "$label" ]] || [[ ${#label} -gt 63 ]]; then
@@ -467,7 +467,7 @@ validate_ipv6_address() {
   # Check that no segment exceeds 4 hex chars
   local IFS=':'
   local -a segments
-  read -ra segments <<< "$addr"
+  read -ra segments <<<"$addr"
   for seg in "${segments[@]}"; do
     if [[ ${#seg} -gt 4 ]]; then
       return 1
@@ -517,14 +517,14 @@ validate_gateway_in_subnet() {
 
   # Convert IPs to integers
   local IFS='.'
-  read -r i1 i2 i3 i4 <<< "$ip"
-  read -r g1 g2 g3 g4 <<< "$gateway"
+  read -r i1 i2 i3 i4 <<<"$ip"
+  read -r g1 g2 g3 g4 <<<"$gateway"
 
-  local ip_int=$(( (i1 << 24) + (i2 << 16) + (i3 << 8) + i4 ))
-  local gw_int=$(( (g1 << 24) + (g2 << 16) + (g3 << 8) + g4 ))
+  local ip_int=$(((i1 << 24) + (i2 << 16) + (i3 << 8) + i4))
+  local gw_int=$(((g1 << 24) + (g2 << 16) + (g3 << 8) + g4))
 
   # Check if both are in same network
-  if (( (ip_int & mask) != (gw_int & mask) )); then
+  if (((ip_int & mask) != (gw_int & mask))); then
     return 1
   fi
 
@@ -1057,113 +1057,113 @@ load_vars_file() {
       # Validate values before setting (skip empty values - they use defaults)
       if [[ -n "$var_val" ]]; then
         case "$var_key" in
-          var_mac)
-            if ! validate_mac_address "$var_val"; then
-              msg_warn "Invalid MAC address '$var_val' in $file, ignoring"
+        var_mac)
+          if ! validate_mac_address "$var_val"; then
+            msg_warn "Invalid MAC address '$var_val' in $file, ignoring"
+            continue
+          fi
+          ;;
+        var_vlan)
+          if ! validate_vlan_tag "$var_val"; then
+            msg_warn "Invalid VLAN tag '$var_val' in $file (must be 1-4094), ignoring"
+            continue
+          fi
+          ;;
+        var_mtu)
+          if ! validate_mtu "$var_val"; then
+            msg_warn "Invalid MTU '$var_val' in $file (must be 576-65535), ignoring"
+            continue
+          fi
+          ;;
+        var_tags)
+          if ! validate_tags "$var_val"; then
+            msg_warn "Invalid tags '$var_val' in $file (alphanumeric, -, _, ; only), ignoring"
+            continue
+          fi
+          ;;
+        var_timezone)
+          if ! validate_timezone "$var_val"; then
+            msg_warn "Invalid timezone '$var_val' in $file, ignoring"
+            continue
+          fi
+          ;;
+        var_brg)
+          if ! validate_bridge "$var_val"; then
+            msg_warn "Bridge '$var_val' not found in $file, ignoring"
+            continue
+          fi
+          ;;
+        var_gateway)
+          if ! validate_gateway_ip "$var_val"; then
+            msg_warn "Invalid gateway IP '$var_val' in $file, ignoring"
+            continue
+          fi
+          ;;
+        var_hostname)
+          if ! validate_hostname "$var_val"; then
+            msg_warn "Invalid hostname '$var_val' in $file, ignoring"
+            continue
+          fi
+          ;;
+        var_cpu)
+          if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 1 || var_val > 128)); then
+            msg_warn "Invalid CPU count '$var_val' in $file (must be 1-128), ignoring"
+            continue
+          fi
+          ;;
+        var_ram)
+          if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 256)); then
+            msg_warn "Invalid RAM '$var_val' in $file (must be >= 256 MiB), ignoring"
+            continue
+          fi
+          ;;
+        var_disk)
+          if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 1)); then
+            msg_warn "Invalid disk size '$var_val' in $file (must be >= 1 GB), ignoring"
+            continue
+          fi
+          ;;
+        var_unprivileged)
+          if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
+            msg_warn "Invalid unprivileged value '$var_val' in $file (must be 0 or 1), ignoring"
+            continue
+          fi
+          ;;
+        var_nesting)
+          if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
+            msg_warn "Invalid nesting value '$var_val' in $file (must be 0 or 1), ignoring"
+            continue
+          fi
+          ;;
+        var_keyctl)
+          if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
+            msg_warn "Invalid keyctl value '$var_val' in $file (must be 0 or 1), ignoring"
+            continue
+          fi
+          ;;
+        var_net)
+          # var_net can be: dhcp, static IP/CIDR, or IP range
+          if [[ "$var_val" != "dhcp" ]]; then
+            if is_ip_range "$var_val"; then
+              : # IP range is valid, will be resolved at runtime
+            elif ! validate_ip_address "$var_val"; then
+              msg_warn "Invalid network '$var_val' in $file (must be dhcp or IP/CIDR), ignoring"
               continue
             fi
-            ;;
-          var_vlan)
-            if ! validate_vlan_tag "$var_val"; then
-              msg_warn "Invalid VLAN tag '$var_val' in $file (must be 1-4094), ignoring"
-              continue
-            fi
-            ;;
-          var_mtu)
-            if ! validate_mtu "$var_val"; then
-              msg_warn "Invalid MTU '$var_val' in $file (must be 576-65535), ignoring"
-              continue
-            fi
-            ;;
-          var_tags)
-            if ! validate_tags "$var_val"; then
-              msg_warn "Invalid tags '$var_val' in $file (alphanumeric, -, _, ; only), ignoring"
-              continue
-            fi
-            ;;
-          var_timezone)
-            if ! validate_timezone "$var_val"; then
-              msg_warn "Invalid timezone '$var_val' in $file, ignoring"
-              continue
-            fi
-            ;;
-          var_brg)
-            if ! validate_bridge "$var_val"; then
-              msg_warn "Bridge '$var_val' not found in $file, ignoring"
-              continue
-            fi
-            ;;
-          var_gateway)
-            if ! validate_gateway_ip "$var_val"; then
-              msg_warn "Invalid gateway IP '$var_val' in $file, ignoring"
-              continue
-            fi
-            ;;
-          var_hostname)
-            if ! validate_hostname "$var_val"; then
-              msg_warn "Invalid hostname '$var_val' in $file, ignoring"
-              continue
-            fi
-            ;;
-          var_cpu)
-            if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 1 || var_val > 128)); then
-              msg_warn "Invalid CPU count '$var_val' in $file (must be 1-128), ignoring"
-              continue
-            fi
-            ;;
-          var_ram)
-            if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 256)); then
-              msg_warn "Invalid RAM '$var_val' in $file (must be >= 256 MiB), ignoring"
-              continue
-            fi
-            ;;
-          var_disk)
-            if ! [[ "$var_val" =~ ^[0-9]+$ ]] || ((var_val < 1)); then
-              msg_warn "Invalid disk size '$var_val' in $file (must be >= 1 GB), ignoring"
-              continue
-            fi
-            ;;
-          var_unprivileged)
-            if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
-              msg_warn "Invalid unprivileged value '$var_val' in $file (must be 0 or 1), ignoring"
-              continue
-            fi
-            ;;
-          var_nesting)
-            if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
-              msg_warn "Invalid nesting value '$var_val' in $file (must be 0 or 1), ignoring"
-              continue
-            fi
-            ;;
-          var_keyctl)
-            if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
-              msg_warn "Invalid keyctl value '$var_val' in $file (must be 0 or 1), ignoring"
-              continue
-            fi
-            ;;
-          var_net)
-            # var_net can be: dhcp, static IP/CIDR, or IP range
-            if [[ "$var_val" != "dhcp" ]]; then
-              if is_ip_range "$var_val"; then
-                : # IP range is valid, will be resolved at runtime
-              elif ! validate_ip_address "$var_val"; then
-                msg_warn "Invalid network '$var_val' in $file (must be dhcp or IP/CIDR), ignoring"
-                continue
-              fi
-            fi
-            ;;
-          var_fuse|var_tun|var_gpu|var_ssh|var_verbose|var_protection)
-            if [[ "$var_val" != "yes" && "$var_val" != "no" ]]; then
-              msg_warn "Invalid boolean '$var_val' for $var_key in $file (must be yes/no), ignoring"
-              continue
-            fi
-            ;;
-          var_ipv6_method)
-            if [[ "$var_val" != "auto" && "$var_val" != "dhcp" && "$var_val" != "static" && "$var_val" != "none" ]]; then
-              msg_warn "Invalid IPv6 method '$var_val' in $file (must be auto/dhcp/static/none), ignoring"
-              continue
-            fi
-            ;;
+          fi
+          ;;
+        var_fuse | var_tun | var_gpu | var_ssh | var_verbose | var_protection)
+          if [[ "$var_val" != "yes" && "$var_val" != "no" ]]; then
+            msg_warn "Invalid boolean '$var_val' for $var_key in $file (must be yes/no), ignoring"
+            continue
+          fi
+          ;;
+        var_ipv6_method)
+          if [[ "$var_val" != "auto" && "$var_val" != "dhcp" && "$var_val" != "static" && "$var_val" != "none" ]]; then
+            msg_warn "Invalid IPv6 method '$var_val' in $file (must be auto/dhcp/static/none), ignoring"
+            continue
+          fi
+          ;;
         esac
       fi
 
@@ -3092,21 +3092,18 @@ check_container_resources() {
 check_container_storage() {
   usage=$(df / -P | awk 'NR==2 {print $5}' | tr -d '%')
 
-  # shellcheck disable=SC2181
-  if [ $? -ne 0 ]; then
-    echo "Error: Failed to check disk usage."
+  if [ -z "$usage" ] || [ "$usage" -lt 0 ]; then
+    echo -e "${CROSS}${HOLD}${RD}Error: Failed to check disk usage.${CL}"
     exit 1
   fi
 
   if [ "$usage" -gt 80 ]; then
-    echo -e "${INFO}${HOLD} ${YWB}Warning: Storage is dangerously low (${usage}%).${CL}"
+    echo -e "${INFO}${HOLD}${YWB}Warning: Storage is dangerously low (${usage}%).${CL}"
     printf "Continue anyway? <y/N>  "
     read -r prompt
 
     case "$prompt" in
-    [yY][eE][sS] | [yY])
-      # User input is "yes" or "y"; continue
-      ;;
+    [yY][eE][sS] | [yY]) ;;
     *)
       echo -e "${CROSS}${HOLD}${YWB}Exiting based on user input.${CL}"
       exit 1
@@ -4016,91 +4013,91 @@ EOF'
 
     if read -t 60 -r response; then
       case "${response:-1}" in
-        1)
-          # Remove container
-          echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID}${CL}"
-          pct stop "$CTID" &>/dev/null || true
-          pct destroy "$CTID" &>/dev/null || true
-          echo -e "${BFR}${CM}${GN}Container ${CTID} removed${CL}"
-          ;;
-        2)
-          echo -e "\n${TAB}${YW}Container ${CTID} kept for debugging${CL}"
-          # Dev mode: Setup MOTD/SSH for debugging access to broken container
-          if [[ "${DEV_MODE_MOTD:-false}" == "true" ]]; then
-            echo -e "${TAB}${HOLD}${DGN}Setting up MOTD and SSH for debugging...${CL}"
-            if pct exec "$CTID" -- bash -c "
+      1)
+        # Remove container
+        echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID}${CL}"
+        pct stop "$CTID" &>/dev/null || true
+        pct destroy "$CTID" &>/dev/null || true
+        echo -e "${BFR}${CM}${GN}Container ${CTID} removed${CL}"
+        ;;
+      2)
+        echo -e "\n${TAB}${YW}Container ${CTID} kept for debugging${CL}"
+        # Dev mode: Setup MOTD/SSH for debugging access to broken container
+        if [[ "${DEV_MODE_MOTD:-false}" == "true" ]]; then
+          echo -e "${TAB}${HOLD}${DGN}Setting up MOTD and SSH for debugging...${CL}"
+          if pct exec "$CTID" -- bash -c "
               source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxVED/raw/branch/main/misc/install.func)
               declare -f motd_ssh >/dev/null 2>&1 && motd_ssh || true
             " >/dev/null 2>&1; then
-              local ct_ip=$(pct exec "$CTID" ip a s dev eth0 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1)
-              echo -e "${BFR}${CM}${GN}MOTD/SSH ready - SSH into container: ssh root@${ct_ip}${CL}"
-            fi
+            local ct_ip=$(pct exec "$CTID" ip a s dev eth0 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1)
+            echo -e "${BFR}${CM}${GN}MOTD/SSH ready - SSH into container: ssh root@${ct_ip}${CL}"
           fi
-          exit $install_exit_code
-          ;;
-        3)
-          # Retry with verbose mode
-          echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID} for rebuild...${CL}"
+        fi
+        exit $install_exit_code
+        ;;
+      3)
+        # Retry with verbose mode
+        echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID} for rebuild...${CL}"
+        pct stop "$CTID" &>/dev/null || true
+        pct destroy "$CTID" &>/dev/null || true
+        echo -e "${BFR}${CM}${GN}Container ${CTID} removed${CL}"
+        echo ""
+        # Get new container ID
+        local old_ctid="$CTID"
+        export CTID=$(get_valid_container_id "$CTID")
+        export VERBOSE="yes"
+        export var_verbose="yes"
+
+        # Show rebuild summary
+        echo -e "${YW}Rebuilding with preserved settings:${CL}"
+        echo -e "  Container ID: ${old_ctid} → ${CTID}"
+        echo -e "  RAM: ${RAM_SIZE} MiB | CPU: ${CORE_COUNT} cores | Disk: ${DISK_SIZE} GB"
+        echo -e "  Network: ${NET:-dhcp} | Bridge: ${BRG:-vmbr0}"
+        echo -e "  Verbose: ${GN}enabled${CL}"
+        echo ""
+        msg_info "Restarting installation..."
+        # Re-run build_container
+        build_container
+        return $?
+        ;;
+      4)
+        if [[ "$is_oom" == true ]]; then
+          # Retry with more resources
+          echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID} for rebuild with more resources...${CL}"
           pct stop "$CTID" &>/dev/null || true
           pct destroy "$CTID" &>/dev/null || true
           echo -e "${BFR}${CM}${GN}Container ${CTID} removed${CL}"
           echo ""
-          # Get new container ID
+          # Get new container ID and increase resources
           local old_ctid="$CTID"
+          local old_ram="$RAM_SIZE"
+          local old_cpu="$CORE_COUNT"
           export CTID=$(get_valid_container_id "$CTID")
-          export VERBOSE="yes"
-          export var_verbose="yes"
+          export RAM_SIZE=$((RAM_SIZE * 3 / 2))
+          export CORE_COUNT=$((CORE_COUNT + 1))
+          export var_ram="$RAM_SIZE"
+          export var_cpu="$CORE_COUNT"
 
           # Show rebuild summary
-          echo -e "${YW}Rebuilding with preserved settings:${CL}"
+          echo -e "${YW}Rebuilding with increased resources:${CL}"
           echo -e "  Container ID: ${old_ctid} → ${CTID}"
-          echo -e "  RAM: ${RAM_SIZE} MiB | CPU: ${CORE_COUNT} cores | Disk: ${DISK_SIZE} GB"
-          echo -e "  Network: ${NET:-dhcp} | Bridge: ${BRG:-vmbr0}"
-          echo -e "  Verbose: ${GN}enabled${CL}"
+          echo -e "  RAM: ${old_ram} → ${GN}${RAM_SIZE}${CL} MiB (+50%)"
+          echo -e "  CPU: ${old_cpu} → ${GN}${CORE_COUNT}${CL} cores (+1)"
+          echo -e "  Disk: ${DISK_SIZE} GB | Network: ${NET:-dhcp} | Bridge: ${BRG:-vmbr0}"
           echo ""
           msg_info "Restarting installation..."
           # Re-run build_container
           build_container
           return $?
-          ;;
-        4)
-          if [[ "$is_oom" == true ]]; then
-            # Retry with more resources
-            echo -e "\n${TAB}${HOLD}${YW}Removing container ${CTID} for rebuild with more resources...${CL}"
-            pct stop "$CTID" &>/dev/null || true
-            pct destroy "$CTID" &>/dev/null || true
-            echo -e "${BFR}${CM}${GN}Container ${CTID} removed${CL}"
-            echo ""
-            # Get new container ID and increase resources
-            local old_ctid="$CTID"
-            local old_ram="$RAM_SIZE"
-            local old_cpu="$CORE_COUNT"
-            export CTID=$(get_valid_container_id "$CTID")
-            export RAM_SIZE=$((RAM_SIZE * 3 / 2))
-            export CORE_COUNT=$((CORE_COUNT + 1))
-            export var_ram="$RAM_SIZE"
-            export var_cpu="$CORE_COUNT"
-
-            # Show rebuild summary
-            echo -e "${YW}Rebuilding with increased resources:${CL}"
-            echo -e "  Container ID: ${old_ctid} → ${CTID}"
-            echo -e "  RAM: ${old_ram} → ${GN}${RAM_SIZE}${CL} MiB (+50%)"
-            echo -e "  CPU: ${old_cpu} → ${GN}${CORE_COUNT}${CL} cores (+1)"
-            echo -e "  Disk: ${DISK_SIZE} GB | Network: ${NET:-dhcp} | Bridge: ${BRG:-vmbr0}"
-            echo ""
-            msg_info "Restarting installation..."
-            # Re-run build_container
-            build_container
-            return $?
-          else
-            echo -e "\n${TAB}${YW}Invalid option. Container ${CTID} kept.${CL}"
-            exit $install_exit_code
-          fi
-          ;;
-        *)
+        else
           echo -e "\n${TAB}${YW}Invalid option. Container ${CTID} kept.${CL}"
           exit $install_exit_code
-          ;;
+        fi
+        ;;
+      *)
+        echo -e "\n${TAB}${YW}Invalid option. Container ${CTID} kept.${CL}"
+        exit $install_exit_code
+        ;;
       esac
     else
       # Timeout - auto-remove


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
Makes the `check_container_storage()` function in build.func POSIX compliant. Checks root (/) partition `/` instead of `/boot` since boot is not guaranteed to be present.

`check_container_storage()` should now work as expected in Alpine containers.

## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
I was testing the update_script (based on the template) for an alpine container and noticed it failed from a non-compatible `df` call and not having a `/boot` partition.

`check_container_resources()` should also be made POSIX compliant (or at least ash compatible) but it doesn't fail in a way that causes the script to abort.
