### PR TITLE
Update UHF script to use setup_ffmpeg tool instead of apt

### DIFF
--- a/ct/uhf.sh
+++ b/ct/uhf.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: zackwithak13
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://www.uhfapp.com/server
+
+APP="UHF"
+var_tags="${var_tags:-media}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+var_gpu="${var_gpu:-yes}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/uhf-server ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+  if check_for_gh_release "uhf-server" "swapplications/uhf-server-dist"; then
+    msg_info "Stopping Service"
+    systemctl stop uhf-server
+    msg_ok "Stopped Service"
+
+    msg_info "Updating LXC"
+    $STD apt update
+    $STD apt -y upgrade
+    msg_ok "Updated LXC"
+
+    setup_ffmpeg
+    fetch_and_deploy_gh_release "comskip" "swapplications/comskip" "prebuild" "latest" "/opt/comskip" "comskip-x64-*.zip"
+    fetch_and_deploy_gh_release "uhf-server" "swapplications/uhf-server-dist" "prebuild" "latest" "/opt/uhf-server" "UHF.Server-linux-x64-*.zip"
+
+    msg_info "Starting Service"
+    systemctl start uhf-server
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:7568${CL}"

--- a/frontend/public/json/uhf.json
+++ b/frontend/public/json/uhf.json
@@ -1,0 +1,40 @@
+{
+  "name": "UHF Server",
+  "slug": "uhf",
+  "categories": [
+    13
+  ],
+  "date_created": "2025-09-12",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 7568,
+  "documentation": "https://www.uhfapp.com/server",
+  "website": "https://www.uhfapp.com/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/uhf.webp",
+  "config_path": "/etc/uhf-server/",
+  "description": "UHF Server is a powerful companion app that lets you seamlessly schedule and record your favorite shows from the UHF app.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/uhf.sh",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "There is no web interface for this service, it only serves as a backend for the UHF app.",
+      "type": "info"
+    }
+  ]
+}

--- a/install/uhf-install.sh
+++ b/install/uhf-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: zackwithak13
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://www.uhfapp.com/server
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+setup_hwaccel
+
+msg_info "Installing Dependencies"
+setup_ffmpeg
+msg_ok "Installed Dependencies"
+
+msg_info "Setting Up UHF Server Environment"
+mkdir -p /etc/uhf-server
+mkdir -p /var/lib/uhf-server/data
+mkdir -p /var/lib/uhf-server/recordings
+cat <<EOF >/etc/uhf-server/.env
+API_HOST=0.0.0.0
+API_PORT=7568
+RECORDINGS_DIR=/var/lib/uhf-server/recordings
+DB_PATH=/var/lib/uhf-server/data/db.json
+LOG_LEVEL=INFO
+EOF
+msg_ok "Set Up UHF Server Environment"
+
+fetch_and_deploy_gh_release "comskip" "swapplications/comskip" "prebuild" "latest" "/opt/comskip" "comskip-x64-*.zip"
+fetch_and_deploy_gh_release "uhf-server" "swapplications/uhf-server-dist" "prebuild" "latest" "/opt/uhf-server" "UHF.Server-linux-x64-*.zip"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/uhf-server.service
+[Unit]
+Description=UHF Server service
+After=syslog.target network-online.target
+[Service]
+Type=simple
+WorkingDirectory=/opt/uhf-server
+EnvironmentFile=/etc/uhf-server/.env
+ExecStart=/opt/uhf-server/uhf-server
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now uhf-server
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
This PR updates the UHF script to install ffmpeg using the shared `setup_ffmpeg` function, instead of using the debian repo.

Additionally, adds a note to the website that there is no web interface for this service.

## 🔗 Related PR / Issue  

Link: #785 

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  

---

## 📦 Application Requirements (for new scripts)

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
