### PR TITLE
Fix and improve UniFi OS Server VM script

### DIFF
--- a/vm/unifi-os-server-vm.sh
+++ b/vm/unifi-os-server-vm.sh
@@ -102,86 +102,16 @@ function get_valid_nextid() {
 }
 
 function cleanup_vmid() {
-  if qm status $VMID &>/dev/null; then
-    qm stop $VMID &>/dev/null
-    qm destroy $VMID &>/dev/null
+  if [ -n "${VMID:-}" ] && qm status "$VMID" &>/dev/null; then
+    qm stop "$VMID" &>/dev/null
+    qm destroy "$VMID" &>/dev/null
   fi
 }
 
-function send_line_to_vm() {
-  local line="$1"
-  for ((i = 0; i < ${#line}; i++)); do
-    character=${line:i:1}
-    case $character in
-    " ") character="spc" ;;
-    "-") character="minus" ;;
-    "=") character="equal" ;;
-    ",") character="comma" ;;
-    ".") character="dot" ;;
-    "/") character="slash" ;;
-    "'") character="apostrophe" ;;
-    ";") character="semicolon" ;;
-    '\') character="backslash" ;;
-    '\`') character="grave_accent" ;;
-    "[") character="bracket_left" ;;
-    "]") character="bracket_right" ;;
-    "_") character="shift-minus" ;;
-    "+") character="shift-equal" ;;
-    "?") character="shift-slash" ;;
-    "<") character="shift-comma" ;;
-    ">") character="shift-dot" ;;
-    '"') character="shift-apostrophe" ;;
-    ":") character="shift-semicolon" ;;
-    "|") character="shift-backslash" ;;
-    "~") character="shift-grave_accent" ;;
-    "{") character="shift-bracket_left" ;;
-    "}") character="shift-bracket_right" ;;
-    "A") character="shift-a" ;;
-    "B") character="shift-b" ;;
-    "C") character="shift-c" ;;
-    "D") character="shift-d" ;;
-    "E") character="shift-e" ;;
-    "F") character="shift-f" ;;
-    "G") character="shift-g" ;;
-    "H") character="shift-h" ;;
-    "I") character="shift-i" ;;
-    "J") character="shift-j" ;;
-    "K") character="shift-k" ;;
-    "L") character="shift-l" ;;
-    "M") character="shift-m" ;;
-    "N") character="shift-n" ;;
-    "O") character="shift-o" ;;
-    "P") character="shift-p" ;;
-    "Q") character="shift-q" ;;
-    "R") character="shift-r" ;;
-    "S") character="shift-s" ;;
-    "T") character="shift-t" ;;
-    "U") character="shift-u" ;;
-    "V") character="shift-v" ;;
-    "W") character="shift-w" ;;
-    "X") character="shift-x" ;;
-    "Y") character="shift-y" ;;
-    "Z") character="shift-z" ;;
-    "!") character="shift-1" ;;
-    "@") character="shift-2" ;;
-    "#") character="shift-3" ;;
-    '$') character="shift-4" ;;
-    "%") character="shift-5" ;;
-    "^") character="shift-6" ;;
-    "&") character="shift-7" ;;
-    "*") character="shift-8" ;;
-    "(") character="shift-9" ;;
-    ")") character="shift-0" ;;
-    esac
-    qm sendkey $VMID "$character"
-  done
-  qm sendkey $VMID ret
-}
-
 function cleanup() {
-  popd >/dev/null
+  popd >/dev/null 2>&1 || true
   post_update_to_api "done" "none"
-  rm -rf $TEMP_DIR
+  [ -n "${TEMP_DIR:-}" ] && rm -rf "$TEMP_DIR"
 }
 
 TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary

- **Bug fixes**: Add ~20 missing `fi` statements, fix `pve_check()` `elif`/`else`/`fi` structure, fix `DISK_SIZE` unbound variable, fix `error_handler()` `${VMID:-}` guard — script does not run without these fixes
- **Architecture improvement**: Migrate from `send_line_to_vm` serial console approach to `virt-customize` with a first-boot systemd service, consistent with other VM scripts (umbrel-os-vm, docker-vm, etc.)
- **New features**: Root password prompt with confirmation, SSH public key support, SSH enabled by default, cloud-init password override, port 11443 readiness check, elapsed time counter during wait loops

## Details

### Bug fixes
The script has ~20 missing `fi` closures across `advanced_settings()`, `check_root()`, `arch_check()`, `ssh_check()`, `select_os()`, `start_script()`, and others — causing immediate syntax errors on execution. `pve_check()` was also missing its `elif`/`else`/`fi` structure, and `DISK_SIZE` was referenced before initialization.

### Architecture
The `send_line_to_vm` serial console approach relies on timing-dependent hardcoded `sleep` values. This PR migrates to `virt-customize` + a first-boot systemd service, which is the pattern used by other VM scripts in this repo. The first-boot service handles clock sync (NTP with HTTP header fallback for GPG signature validation), package installation with retry logic, swap setup, and UniFi OS installer execution.

### Features
Users can now set a root password and paste SSH public keys during the setup wizard. SSH is enabled by default for remote management. After VM boot, the script waits for the QEMU guest agent and then polls port 11443 to confirm UniFi OS is accessible, with an elapsed time counter so the user can see progress.

## Test plan
- [ ] Run with default settings on Proxmox VE 8.x
- [ ] Run with advanced settings, verify all whiptail dialogs work
- [ ] Verify root password and SSH key access after VM creation
- [ ] Verify UniFi OS accessible on port 11443 after first-boot completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-side first-boot orchestration that stages the UniFi OS installer onto the VM image and runs installation on first boot
  * Interactive VM setup to collect root password and optional SSH public keys for provisioning; credentials are injected via cloud-init

* **Improvements**
  * Clearer progress and final access messaging while waiting for VM networking and UniFi OS readiness
  * More robust initialization, error handling, and compatibility tweaks for machine type and disk sizing defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->