### PR TITLE
feat: add Plex Auto Languages container

### DIFF
--- a/ct/plex-auto-languages.sh
+++ b/ct/plex-auto-languages.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Shaalan
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/RemiRigal/Plex-Auto-Languages
+
+# Import main orchestrator
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Application Configuration
+APP="Plex-Auto-Languages"
+var_tags="${var_tags:-plex;media;automation}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+# Display header
+header_info "$APP"
+
+# Initialize
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/plex-auto-languages ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Stopping ${APP} Service"
+  systemctl stop plex-auto-languages
+  msg_ok "Stopped ${APP} Service"
+
+  msg_info "Updating ${APP}"
+  cd /opt/plex-auto-languages || exit
+  $STD git pull
+  $STD /opt/plex-auto-languages/venv/bin/pip install -r requirements.txt
+  msg_ok "Updated ${APP}"
+
+  msg_info "Starting ${APP} Service"
+  systemctl start plex-auto-languages
+  msg_ok "Started ${APP} Service"
+
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access the configuration file:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}/opt/plex-auto-languages/config/config.yaml${CL}"
+echo -e "${INFO}${YW} You must edit the config to set your Plex URL and Token before the service will work.${CL}"

--- a/install/plex-auto-languages-install.sh
+++ b/install/plex-auto-languages-install.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Shaalan
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/RemiRigal/Plex-Auto-Languages
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  git \
+  curl \
+  ca-certificates
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up Python3"
+$STD apt-get install -y \
+  python3 \
+  python3-pip \
+  python3-venv
+msg_ok "Set up Python3"
+
+msg_info "Installing ${APP}"
+cd /opt || exit
+$STD git clone https://github.com/RemiRigal/Plex-Auto-Languages.git /opt/plex-auto-languages
+$STD python3 -m venv /opt/plex-auto-languages/venv
+$STD /opt/plex-auto-languages/venv/bin/pip install --upgrade pip
+$STD /opt/plex-auto-languages/venv/bin/pip install -r /opt/plex-auto-languages/requirements.txt
+msg_ok "Installed ${APP}"
+
+msg_info "Creating Configuration"
+mkdir -p /opt/plex-auto-languages/config
+cat <<'EOF' >/opt/plex-auto-languages/config/config.yaml
+plexautolanguages:
+  update_level: "show"
+  update_strategy: "all"
+  trigger_on_play: true
+  trigger_on_scan: true
+  trigger_on_activity: false
+  refresh_library_on_scan: true
+  ignore_labels:
+    - PAL_IGNORE
+
+  plex:
+    url: "http://PLEX_IP:32400"
+    token: "CHANGE_ME"
+
+  scheduler:
+    enable: true
+    schedule_time: "02:00"
+
+  notifications:
+    enable: false
+
+  debug: false
+EOF
+msg_ok "Created Configuration"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/plex-auto-languages.service
+[Unit]
+Description=Plex Auto Languages
+Documentation=https://github.com/RemiRigal/Plex-Auto-Languages
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/plex-auto-languages
+ExecStart=/opt/plex-auto-languages/venv/bin/python3 main.py -c /opt/plex-auto-languages/config/config.yaml
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable -q --now plex-auto-languages
+msg_ok "Created Service"
+
+motd_ssh_info
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/json/plex-auto-languages.json
+++ b/json/plex-auto-languages.json
@@ -1,0 +1,40 @@
+{
+  "name": "Plex Auto Languages",
+  "slug": "plex-auto-languages",
+  "categories": [
+    13
+  ],
+  "date_created": "2025-03-18",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/RemiRigal/Plex-Auto-Languages",
+  "website": "https://github.com/RemiRigal/Plex-Auto-Languages",
+  "logo": "https://raw.githubusercontent.com/selfhst/icons/refs/heads/main/svg/plex.svg",
+  "config_path": "/opt/plex-auto-languages/config/config.yaml",
+  "description": "Plex Auto Languages automatically updates the language of your Plex TV Show episodes based on your current language selection, providing a Netflix-like experience without messing with your existing preferences.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/plex-auto-languages.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "12"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "After installation, edit `/opt/plex-auto-languages/config/config.yaml` to set your Plex URL and Token.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
Adds a new LXC container script for **Plex Auto Languages** — a Python service that automatically updates the audio/subtitle language of Plex TV Show episodes based on your current language selection, providing a Netflix-like experience.

After installation, the user edits `/opt/plex-auto-languages/config/config.yaml` to set their Plex URL and token. The service runs as a systemd unit.

## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [ ] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [X] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  

**Files added:**
- `ct/plex-auto-languages.sh` — container creation script with `update_script()` support
- `install/plex-auto-languages-install.sh` — installs Python venv, clones repo, creates config + systemd service
- `json/plex-auto-languages.json` — metadata for the web frontend (category: Media & Streaming, id 13)

**Container defaults:** Debian 12, 1 vCPU, 512 MB RAM, 4 GB disk, unprivileged.

---

## 📦 Application Requirements (for new scripts)

- [X] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [X] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- GitHub: https://github.com/RemiRigal/Plex-Auto-Languages