### PR TITLE
fix: use correct url for downloading forgejo-runner

### DIFF
--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -39,7 +39,7 @@ function update_script() {
 
   RELEASE=$(curl -fsSL https://data.forgejo.org/api/v1/repos/forgejo/runner/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+' | sed 's/^v//')
   msg_info "Updating Forgejo Runner to v${RELEASE}"
-  curl -fsSL "https://code.forgejo.org/forgejo/runner/releases/download/v${RELEASE}/forgejo-runner-linux-amd64" -o /usr/local/bin/forgejo-runner
+  curl -fsSL "https://code.forgejo.org/forgejo/runner/releases/download/v${RELEASE}/forgejo-runner-${RELEASE}-linux-amd64" -o /usr/local/bin/forgejo-runner
   chmod +x /usr/local/bin/forgejo-runner
   msg_ok "Updated Forgejo Runner"
 


### PR DESCRIPTION
## ✍️ Description  
<!-- Briefly describe your changes. -->

This PR is to fix an issue when trying to update forgejo-runner with the update command. See below for a screenshot

## 🔗 Related PR / Issue  

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. --> 

Current State is failing when trying to update:

<img width="2057" height="433" alt="image" src="https://github.com/user-attachments/assets/0fb80fff-c423-4d89-b9a5-81f7cff4a05d" />


Updating of the Forgejo Runner is working after my adjustment:
<img width="1126" height="332" alt="image" src="https://github.com/user-attachments/assets/0a6f057e-7e65-4976-bdc1-606835555ec2" />


