### PR TITLE
forgejo-runner (FIX): support generated/unattended mode and configurable runner labels

### DIFF
--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: Simon Friedrich

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -63,8 +63,9 @@ function update_script() {
 }
 
 # Fail early if running unattended without required values
-# Only check when there's no TTY (truly non-interactive, e.g. piped or scripted)
-if [[ -n "${mode:-}" && ! -t 0 ]]; then
+# mode is only set when the user explicitly passes it (automating);
+# bare "bash -c $(curl ...)" leaves mode empty and shows the whiptail menu
+if [[ -n "${mode:-}" ]]; then
   if [[ -z "${var_forgejo_instance:-}" ]]; then
     msg_error "var_forgejo_instance is required for unattended installs."
     exit 1

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: Simon Friedrich

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -63,7 +63,8 @@ function update_script() {
 }
 
 # Fail early if running unattended without required values
-if [[ -n "${mode:-}" ]]; then
+# Only check when there's no TTY (truly non-interactive, e.g. piped or scripted)
+if [[ -n "${mode:-}" && ! -t 0 ]]; then
   if [[ -z "${var_forgejo_instance:-}" ]]; then
     msg_error "var_forgejo_instance is required for unattended installs."
     exit 1

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -18,6 +18,12 @@ var_unprivileged="${var_unprivileged:-1}"
 var_nesting="${var_nesting:-1}"
 var_keyctl="${var_keyctl:-1}"
 
+# App-specific variables (not in build.func whitelist)
+# Export so they survive lxc-attach into the container
+export var_forgejo_instance="${var_forgejo_instance:-}"
+export var_forgejo_runner_token="${var_forgejo_runner_token:-}"
+export var_runner_labels="${var_runner_labels:-}"
+
 header_info "$APP"
 variables
 color

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -62,10 +62,16 @@ function update_script() {
   exit
 }
 
-# Fail early if running unattended without a runner token
-if [[ -n "${mode:-}" && -z "${var_forgejo_runner_token:-}" ]]; then
-  msg_error "var_forgejo_runner_token is required for unattended installs."
-  exit 1
+# Fail early if running unattended without required values
+if [[ -n "${mode:-}" ]]; then
+  if [[ -z "${var_forgejo_instance:-}" ]]; then
+    msg_error "var_forgejo_instance is required for unattended installs."
+    exit 1
+  fi
+  if [[ -z "${var_forgejo_runner_token:-}" ]]; then
+    msg_error "var_forgejo_runner_token is required for unattended installs."
+    exit 1
+  fi
 fi
 
 start

--- a/ct/forgejo-runner.sh
+++ b/ct/forgejo-runner.sh
@@ -62,6 +62,12 @@ function update_script() {
   exit
 }
 
+# Fail early if running unattended without a runner token
+if [[ -n "${mode:-}" && -z "${var_forgejo_runner_token:-}" ]]; then
+  msg_error "var_forgejo_runner_token is required for unattended installs."
+  exit 1
+fi
+
 start
 build_container
 description

--- a/install/forgejo-runner-install.sh
+++ b/install/forgejo-runner-install.sh
@@ -63,7 +63,7 @@ export DOCKER_HOST="unix:///run/podman/podman.sock"
 forgejo-runner register \
   --instance "$FORGEJO_INSTANCE" \
   --token "$FORGEJO_RUNNER_TOKEN" \
-  --name "$HOSTNAME" \
+  --name "$(hostname)" \
   --labels "$RUNNER_LABELS" \
   --no-interactive
 msg_ok "Registered Forgejo Runner"

--- a/install/forgejo-runner-install.sh
+++ b/install/forgejo-runner-install.sh
@@ -60,6 +60,7 @@ msg_ok "Installed Forgejo Runner"
 
 msg_info "Registering Forgejo Runner"
 export DOCKER_HOST="unix:///run/podman/podman.sock"
+cd /root
 forgejo-runner register \
   --instance "$FORGEJO_INSTANCE" \
   --token "$FORGEJO_RUNNER_TOKEN" \

--- a/install/forgejo-runner-install.sh
+++ b/install/forgejo-runner-install.sh
@@ -12,19 +12,31 @@ setting_up_container
 network_check
 update_os
 
-# Get required configuration with sensible fallbacks for unattended mode
-# These will show a warning if defaults are used
-var_forgejo_instance=$(prompt_input_required \
-  "Forgejo Instance URL:" \
-  "${var_forgejo_instance:-https://codeberg.org}" \
-  120 \
-  "var_forgejo_instance")
+# Get required configuration — skip prompts if already set (generated/unattended mode)
+if [[ -z "${var_forgejo_instance:-}" ]]; then
+  read -r -p "${TAB3}Forgejo Instance URL (e.g. https://codeberg.org): " var_forgejo_instance
+  var_forgejo_instance="${var_forgejo_instance:-https://codeberg.org}"
+fi
 
-var_forgejo_runner_token=$(prompt_input_required \
-  "Forgejo Runner Registration Token:" \
-  "${var_forgejo_runner_token:-REPLACE_WITH_YOUR_TOKEN}" \
-  120 \
-  "var_forgejo_runner_token")
+if [[ -z "${var_forgejo_runner_token:-}" ]]; then
+  read -r -p "${TAB3}Forgejo Runner Registration Token: " var_forgejo_runner_token
+fi
+
+if [[ -z "${var_forgejo_runner_token:-}" ]]; then
+  msg_error "No runner registration token provided. Cannot continue."
+  exit 1
+fi
+
+# Runner labels — default is always included; additional labels are appended
+DEFAULT_RUNNER_LABELS="linux-amd64:docker://node:22-bookworm"
+if [[ -z "${var_runner_labels:-}" ]]; then
+  read -r -p "${TAB3}Additional runner labels (comma-separated, or leave blank for default only): " var_runner_labels
+fi
+if [[ -n "${var_runner_labels:-}" ]]; then
+  RUNNER_LABELS="${DEFAULT_RUNNER_LABELS},${var_runner_labels}"
+else
+  RUNNER_LABELS="${DEFAULT_RUNNER_LABELS}"
+fi
 
 export FORGEJO_INSTANCE="$var_forgejo_instance"
 export FORGEJO_RUNNER_TOKEN="$var_forgejo_runner_token"
@@ -52,7 +64,7 @@ forgejo-runner register \
   --instance "$FORGEJO_INSTANCE" \
   --token "$FORGEJO_RUNNER_TOKEN" \
   --name "$HOSTNAME" \
-  --labels "linux-amd64:docker://node:20-bookworm" \
+  --labels "$RUNNER_LABELS" \
   --no-interactive
 msg_ok "Registered Forgejo Runner"
 
@@ -78,9 +90,6 @@ WantedBy=multi-user.target
 EOF
 systemctl enable -q --now forgejo-runner
 msg_ok "Created Services"
-
-# Show warning if any required values used fallbacks
-show_missing_values_warning
 
 motd_ssh
 customize


### PR DESCRIPTION
## ✍️ Description  

  - Fix install script calling nonexistent prompt_input_required and show_missing_values_warning functions from build.func, which causes the install to fail
  - Export app-specific variables (var_forgejo_instance, var_forgejo_runner_token, var_runner_labels) in the CT script so they cross the lxc-attach boundary into the container
  - Replace broken calls with standard read -r -p prompts that skip when variables are pre-set, enabling mode="generated" (unattended) installs 
  - Make runner labels configurable — additional labels passed via var_runner_labels are appended to the default, not replacing it  (NOT LXC CONTAINER LABELS)
  - Update default runner image from node:20-bookworm to node:22-bookworm (Node 22 LTS; Node 20 EOL April 2026)
     NOTE: I have weighed using `node:lts` as the image tag, however that would make the CI runner not deploy in the same manner every time, undermining a core principle in the DevOps world: Reproducible Builds.

## 🔗 Related PR / Issue  


  - #1576 :~~Still requires testing, will do so following the test plan outlined below in Additional Information~~
  - #1576 : This has been tested, please see test outputs in https://github.com/community-scripts/ProxmoxVED/pull/1645#issuecomment-4151856110 with one note: There has been a question asked in this issue (Linked below in additional information) as to why VED repo differs from VE repo. 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  


## 📋 Additional Information
  Test plan

  - Interactive install: verify prompts appear for instance URL, token, and additional labels
  - Interactive install with no extra labels: verify only linux-amd64:docker://node:22-bookworm is registered
  - Interactive install with extra labels: verify default + custom labels are both registered
  ~~- Unattended install with mode="generated" and all var_* set: verify no prompts, container created with correct config~~ Test 4 has been withheld at this time, pending question asked in issue  https://github.com/community-scripts/ProxmoxVED/issues/1576#issuecomment-4151636223
  - Unattended install with missing token: verify hard error and clean exit
 
 Once steps have been tested (and gif of output provided here) I will update and remove DRAFT, indicating ready for merge. 

---

## 📦 Application Requirements (for new scripts)
brevity removal
## 🌐 Source
brevity removal
