### PR TITLE
feat: add CinePlete LXC script

### DIFF
--- a/ct/cineplete.sh
+++ b/ct/cineplete.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sdblepas
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/sdblepas/CinePlete
+
+APP="CinePlete"
+var_tags="${var_tags:-media;plex;jellyfin}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/cineplete ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "cineplete" "sdblepas/CinePlete"; then
+    msg_info "Stopping Service"
+    systemctl stop cineplete
+    msg_ok "Stopped Service"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cineplete" "sdblepas/CinePlete" "tarball"
+
+    msg_info "Updating Python Dependencies"
+    cd /opt/cineplete
+    $STD uv pip install -r requirements.txt --python .venv/bin/python
+    msg_ok "Updated Python Dependencies"
+
+    msg_info "Starting Service"
+    systemctl start cineplete
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:7474${CL}"

--- a/install/cineplete-install.sh
+++ b/install/cineplete-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sdblepas
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/sdblepas/CinePlete
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y python3
+msg_ok "Installed Dependencies"
+
+UV_PYTHON="3.12" setup_uv
+fetch_and_deploy_gh_release "cineplete" "sdblepas/CinePlete" "tarball"
+
+msg_info "Setting up ${APP}"
+mkdir -p /data /config
+cd /opt/cineplete
+$STD uv venv --clear .venv --python=python3
+$STD uv pip install -r requirements.txt --python .venv/bin/python
+msg_ok "Set up ${APP}"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/cineplete.service
+[Unit]
+Description=CinePlete — Movie library gap finder
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/cineplete
+Environment=DATA_DIR=/data
+Environment=CONFIG_DIR=/config
+Environment=STATIC_DIR=/opt/cineplete/static
+ExecStart=/opt/cineplete/.venv/bin/uvicorn app.web:app --host 0.0.0.0 --port 7474 --workers 1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now cineplete
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/cineplete.json
+++ b/json/cineplete.json
@@ -1,0 +1,38 @@
+{
+    "name": "CinePlete",
+    "slug": "cineplete",
+    "categories": [13],
+    "date_created": "2026-03-31",
+    "type": "ct",
+    "updateable": true,
+    "privileged": false,
+    "interface_port": 7474,
+    "documentation": "https://github.com/sdblepas/CinePlete",
+    "website": "https://github.com/sdblepas/CinePlete",
+    "logo": "https://raw.githubusercontent.com/sdblepas/CinePlete/main/assets/icon.png",
+    "config_path": "/config/config.yml",
+    "description": "Scans your Plex or Jellyfin library and shows missing movies from franchises, directors, actors, and classics.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/cineplete.sh",
+            "resources": {
+                "cpu": 2,
+                "ram": 512,
+                "hdd": 4,
+                "os": "Debian",
+                "version": "13"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": null,
+        "password": null
+    },
+    "notes": [
+        {
+            "text": "A TMDB API key is required. Configure it from the web UI after install.",
+            "type": "info"
+        }
+    ]
+}


### PR DESCRIPTION
## ✍️ Description
Add CinePlete — a self-hosted tool that scans Plex or Jellyfin libraries and shows missing movies from franchises, directors, actors, and classics. Includes a dashboard with charts, Radarr/Overseerr/Jellyseerr integration, Letterboxd import, wishlist, and smart authentication.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

- [X] 🆕 **New script** – A fully functional and tested script or script set.

---

## 🔍 Code & Security Review

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**

## 📋 Additional Information

- Uses `setup_uv` for Python runtime
- Uses `fetch_and_deploy_gh_release` with tarball mode
- No database required — file-based storage (`/data`, `/config`)
- Uvicorn serves directly on port 7474, no Nginx needed
- Update function uses `CLEAN_INSTALL=1` flag

## 📦 Application Requirements

- [ ] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars** *(growing project, currently below threshold)*
- [X] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
https://github.com/sdblepas/CinePlete