### PR TITLE
feat: add NoteSX LXC container

### DIFF
--- a/ct/notesx.sh
+++ b/ct/notesx.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Hotfirenet
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/note-sx/server
+
+APP="NoteSX"
+var_tags="${var_tags:-notes;sharing}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/notesx ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "notesx" "note-sx/server"; then
+    msg_info "Stopping Service"
+    systemctl stop notesx
+    msg_ok "Stopped Service"
+
+    msg_info "Backing up Data"
+    cp /opt/notesx/app/.env /opt/notesx_env_backup
+    cp -r /opt/notesx/db /opt/notesx_db_backup
+    cp -r /opt/notesx/userfiles /opt/notesx_userfiles_backup
+    msg_ok "Backed up Data"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "notesx" "note-sx/server" "tarball" "latest" "/opt/notesx"
+
+    msg_info "Rebuilding ${APP}"
+    cd /opt/notesx/app
+    $STD npm install --omit=dev
+    $STD npx tsc --noCheck
+    msg_ok "Rebuilt ${APP}"
+
+    msg_info "Restoring Data"
+    cp /opt/notesx_env_backup /opt/notesx/app/.env
+    cp -r /opt/notesx_db_backup/. /opt/notesx/db
+    cp -r /opt/notesx_userfiles_backup/. /opt/notesx/userfiles
+    rm -f /opt/notesx_env_backup
+    rm -rf /opt/notesx_db_backup /opt/notesx_userfiles_backup
+    msg_ok "Restored Data"
+
+    msg_info "Starting Service"
+    systemctl start notesx
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3000${CL}"

--- a/ct/notesx.sh
+++ b/ct/notesx.sh
@@ -42,11 +42,11 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "notesx" "note-sx/server" "tarball" "latest" "/opt/notesx"
 
-    msg_info "Rebuilding ${APP}"
+    msg_info "Rebuilding NoteSX"
     cd /opt/notesx/app
     $STD npm install --omit=dev
     $STD npx tsc --noCheck
-    msg_ok "Rebuilt ${APP}"
+    msg_ok "Rebuilt NoteSX"
 
     msg_info "Restoring Data"
     cp /opt/notesx_env_backup /opt/notesx/app/.env

--- a/install/notesx-install.sh
+++ b/install/notesx-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Hotfirenet
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/note-sx/server
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y build-essential
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+get_lxc_ip
+
+fetch_and_deploy_gh_release "notesx" "note-sx/server" "tarball" "latest" "/opt/notesx"
+
+msg_info "Building NoteSX"
+cd /opt/notesx/app
+$STD npm install --omit=dev
+$STD npx tsc --noCheck
+msg_ok "Built NoteSX"
+
+msg_info "Configuring NoteSX"
+HASH_SALT=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c32)
+cat <<EOF >/opt/notesx/app/.env
+BASE_WEB_URL=http://${LOCAL_IP}:3000
+HASH_SALT=${HASH_SALT}
+MAXIMUM_UPLOAD_SIZE_MB=5
+FOLDER_PREFIX=0
+ALLOW_NEW_USERS=true
+NODE_ENV=production
+EOF
+msg_ok "Configured NoteSX"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/notesx.service
+[Unit]
+Description=NoteXS Share Note Server
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/notesx/app
+EnvironmentFile=/opt/notesx/app/.env
+ExecStart=/usr/bin/node /opt/notesx/app/dist/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now notesx
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/notesx.json
+++ b/json/notesx.json
@@ -11,7 +11,7 @@
     "interface_port": 3000,
     "documentation": "https://github.com/note-sx/server",
     "website": "https://note.sx",
-    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/notesx.webp",
+    "logo": "",
     "config_path": "/opt/notesx/app/.env",
     "description": "Self-hosted backend for the Obsidian Share Note plugin, enabling encrypted note sharing without relying on external services.",
     "install_methods": [

--- a/json/notesx.json
+++ b/json/notesx.json
@@ -11,7 +11,7 @@
     "interface_port": 3000,
     "documentation": "https://github.com/note-sx/server",
     "website": "https://note.sx",
-    "logo": "",
+    "logo": "https://raw.githubusercontent.com/note-sx/server/main/app/static/favicon-512x512.webp",
     "config_path": "/opt/notesx/app/.env",
     "description": "Self-hosted backend for the Obsidian Share Note plugin, enabling encrypted note sharing without relying on external services.",
     "install_methods": [

--- a/json/notesx.json
+++ b/json/notesx.json
@@ -1,0 +1,40 @@
+{
+    "name": "NoteSX",
+    "slug": "notesx",
+    "categories": [
+        12
+    ],
+    "date_created": "2026-04-09",
+    "type": "ct",
+    "updateable": true,
+    "privileged": false,
+    "interface_port": 3000,
+    "documentation": "https://github.com/note-sx/server",
+    "website": "https://note.sx",
+    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/notesx.webp",
+    "config_path": "/opt/notesx/app/.env",
+    "description": "Self-hosted backend for the Obsidian Share Note plugin, enabling encrypted note sharing without relying on external services.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/notesx.sh",
+            "resources": {
+                "cpu": 1,
+                "ram": 512,
+                "hdd": 4,
+                "os": "Debian",
+                "version": "13"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": null,
+        "password": null
+    },
+    "notes": [
+        {
+            "text": "Update BASE_WEB_URL in /opt/notesx/app/.env to your public domain after installation.",
+            "type": "info"
+        }
+    ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds LXC container scripts for [NoteSX](https://github.com/note-sx/server), the self-hosted backend for the [Obsidian Share Note](https://github.com/note-sx/obsidian-plugin) plugin.

NoteSX is a lightweight TypeScript/Hono server that handles encrypted note sharing, file uploads and user management. It lets users self-host the backend instead of using the official note.sx service.

**Stack:** Node.js 22, SQLite (better-sqlite3 — native module, requires build-essential), Hono, port 3000

**Resources:** Debian 13 | 1 CPU | 512 MiB RAM | 4 GB disk | Unprivileged

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Tested on Proxmox VE 8.x. Container installs cleanly, service starts and responds on port 3000. Update function tested with backup/restore of `.env`, `db/` and `userfiles/`.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.