### PR TITLE
feat(opentoggl): add OpenToggl LXC container script

### DIFF
--- a/ct/opentoggl.sh
+++ b/ct/opentoggl.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: CorrectRoadH
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/CorrectRoadH/opentoggl
+
+APP="OpenToggl"
+var_tags="${var_tags:-time-tracking}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -f /usr/local/bin/opentoggl ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "opentoggl" "CorrectRoadH/opentoggl"; then
+    msg_info "Stopping Service"
+    systemctl stop opentoggl
+    msg_ok "Stopped Service"
+
+    fetch_and_deploy_gh_release "opentoggl" "CorrectRoadH/opentoggl" "singlefile" "latest" "/usr/local/bin" "opentoggl-linux-amd64"
+    chmod +x /usr/local/bin/opentoggl
+
+    msg_info "Starting Service"
+    systemctl start opentoggl
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8080${CL}"

--- a/install/opentoggl-install.sh
+++ b/install/opentoggl-install.sh
@@ -19,7 +19,6 @@ msg_ok "Installed Dependencies"
 
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="opentoggl" PG_DB_USER="opentoggl" setup_postgresql_db
-get_lxc_ip
 
 fetch_and_deploy_gh_release "opentoggl" "CorrectRoadH/opentoggl" "singlefile" "latest" "/usr/local/bin" "opentoggl-linux-amd64"
 chmod +x /usr/local/bin/opentoggl
@@ -54,8 +53,7 @@ User=root
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now redis
-systemctl enable -q --now opentoggl
+systemctl enable -q --now redis opentoggl
 msg_ok "Created Service"
 
 motd_ssh

--- a/install/opentoggl-install.sh
+++ b/install/opentoggl-install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: CorrectRoadH
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/CorrectRoadH/opentoggl
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y redis
+msg_ok "Installed Dependencies"
+
+PG_VERSION="16" setup_postgresql
+PG_DB_NAME="opentoggl" PG_DB_USER="opentoggl" setup_postgresql_db
+get_lxc_ip
+
+fetch_and_deploy_gh_release "opentoggl" "CorrectRoadH/opentoggl" "singlefile" "latest" "/usr/local/bin" "opentoggl-linux-amd64"
+chmod +x /usr/local/bin/opentoggl
+
+msg_info "Configuring OpenToggl"
+mkdir -p /opt/opentoggl
+cat <<EOF >/opt/opentoggl/.env
+OPENTOGGL_SERVICE_NAME=opentoggl
+PORT=8080
+DATABASE_URL=postgres://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}?sslmode=disable
+REDIS_URL=redis://127.0.0.1:6379/0
+OPENTOGGL_FILESTORE_NAMESPACE=opentoggl
+OPENTOGGL_JOBS_QUEUE_NAME=default
+EOF
+msg_ok "Configured OpenToggl"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/opentoggl.service
+[Unit]
+Description=OpenToggl Service
+After=network.target postgresql.service redis.service
+
+[Service]
+WorkingDirectory=/opt/opentoggl
+EnvironmentFile=/opt/opentoggl/.env
+ExecStartPre=/usr/local/bin/opentoggl schema-apply
+ExecStart=/usr/local/bin/opentoggl serve
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now redis
+systemctl enable -q --now opentoggl
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/opentoggl.json
+++ b/json/opentoggl.json
@@ -10,7 +10,7 @@
   "privileged": false,
   "interface_port": 8080,
   "documentation": "https://github.com/CorrectRoadH/opentoggl",
-  "website": "https://github.com/CorrectRoadH/opentoggl",
+  "website": "https://opentoggl.com",
   "logo": "",
   "description": "OpenToggl is an open-source self-hosted time-tracking application, distributed as a single pre-compiled binary and backed by PostgreSQL and Redis.",
   "install_methods": [

--- a/json/opentoggl.json
+++ b/json/opentoggl.json
@@ -1,0 +1,40 @@
+{
+  "name": "OpenToggl",
+  "slug": "opentoggl",
+  "categories": [
+    25
+  ],
+  "date_created": "2026-04-19",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 8080,
+  "documentation": "https://github.com/CorrectRoadH/opentoggl",
+  "website": "https://github.com/CorrectRoadH/opentoggl",
+  "logo": "",
+  "description": "OpenToggl is an open-source self-hosted time-tracking application, distributed as a single pre-compiled binary and backed by PostgreSQL and Redis.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/opentoggl.sh",
+      "config_path": "/opt/opentoggl/.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Create your first account by registering via the web interface.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description
Adds a new CT script for **OpenToggl**, an open-source self-hosted time-tracking application.

The install script deploys the pre-compiled single-file binary from GitHub Releases, sets up PostgreSQL 16 and Redis as local dependencies, writes `/opt/opentoggl/.env`, and registers a `systemd` service that runs `opentoggl serve` on port 8080.

## 🔗 Related PR / Issue
Link: #

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

- [x] 🆕 **New script** – A fully functional and tested script or script set.

---

## 🔍 Code & Security Review

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**

## 📋 Additional Information
- Uses `fetch_and_deploy_gh_release` in `singlefile` mode for the prebuilt binary
- Uses `setup_postgresql` / `setup_postgresql_db` helpers for the database
- Update path uses `check_for_gh_release` to stop the service, redeploy the binary, and restart

---

## 📦 Application Requirements (for new scripts)

- [ ] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- Upstream project: https://github.com/CorrectRoadH/opentoggl
