### PR TITLE
feat: add Etherpad

### DIFF
--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: John McLear (JohnMcLear)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://etherpad.org
+
+APP="Etherpad"
+var_tags="${var_tags:-docs;collaboration;editor}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/etherpad-lite ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "etherpad-lite" "ether/etherpad-lite"; then
+    msg_info "Stopping Service"
+    systemctl stop etherpad
+    msg_ok "Stopped Service"
+
+    msg_info "Backing up Configuration"
+    [ -f /opt/etherpad-lite/settings.json ] && cp /opt/etherpad-lite/settings.json /opt/etherpad-settings.json.bak
+    [ -d /opt/etherpad-lite/var ] && cp -a /opt/etherpad-lite/var /opt/etherpad-var.bak
+    msg_ok "Backed up Configuration"
+
+    LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
+    msg_info "Updating to ${LATEST_TAG}"
+    cd /opt/etherpad-lite
+    $STD git fetch --tags --prune
+    $STD git checkout "${LATEST_TAG}"
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    $STD corepack enable
+    $STD pnpm install --frozen-lockfile
+    $STD pnpm run build:etherpad
+    msg_ok "Updated to ${LATEST_TAG}"
+
+    msg_info "Restoring Configuration"
+    [ -f /opt/etherpad-settings.json.bak ] && mv /opt/etherpad-settings.json.bak /opt/etherpad-lite/settings.json
+    [ -d /opt/etherpad-var.bak ] && rm -rf /opt/etherpad-lite/var && mv /opt/etherpad-var.bak /opt/etherpad-lite/var
+    chown -R etherpad:etherpad /opt/etherpad-lite
+    msg_ok "Restored Configuration"
+
+    msg_info "Starting Service"
+    systemctl start etherpad
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:9001${CL}"

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: John McLear (JohnMcLear)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://etherpad.org
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  git \
+  curl \
+  ca-certificates \
+  build-essential \
+  pkg-config \
+  libsqlite3-dev
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Enabling pnpm via corepack"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+$STD corepack enable
+msg_ok "Enabled pnpm"
+
+msg_info "Creating etherpad User"
+if ! id -u etherpad >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir /var/lib/etherpad --shell /usr/sbin/nologin etherpad
+fi
+msg_ok "Created etherpad User"
+
+msg_info "Cloning Etherpad"
+LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
+if [ -z "${LATEST_TAG}" ]; then
+  msg_error "Unable to determine latest Etherpad release"
+  exit 1
+fi
+$STD git clone --depth 1 --branch "${LATEST_TAG}" https://github.com/ether/etherpad-lite.git /opt/etherpad-lite
+echo "${LATEST_TAG}" >/opt/etherpad-lite/.version
+msg_ok "Cloned Etherpad ${LATEST_TAG}"
+
+msg_info "Building Etherpad"
+cd /opt/etherpad-lite
+$STD pnpm install --frozen-lockfile
+$STD pnpm run build:etherpad
+msg_ok "Built Etherpad"
+
+msg_info "Configuring Etherpad"
+cp /opt/etherpad-lite/settings.json.template /opt/etherpad-lite/settings.json
+sed -i 's#"ip": *"127.0.0.1"#"ip": "0.0.0.0"#' /opt/etherpad-lite/settings.json
+chown -R etherpad:etherpad /opt/etherpad-lite
+msg_ok "Configured Etherpad"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/etherpad.service
+[Unit]
+Description=Etherpad Collaborative Editor
+Documentation=https://etherpad.org/doc
+After=network.target
+
+[Service]
+Type=simple
+User=etherpad
+Group=etherpad
+WorkingDirectory=/opt/etherpad-lite
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/env pnpm run prod
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now etherpad
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/etherpad.json
+++ b/json/etherpad.json
@@ -1,0 +1,48 @@
+{
+  "name": "Etherpad",
+  "slug": "etherpad",
+  "categories": [
+    12
+  ],
+  "date_created": "2026-04-19",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 9001,
+  "documentation": "https://etherpad.org/doc",
+  "website": "https://etherpad.org",
+  "logo": "https://raw.githubusercontent.com/ether/etherpad-lite/develop/src/static/favicon.ico",
+  "description": "Etherpad is a highly customizable real-time collaborative document editor. It lets multiple people edit the same document simultaneously in the browser, with live changes, per-user colors, chat, and a rich plugin ecosystem.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/etherpad.sh",
+      "config_path": "/opt/etherpad-lite/settings.json",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "12"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The default install uses the built-in DirtyDB store, intended for evaluation only. For production, edit /opt/etherpad-lite/settings.json and switch the 'dbType' to mysql or postgres.",
+      "type": "info"
+    },
+    {
+      "text": "View logs with: journalctl -u etherpad -f",
+      "type": "info"
+    },
+    {
+      "text": "Etherpad listens on port 9001. Restart the service after editing settings.json: systemctl restart etherpad",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a new LXC helper-script for **Etherpad** (https://etherpad.org), a real-time collaborative document editor (Node.js / pnpm). Requested in ether/etherpad#7529.

- `ct/etherpad.sh` — launcher + `update_script` using `check_for_gh_release` against `ether/etherpad-lite`
- `install/etherpad-install.sh` — Node.js 22 via `setup_nodejs`, pnpm via corepack, clone latest release tag, `pnpm install --frozen-lockfile && pnpm run build:etherpad`, dedicated `etherpad` system user, systemd unit running `pnpm run prod`
- `json/etherpad.json` — category 12 (Documents & Notes), port 9001, default creds none

## Application details
- Upstream: https://github.com/ether/etherpad-lite (tag v2.6.1 at time of writing)
- Runtime: Node.js 20+ (we use 22), pnpm managed via corepack
- Default port: 9001
- Config: `/opt/etherpad-lite/settings.json` (copied from `settings.json.template` on install; `ip` rewritten to `0.0.0.0`)
- Default DB: DirtyDB (evaluation only); notes tell the user to switch to MySQL/Postgres for production
- Service: `etherpad.service`, runs as unprivileged `etherpad` user, `ExecStart=/usr/bin/env pnpm run prod`

## Resources
- Default: 2 vCPU / 2048 MB RAM / 8 GB disk, Debian 12, unprivileged

## Update path
`update_script` stops the service, backs up `settings.json` and `var/`, `git fetch --tags && git checkout <latest tag>`, reinstalls deps, rebuilds, restores config, restarts.

## Test plan
- [ ] Fresh install on Debian 12 unprivileged LXC; `http://<ip>:9001` loads the pad
- [ ] `systemctl status etherpad` active
- [ ] Create a pad, open in a second browser, confirm live collaboration
- [ ] Edit `settings.json` (change title), `systemctl restart etherpad`, verify change
- [ ] Re-run update path; confirm it picks up the latest tag
- [ ] `shellcheck ct/etherpad.sh install/etherpad-install.sh` clean

## Related
Closest precedent in repo: `ct/affine.sh` / `install/affine-install.sh` (Node.js + pnpm + git build pattern). Refs ether/etherpad#7529. 
