### PR TITLE
feat: add Etherpad

### DIFF
--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -39,16 +39,15 @@ function update_script() {
     [ -d /opt/etherpad-lite/var ] && cp -a /opt/etherpad-lite/var /opt/etherpad-var.bak
     msg_ok "Backed up Configuration"
 
-    LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
-    msg_info "Updating to ${LATEST_TAG}"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad-lite" "tarball" "latest" "/opt/etherpad-lite"
+
+    msg_info "Rebuilding Etherpad"
     cd /opt/etherpad-lite
-    $STD git fetch --tags --prune
-    $STD git checkout "${LATEST_TAG}"
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     $STD corepack enable
     $STD pnpm install --frozen-lockfile
     $STD pnpm run build:etherpad
-    msg_ok "Updated to ${LATEST_TAG}"
+    msg_ok "Rebuilt Etherpad"
 
     msg_info "Restoring Configuration"
     [ -f /opt/etherpad-settings.json.bak ] && mv /opt/etherpad-settings.json.bak /opt/etherpad-lite/settings.json

--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: John McLear (JohnMcLear)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://etherpad.org
+
+APP="Etherpad"
+var_tags="${var_tags:-docs;collaboration;editor}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/etherpad-lite ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "etherpad-lite" "ether/etherpad-lite"; then
+    msg_info "Stopping Service"
+    systemctl stop etherpad
+    msg_ok "Stopped Service"
+
+    msg_info "Backing up Configuration"
+    [ -f /opt/etherpad-lite/settings.json ] && cp /opt/etherpad-lite/settings.json /opt/etherpad-settings.json.bak
+    [ -d /opt/etherpad-lite/var ] && cp -a /opt/etherpad-lite/var /opt/etherpad-var.bak
+    msg_ok "Backed up Configuration"
+
+    LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
+    msg_info "Updating to ${LATEST_TAG}"
+    cd /opt/etherpad-lite
+    $STD git fetch --tags --prune
+    $STD git checkout "${LATEST_TAG}"
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    $STD corepack enable
+    $STD pnpm install --frozen-lockfile
+    $STD pnpm run build:etherpad
+    msg_ok "Updated to ${LATEST_TAG}"
+
+    msg_info "Restoring Configuration"
+    [ -f /opt/etherpad-settings.json.bak ] && mv /opt/etherpad-settings.json.bak /opt/etherpad-lite/settings.json
+    [ -d /opt/etherpad-var.bak ] && rm -rf /opt/etherpad-lite/var && mv /opt/etherpad-var.bak /opt/etherpad-lite/var
+    chown -R etherpad:etherpad /opt/etherpad-lite
+    msg_ok "Restored Configuration"
+
+    msg_info "Starting Service"
+    systemctl start etherpad
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:9001${CL}"

--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  if check_for_gh_release "etherpad-lite" "ether/etherpad-lite"; then
+  if check_for_gh_release "etherpad-lite" "ether/etherpad"; then
     msg_info "Stopping Service"
     systemctl stop etherpad
     msg_ok "Stopped Service"
@@ -39,7 +39,7 @@ function update_script() {
     [ -d /opt/etherpad-lite/var ] && cp -a /opt/etherpad-lite/var /opt/etherpad-var.bak
     msg_ok "Backed up Configuration"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad-lite" "tarball" "latest" "/opt/etherpad-lite"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball" "latest" "/opt/etherpad-lite"
 
     msg_info "Rebuilding Etherpad"
     cd /opt/etherpad-lite

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -15,9 +15,6 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt install -y \
-  git \
-  curl \
-  ca-certificates \
   build-essential \
   pkg-config \
   libsqlite3-dev
@@ -31,20 +28,10 @@ $STD corepack enable
 msg_ok "Enabled pnpm"
 
 msg_info "Creating etherpad User"
-if ! id -u etherpad >/dev/null 2>&1; then
-  useradd --system --create-home --home-dir /var/lib/etherpad --shell /usr/sbin/nologin etherpad
-fi
+useradd --system --create-home --home-dir /var/lib/etherpad --shell /usr/sbin/nologin etherpad
 msg_ok "Created etherpad User"
 
-msg_info "Cloning Etherpad"
-LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
-if [ -z "${LATEST_TAG}" ]; then
-  msg_error "Unable to determine latest Etherpad release"
-  exit 1
-fi
-$STD git clone --depth 1 --branch "${LATEST_TAG}" https://github.com/ether/etherpad-lite.git /opt/etherpad-lite
-echo "${LATEST_TAG}" >/opt/etherpad-lite/.version
-msg_ok "Cloned Etherpad ${LATEST_TAG}"
+fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad-lite" "tarball" "latest" "/opt/etherpad-lite"
 
 msg_info "Building Etherpad"
 cd /opt/etherpad-lite

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: John McLear (JohnMcLear)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://etherpad.org
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  git \
+  curl \
+  ca-certificates \
+  build-essential \
+  pkg-config \
+  libsqlite3-dev
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Enabling pnpm via corepack"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+$STD corepack enable
+msg_ok "Enabled pnpm"
+
+msg_info "Creating etherpad User"
+if ! id -u etherpad >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir /var/lib/etherpad --shell /usr/sbin/nologin etherpad
+fi
+msg_ok "Created etherpad User"
+
+msg_info "Cloning Etherpad"
+LATEST_TAG=$(curl -fsSL https://api.github.com/repos/ether/etherpad-lite/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')
+if [ -z "${LATEST_TAG}" ]; then
+  msg_error "Unable to determine latest Etherpad release"
+  exit 1
+fi
+$STD git clone --depth 1 --branch "${LATEST_TAG}" https://github.com/ether/etherpad-lite.git /opt/etherpad-lite
+echo "${LATEST_TAG}" >/opt/etherpad-lite/.version
+msg_ok "Cloned Etherpad ${LATEST_TAG}"
+
+msg_info "Building Etherpad"
+cd /opt/etherpad-lite
+$STD pnpm install --frozen-lockfile
+$STD pnpm run build:etherpad
+msg_ok "Built Etherpad"
+
+msg_info "Configuring Etherpad"
+cp /opt/etherpad-lite/settings.json.template /opt/etherpad-lite/settings.json
+sed -i 's#"ip": *"127.0.0.1"#"ip": "0.0.0.0"#' /opt/etherpad-lite/settings.json
+chown -R etherpad:etherpad /opt/etherpad-lite
+msg_ok "Configured Etherpad"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/etherpad.service
+[Unit]
+Description=Etherpad Collaborative Editor
+Documentation=https://etherpad.org/doc
+After=network.target
+
+[Service]
+Type=simple
+User=etherpad
+Group=etherpad
+WorkingDirectory=/opt/etherpad-lite
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/env pnpm run prod
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now etherpad
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -31,7 +31,7 @@ msg_info "Creating etherpad User"
 useradd --system --create-home --home-dir /var/lib/etherpad --shell /usr/sbin/nologin etherpad
 msg_ok "Created etherpad User"
 
-fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad-lite" "tarball" "latest" "/opt/etherpad-lite"
+fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball" "latest" "/opt/etherpad-lite"
 
 msg_info "Building Etherpad"
 cd /opt/etherpad-lite
@@ -41,7 +41,18 @@ msg_ok "Built Etherpad"
 
 msg_info "Configuring Etherpad"
 cp /opt/etherpad-lite/settings.json.template /opt/etherpad-lite/settings.json
-sed -i 's#"ip": *"127.0.0.1"#"ip": "0.0.0.0"#' /opt/etherpad-lite/settings.json
+# Switch dbType from the upstream template's dev-only "dirty" default to
+# sqlite (ACID, single-file) backed by a file in the etherpad user's
+# state directory. Matches the same default across our snap, .deb, and
+# Home Assistant add-on packagings. Admins who need postgres or mysql
+# can edit settings.json and switch dbType + dbSettings; ueberdb
+# supports both backends via the same code path.
+install -d -o etherpad -g etherpad -m 0750 /var/lib/etherpad
+sed -i \
+  -e 's#"ip": *"127.0.0.1"#"ip": "0.0.0.0"#' \
+  -e 's#"dbType" *: *"dirty"#"dbType": "sqlite"#' \
+  -e 's#"filename" *: *"var/dirty.db"#"filename": "/var/lib/etherpad/etherpad.db"#' \
+  /opt/etherpad-lite/settings.json
 chown -R etherpad:etherpad /opt/etherpad-lite
 msg_ok "Configured Etherpad"
 

--- a/json/etherpad.json
+++ b/json/etherpad.json
@@ -1,0 +1,48 @@
+{
+  "name": "Etherpad",
+  "slug": "etherpad",
+  "categories": [
+    12
+  ],
+  "date_created": "2026-04-19",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 9001,
+  "documentation": "https://etherpad.org/doc",
+  "website": "https://etherpad.org",
+  "logo": "https://raw.githubusercontent.com/ether/etherpad-lite/develop/src/static/favicon.ico",
+  "description": "Etherpad is a highly customizable real-time collaborative document editor. It lets multiple people edit the same document simultaneously in the browser, with live changes, per-user colors, chat, and a rich plugin ecosystem.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/etherpad.sh",
+      "config_path": "/opt/etherpad-lite/settings.json",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "12"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The default install uses the built-in DirtyDB store, intended for evaluation only. For production, edit /opt/etherpad-lite/settings.json and switch the 'dbType' to mysql or postgres.",
+      "type": "info"
+    },
+    {
+      "text": "View logs with: journalctl -u etherpad -f",
+      "type": "info"
+    },
+    {
+      "text": "Etherpad listens on port 9001. Restart the service after editing settings.json: systemctl restart etherpad",
+      "type": "info"
+    }
+  ]
+}

--- a/json/etherpad.json
+++ b/json/etherpad.json
@@ -11,7 +11,7 @@
   "interface_port": 9001,
   "documentation": "https://etherpad.org/doc",
   "website": "https://etherpad.org",
-  "logo": "https://raw.githubusercontent.com/ether/etherpad-lite/develop/src/static/favicon.ico",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/etherpad.webp",
   "description": "Etherpad is a highly customizable real-time collaborative document editor. It lets multiple people edit the same document simultaneously in the browser, with live changes, per-user colors, chat, and a rich plugin ecosystem.",
   "install_methods": [
     {
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "Debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/json/etherpad.json
+++ b/json/etherpad.json
@@ -33,7 +33,7 @@
   },
   "notes": [
     {
-      "text": "The default install uses the built-in DirtyDB store, intended for evaluation only. For production, edit /opt/etherpad-lite/settings.json and switch the 'dbType' to mysql or postgres.",
+      "text": "The default install uses an embedded sqlite database at /var/lib/etherpad/etherpad.db — ACID, zero-config, suitable for single-instance homelab use. To use postgres or mysql instead, edit /opt/etherpad-lite/settings.json and switch 'dbType' + 'dbSettings' (Etherpad's ueberdb abstraction supports both).",
       "type": "info"
     },
     {


### PR DESCRIPTION
## ✍️ Description

Adds an LXC helper-script for **Etherpad** — a real-time collaborative document editor (Node.js / pnpm, Apache-2.0).

- `ct/etherpad.sh` — launcher + `update_script` using `check_for_gh_release` against `ether/etherpad-lite`, with service-stop / config-backup / `CLEAN_INSTALL=1 fetch_and_deploy_gh_release` / rebuild / config-restore / service-start steps.
- `install/etherpad-install.sh` — installs Node.js 22 via `setup_nodejs`, enables pnpm via corepack, deploys the latest `ether/etherpad-lite` release tarball to `/opt/etherpad-lite` via `fetch_and_deploy_gh_release`, runs `pnpm install --frozen-lockfile && pnpm run build:etherpad`, creates a dedicated `etherpad` system user, seeds `settings.json` from the template (rewriting `ip` to `0.0.0.0`), and installs a systemd unit running `pnpm run prod`.
- `json/etherpad.json` — category 12 (Documents & Notes), port 9001, default credentials none, selfh.st/icons logo, Debian 13.

## 🔗 Related PR / Issue

Link: ether/etherpad#7529

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards; AI-drafted, hand-reviewed and tested before submission.
- [x] **Tested thoroughly** – Fresh install on Debian 12 unprivileged LXC; `http://<ip>:9001` loads the pad, multi-browser collaboration works, `systemctl status etherpad` active, logs via `journalctl -u etherpad -f` clean. Retest on Debian 13 pending after review refactor.
- [x] **No breaking changes** – New files only; no edits to existing scripts/json.
- [x] **No security risks** – Runs as an unprivileged `etherpad` system user; no hardcoded credentials; firewalling is the operator's responsibility.

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script** – A fully functional and tested script set.
- [ ] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**

---

## 🔍 Code & Security Review

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)** — `ct/etherpad.sh`, `install/etherpad-install.sh`, `json/etherpad.json`.
- [x] **No hardcoded credentials**

## 📋 Additional Information

- Default resources: 2 vCPU / 2048 MB RAM / 8 GB disk, Debian 13, unprivileged.
- Install path: `fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad-lite" "tarball" "latest" "/opt/etherpad-lite"` — same helper used across the catalog (e.g. `ct/clickhouse.sh`).
- Update path: `check_for_gh_release` detects new `ether/etherpad-lite` tags; on update the script stops the service, backs up `settings.json` and `var/`, redeploys the tarball with `CLEAN_INSTALL=1`, reinstalls deps, rebuilds, restores config, restarts.
- Review feedback addressed in commit `e56def8a`:
  - `fetch_and_deploy_gh_release` replaces manual clone in both install and update.
  - Dropped `git`, `curl`, `ca-certificates` from apt list (base image has them, helper removes git need).
  - Removed the `id -u etherpad` guard around `useradd`.
  - Debian 12 → 13.
  - Logo switched to `selfh.st/icons` webp.

---

## 📦 Application Requirements (for new scripts)

- [x] The application is **at least 6 months old** — Etherpad has been under active development since 2011 (14+ years).
- [x] The application is **actively maintained** — v2.6.1 released January 2026; continuous commit activity on `develop` through today.
- [x] The application has **600+ GitHub stars** — [`ether/etherpad-lite`](https://github.com/ether/etherpad-lite) has 18k+ stars.
- [x] Official **release tarballs** are published — see [GitHub Releases](https://github.com/ether/etherpad-lite/releases); `fetch_and_deploy_gh_release` consumes `archive/refs/tags/<tag>.tar.gz`.
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG.

## 🌐 Source
- Upstream: https://github.com/ether/etherpad-lite
- Website: https://etherpad.org
- Docs: https://etherpad.org/doc
- Latest release: https://github.com/ether/etherpad-lite/releases/latest
