### PR TITLE
Add Moltis CT script

### DIFF
--- a/ct/moltis.sh
+++ b/ct/moltis.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Fabien Penso (penso)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/moltis-org/moltis
+
+APP="Moltis"
+var_tags="${var_tags:-ai;coding}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /usr/bin/moltis ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  RELEASE=$(curl -fsSL https://api.github.com/repos/moltis-org/moltis/releases/latest | grep "tag_name" | awk -F '"' '{print $4}')
+  CURRENT=$(moltis --version 2>/dev/null | awk '{print $NF}')
+
+  if [[ "${RELEASE}" == "${CURRENT}" ]]; then
+    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+    exit
+  fi
+
+  msg_info "Stopping Service"
+  systemctl stop moltis
+  msg_ok "Stopped Service"
+
+  ARCH=$(dpkg --print-architecture)
+  msg_info "Updating ${APP} to ${RELEASE}"
+  curl -fsSL -o /tmp/moltis.deb "https://github.com/moltis-org/moltis/releases/download/${RELEASE}/moltis_${RELEASE}_${ARCH}.deb"
+  $STD dpkg -i /tmp/moltis.deb
+  rm -f /tmp/moltis.deb
+  msg_ok "Updated ${APP} to ${RELEASE}"
+
+  msg_info "Starting Service"
+  systemctl start moltis
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}:13131${CL}"

--- a/install/moltis-install.sh
+++ b/install/moltis-install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Fabien Penso (penso)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/moltis-org/moltis
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+ARCH=$(dpkg --print-architecture)
+RELEASE=$(curl -fsSL https://api.github.com/repos/moltis-org/moltis/releases/latest | grep "tag_name" | awk -F '"' '{print $4}')
+
+msg_info "Installing Moltis ${RELEASE}"
+curl -fsSL -o /tmp/moltis.deb "https://github.com/moltis-org/moltis/releases/download/${RELEASE}/moltis_${RELEASE}_${ARCH}.deb"
+$STD dpkg -i /tmp/moltis.deb
+rm -f /tmp/moltis.deb
+msg_ok "Installed Moltis ${RELEASE}"
+
+msg_info "Configuring Moltis"
+useradd -r -s /usr/sbin/nologin -d /var/lib/moltis moltis
+mkdir -p /var/lib/moltis /etc/moltis
+chown moltis:moltis /var/lib/moltis /etc/moltis
+msg_ok "Configured Moltis"
+
+read -r -p "${TAB3}Would you like to install Docker for sandbox support? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  msg_info "Installing Docker"
+  $STD sh <(curl -fsSL https://get.docker.com)
+  $STD usermod -aG docker moltis
+  msg_ok "Installed Docker"
+fi
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/moltis.service
+[Unit]
+Description=Moltis Agent Server
+After=network-online.target
+Wants=network-online.target
+Documentation=https://docs.moltis.org
+
+[Service]
+Type=simple
+User=moltis
+Group=moltis
+ExecStart=/usr/bin/moltis serve --bind 0.0.0.0
+Restart=on-failure
+RestartSec=5
+Environment=MOLTIS_DATA_DIR=/var/lib/moltis
+Environment=MOLTIS_CONFIG_DIR=/etc/moltis
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/moltis /etc/moltis
+PrivateTmp=true
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now moltis
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/moltis.json
+++ b/json/moltis.json
@@ -1,0 +1,46 @@
+{
+  "name": "Moltis",
+  "slug": "moltis",
+  "categories": [20],
+  "date_created": "2026-04-30",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 13131,
+  "documentation": "https://docs.moltis.org",
+  "website": "https://moltis.org",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/moltis.webp",
+  "description": "Moltis is a personal AI gateway that runs locally with a web UI, supporting multiple LLM providers and integrating with messaging platforms like WhatsApp, Telegram, Discord, and Slack.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/moltis.sh",
+      "config_path": "/etc/moltis",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "On first launch, a setup code is printed to the service logs. View it with: pct exec <CTID> -- journalctl -u moltis --no-pager | grep setup",
+      "type": "info"
+    },
+    {
+      "text": "The web UI requires HTTPS. Use a reverse proxy or access via SSH tunnel: ssh -L 13131:localhost:13131 root@<container-ip>",
+      "type": "warning"
+    },
+    {
+      "text": "For agent sandbox support (shell command execution), install Docker when prompted during setup.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Moltis as a new Proxmox VE LXC container script.

[Moltis](https://moltis.org) is a personal AI gateway with a web UI that supports multiple LLM providers (OpenAI, Anthropic, Google, Ollama, etc.) and integrates with messaging platforms (WhatsApp, Telegram, Discord, Slack).

## Changes

- `ct/moltis.sh` — Container creation and update logic
- `install/moltis-install.sh` — Bare-metal install via `.deb` package
- `json/moltis.json` — Website metadata

## Installation approach

- Downloads the `.deb` package from [GitHub Releases](https://github.com/moltis-org/moltis/releases) (supports amd64 and arm64)
- Creates a dedicated `moltis` system user with hardened systemd service
- Optionally installs Docker for agent sandbox support (shell command execution in isolated containers)
- Update function compares installed version against latest release and upgrades via `.deb`

## Resources

| Resource | Value |
|----------|-------|
| CPU | 2 cores |
| RAM | 2048 MB |
| Disk | 4 GB |
| OS | Debian 13 |

## Links

- Website: https://moltis.org
- Docs: https://docs.moltis.org
- Source: https://github.com/moltis-org/moltis
- Docker: `ghcr.io/moltis-org/moltis:latest`