### PR TITLE
authentik:storage-fix

### DIFF
--- a/ct/authentik.sh
+++ b/ct/authentik.sh
@@ -35,7 +35,7 @@ function update_script() {
   setup_rust
 
   AUTHENTIK_VERSION="version/2026.2.2"
-  XMLSEC_VERSION="1.3.9"
+  XMLSEC_VERSION="1.3.11"
 
   if check_for_gh_release "geoipupdate" "maxmind/geoipupdate"; then
     fetch_and_deploy_gh_release "geoipupdate" "maxmind/geoipupdate" "binary"
@@ -122,7 +122,13 @@ build_container
 
 msg_info "Attaching data storage volume"
 $STD pct stop "$CTID"
-$STD pct set "$CTID" -mp0 "${CONTAINER_STORAGE}":1,mp=/opt/authentik-data,backup=1
+if [ "${PROTECT_CT:-}" == "1" ] || [ "${PROTECT_CT:-}" == "yes" ]; then
+  $STD pct set "$CTID" --protection 0
+  $STD pct set "$CTID" -mp0 "${CONTAINER_STORAGE}":1,mp=/opt/authentik-data,backup=1
+  $STD pct set "$CTID" --protection 1
+else
+  $STD pct set "$CTID" -mp0 "${CONTAINER_STORAGE}":1,mp=/opt/authentik-data,backup=1
+fi
 $STD pct start "$CTID"
 for i in {1..10}; do
   pct status "$CTID" | grep -q "status: running" && break

--- a/install/authentik-install.sh
+++ b/install/authentik-install.sh
@@ -55,7 +55,7 @@ setup_rust
 PG_VERSION="17" setup_postgresql
 PG_DB_NAME="authentik" PG_DB_USER="authentik" PG_DB_GRANT_SUPERUSER="true" setup_postgresql_db
 
-XMLSEC_VERSION="1.3.9"
+XMLSEC_VERSION="1.3.11"
 AUTHENTIK_VERSION="version/2026.2.2"
 fetch_and_deploy_gh_release "xmlsec" "lsh123/xmlsec" "tarball" "${XMLSEC_VERSION}" "/opt/xmlsec"
 fetch_and_deploy_gh_release "authentik" "goauthentik/authentik" "tarball" "${AUTHENTIK_VERSION}" "/opt/authentik"
@@ -122,6 +122,7 @@ yq -i ".blueprints_dir = \"/opt/authentik/blueprints\"" /etc/authentik/config.ym
 yq -i ".cert_discovery_dir = \"/opt/authentik-data/certs\"" /etc/authentik/config.yml
 yq -i ".email.template_dir = \"/opt/authentik-data/templates\"" /etc/authentik/config.yml
 yq -i ".storage.file.path = \"/opt/authentik-data\"" /etc/authentik/config.yml
+yq -i ".disable_startup_analytics = \"true\"" /etc/authentik/config.yml
 $STD useradd -U -s /usr/sbin/nologin -r -M -d /opt/authentik authentik
 chown -R authentik:authentik /opt/authentik
 cat <<EOF >/etc/default/authentik


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
Fix secondary storage attach to protected container.
Bump xmlsec to 1.3.11
Disable startup analytics

## 🔗 Related PR / Issue  

Link: https://github.com/community-scripts/ProxmoxVED/issues/1500#issuecomment-4366374105

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  


## 📋 Additional Information (optional)  


---

## 📦 Application Requirements (for new scripts)

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

