### PR TITLE
feat: add Webtrees LXC container

### DIFF
--- a/ct/webtrees.sh
+++ b/ct/webtrees.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sudofly
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://webtrees.net/
+
+APP="Webtrees"
+var_tags="${var_tags:-genealogy;cms}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/webtrees ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "webtrees" "fisharebest/webtrees"; then
+    msg_info "Stopping Service"
+    PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
+    systemctl stop php${PHP_VER}-fpm
+    systemctl stop caddy
+    msg_ok "Stopped Service"
+
+    msg_info "Backing up Data"
+    cp -r /opt/webtrees/data /opt/webtrees_data_backup
+    msg_ok "Backed up Data"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "webtrees" "fisharebest/webtrees" "prebuild" "latest" "/opt/webtrees" "webtrees-*.zip"
+
+    msg_info "Restoring Data"
+    cp -r /opt/webtrees_data_backup/. /opt/webtrees/data
+    rm -rf /opt/webtrees_data_backup
+    chown -R www-data:www-data /opt/webtrees
+    msg_ok "Restored Data"
+
+    msg_info "Starting Service"
+    systemctl start php${PHP_VER}-fpm
+    systemctl start caddy
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"

--- a/install/webtrees-install.sh
+++ b/install/webtrees-install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sudofly
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://webtrees.net/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  caddy \
+  unzip
+msg_ok "Installed Dependencies"
+
+PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULES="bcmath,gd,intl,xml,zip,pdo_mysql,mbstring,curl" setup_php
+setup_mariadb
+MARIADB_DB_NAME="webtrees" MARIADB_DB_USER="webtrees" setup_mariadb_db
+$STD mariadb -u root -e "GRANT ALL ON \`webtrees\`.* TO 'webtrees'@'127.0.0.1' IDENTIFIED BY '${MARIADB_DB_PASS}'; FLUSH PRIVILEGES;"
+
+fetch_and_deploy_gh_release "webtrees" "fisharebest/webtrees" "prebuild" "latest" "/opt/webtrees" "webtrees-*.zip"
+
+msg_info "Setting up Webtrees"
+chown -R www-data:www-data /opt/webtrees
+msg_ok "Set up Webtrees"
+
+msg_info "Configuring Caddy"
+PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
+cat <<EOF >/etc/caddy/Caddyfile
+:80 {
+    root * /opt/webtrees
+    php_fastcgi unix//run/php/php${PHP_VER}-fpm.sock
+    file_server
+    encode gzip
+}
+EOF
+usermod -aG www-data caddy
+msg_ok "Configured Caddy"
+
+systemctl enable -q --now php${PHP_VER}-fpm
+systemctl restart caddy
+
+msg_info "Automating Webtrees Setup"
+sleep 5
+WT_ADMIN_PASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c15)
+curl -sS -X POST "http://127.0.0.1/" \
+  -d "step=6" \
+  --data-urlencode "baseurl=http://${LOCAL_IP}" \
+  -d "lang=en-US" \
+  -d "dbtype=mysql" \
+  -d "dbhost=127.0.0.1" \
+  -d "dbport=3306" \
+  -d "dbuser=webtrees" \
+  --data-urlencode "dbpass=${MARIADB_DB_PASS}" \
+  -d "dbname=webtrees" \
+  -d "tblpfx=wt_" \
+  -d "wtname=Administrator" \
+  -d "wtuser=Admin" \
+  --data-urlencode "wtpass=${WT_ADMIN_PASS}" \
+  -d "wtemail=admin@example.com" >/dev/null
+
+cat <<EOF >>~/webtrees.creds
+
+Webtrees Admin User: Admin
+Webtrees Admin Password: ${WT_ADMIN_PASS}
+EOF
+msg_ok "Webtrees Setup Automated"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/webtrees.json
+++ b/json/webtrees.json
@@ -1,0 +1,40 @@
+{
+  "name": "Webtrees",
+  "slug": "webtrees",
+  "categories": [
+    1
+  ],
+  "date_created": "2026-05-10",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 80,
+  "documentation": "https://webtrees.net/install/",
+  "website": "https://webtrees.net/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/webtrees.webp",
+  "description": "webtrees is the web's leading online collaborative genealogy application.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/webtrees.sh",
+      "config_path": "/opt/webtrees/data/config.ini.php",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "Admin",
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Setup is fully automated. Login credentials are stored in '/root/webtrees.creds' inside the container.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds a new LXC container script for [webtrees](https://webtrees.net/), the web's leading open-source collaborative genealogy application.

The installation is fully automated:
- PHP 8.3 + PHP-FPM, MariaDB, and Caddy are installed and configured
- The webtrees prebuilt release is downloaded and deployed
- The setup wizard is completed automatically via a local HTTP POST request
- An administrator account is created with a randomly generated password
- All credentials (DB + admin login) are saved to `/root/webtrees.creds`

No manual browser-based setup is required after container creation.

## Type of Change

- [x] New application (ct/webtrees.sh + install/webtrees-install.sh)
- [ ] Update existing application
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other: **___**

## Testing

- [x] Tested on Proxmox VE 9.x
- [x] Container creation successful
- [x] Application installation successful
- [x] Application is accessible at URL
- [x] Update function works (if applicable)
- [x] No temporary files left after installation

## Application Details

- **App Name**: Webtrees
- **Source**: https://github.com/fisharebest/webtrees
- **Default OS**: Debian 13
- **Recommended Resources**: 2 CPU, 2GB RAM, 8GB Disk
- **Tags**: `genealogy;cms`
- **Access URL**: `http://IP`

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have tested the script via curl from my fork (after git push)
- [x] GitHub had time to update (waited 10-30 seconds)
- [x] ShellCheck shows no critical warnings
- [x] Documentation is accurate and complete
- [x] I have added/updated relevant documentation
