### PR TITLE
Add Spliit

### DIFF
--- a/ct/spliit.sh
+++ b/ct/spliit.sh
@@ -47,11 +47,15 @@ function update_script() {
 
     msg_info "Building Application"
     cd /opt/spliit
-    set -a && source /opt/spliit/.env && set +a
-    $STD npm install
-    $STD npm install deepmerge
+    $STD npm ci --ignore-scripts
+    $STD npx prisma generate
     $STD npm run build
     msg_ok "Built Application"
+
+    msg_info "Running Database Migrations"
+    cd /opt/spliit
+    $STD npx prisma migrate deploy
+    msg_ok "Ran Database Migrations"
 
     msg_info "Starting Service"
     systemctl start spliit

--- a/ct/spliit.sh
+++ b/ct/spliit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: a (cynicalchicken)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/spliit-app/spliit
+
+APP="Spliit"
+var_tags="${var_tags:-finance;expense-sharing}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/spliit ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "spliit" "spliit-app/spliit"; then
+    msg_info "Stopping Service"
+    systemctl stop spliit
+    msg_ok "Stopped Service"
+
+    msg_info "Backing up Configuration"
+    cp /opt/spliit/.env /opt/spliit.env.bak
+    msg_ok "Backed up Configuration"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "spliit" "spliit-app/spliit" "tarball"
+
+    msg_info "Restoring Configuration"
+    cp /opt/spliit.env.bak /opt/spliit/.env
+    rm -f /opt/spliit.env.bak
+    msg_ok "Restored Configuration"
+
+    msg_info "Building Application"
+    cd /opt/spliit
+    set -a && source /opt/spliit/.env && set +a
+    $STD npm install
+    $STD npm run build
+    msg_ok "Built Application"
+
+    msg_info "Starting Service"
+    systemctl start spliit
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3000${CL}"

--- a/ct/spliit.sh
+++ b/ct/spliit.sh
@@ -49,6 +49,7 @@ function update_script() {
     cd /opt/spliit
     set -a && source /opt/spliit/.env && set +a
     $STD npm install
+    $STD npm install deepmerge
     $STD npm run build
     msg_ok "Built Application"
 

--- a/install/spliit-install.sh
+++ b/install/spliit-install.sh
@@ -41,6 +41,7 @@ msg_info "Building Application"
 cd /opt/spliit
 set -a && source /opt/spliit/.env && set +a
 $STD npm install
+$STD npm install deepmerge
 $STD npm run build
 msg_ok "Built Application"
 

--- a/install/spliit-install.sh
+++ b/install/spliit-install.sh
@@ -39,11 +39,15 @@ msg_ok "Configured Application"
 
 msg_info "Building Application"
 cd /opt/spliit
-set -a && source /opt/spliit/.env && set +a
-$STD npm install
-$STD npm install deepmerge
+$STD npm ci --ignore-scripts
+$STD npx prisma generate
 $STD npm run build
 msg_ok "Built Application"
+
+msg_info "Running Database Migrations"
+cd /opt/spliit
+$STD npx prisma migrate deploy
+msg_ok "Ran Database Migrations"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/spliit.service

--- a/install/spliit-install.sh
+++ b/install/spliit-install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: a (cynicalchicken)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/spliit-app/spliit
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  build-essential \
+  git
+msg_ok "Installed Dependencies"
+
+PG_VERSION="16" setup_postgresql
+PG_DB_NAME="spliit" PG_DB_USER="spliit" setup_postgresql_db
+NODE_VERSION="22" setup_nodejs
+
+fetch_and_deploy_gh_release "spliit" "spliit-app/spliit" "tarball"
+
+msg_info "Configuring Application"
+cat <<EOF >/opt/spliit/.env
+POSTGRES_PRISMA_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}?schema=public
+POSTGRES_URL_NON_POOLING=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}?schema=public
+NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=
+NEXT_TELEMETRY_DISABLED=1
+NODE_ENV=production
+PORT=3000
+HOSTNAME=0.0.0.0
+EOF
+msg_ok "Configured Application"
+
+msg_info "Building Application"
+cd /opt/spliit
+set -a && source /opt/spliit/.env && set +a
+$STD npm install
+$STD npm run build
+msg_ok "Built Application"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/spliit.service
+[Unit]
+Description=Spliit
+After=network.target postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/spliit
+EnvironmentFile=/opt/spliit/.env
+ExecStart=/usr/bin/npm run start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now spliit
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/spliit.json
+++ b/json/spliit.json
@@ -1,0 +1,40 @@
+{
+  "name": "Spliit",
+  "slug": "spliit",
+  "categories": [
+    23
+  ],
+  "date_created": "2026-05-17",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 3000,
+  "documentation": "https://github.com/spliit-app/spliit#readme",
+  "website": "https://spliit.app/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/spliit.webp",
+  "description": "Spliit is a free and open-source alternative to Splitwise for sharing expenses with friends and groups, built with Next.js and PostgreSQL.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/spliit.sh",
+      "config_path": "/opt/spliit/.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Database credentials are written to /opt/spliit/.env. To configure a default currency, set NEXT_PUBLIC_DEFAULT_CURRENCY_CODE in /opt/spliit/.env and rebuild: cd /opt/spliit && npm run build && systemctl restart spliit",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New CT script for [Spliit](https://github.com/spliit-app/spliit), an open-source Splitwise alternative for sharing expenses (Next.js 16 + PostgreSQL + Prisma).
- Build flow mirrors the upstream Dockerfile.

Tested by deploying from a fork into a fresh CT on Proxmox VE 9.1.9 (Debian 13).

## Test plan
- [x] Fresh install on Debian 13 unprivileged LXC
- [x] Postgres 16 + Node 22 set up via `setup_postgresql` / `setup_nodejs` helpers
- [x] Prisma migrations applied
- [x] App reachable at `http://<IP>:3000`

Disclaimer: drafted with Claude Opus 4.7.