### PR TITLE
fix: correct garmin-grafana JSON type and script path

### DIFF
--- a/json/garmin-grafana.json
+++ b/json/garmin-grafana.json
@@ -5,25 +5,25 @@
     9
   ],
   "date_created": "2025-05-08",
-  "type": "addon",
+  "type": "ct",
   "updateable": true,
   "privileged": false,
   "interface_port": 3000,
   "documentation": "https://github.com/arpanghosh8453/garmin-grafana",
   "website": "https://github.com/arpanghosh8453/garmin-grafana",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/garmin-grafana.webp",
+  "config_path": "/opt/garmin-grafana/.env",
   "description": "A self-hosted solution to fetch data from Garmin servers and store it in a local InfluxDB database for visualization with Grafana.",
   "install_methods": [
     {
       "type": "default",
-      "script": "/tools/addon/garmin-grafana.sh",
-      "config_path": "/opt/garmin-grafana/.env",
+      "script": "ct/garmin-grafana.sh",
       "resources": {
-        "cpu": null,
-        "ram": null,
-        "hdd": null,
-        "os": null,
-        "version": null
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
       }
     }
   ],


### PR DESCRIPTION
## ✍️ Description

The `json/garmin-grafana.json` metadata file was created with `"type": "addon"` and `"script": "/tools/addon/garmin-grafana.sh"`, but the actual script has always lived at `ct/garmin-grafana.sh`. The website generates the installer URL from this JSON, so every user who copies the install command gets a 404.

**Changes to `json/garmin-grafana.json`:**
- `"type": "addon"` → `"type": "ct"`
- `"script": "/tools/addon/garmin-grafana.sh"` → `"script": "ct/garmin-grafana.sh"`
- Move `config_path` to top level (matches ct JSON convention, e.g. `shiori.json`)
- Fill in resource values from `ct/garmin-grafana.sh` (`cpu: 2`, `ram: 2048`, `hdd: 8`, `os: Debian`, `version: 13`)

## 🔗 Related Issues

Fixes the 404 reported by users trying to install garmin-grafana via the website one-liner.

## ✅ Prerequisites

- [x] Self-reviewed the changes
- [x] Tested: `curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/ct/garmin-grafana.sh` returns the script (HTTP 200)
- [x] No breaking changes
- [x] No hardcoded credentials

## 🛠️ Type of Change

- [x] Bug fix

## 🔍 Code & Security Review

- [x] Follows project coding guidelines
- [x] No hardcoded credentials or sensitive data

## 📦 Application Requirements

N/A — this is a metadata-only fix for an already-merged script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)