### PR TITLE
Refactor Namer installer flow for ProxmoxVED conventions

### DIFF
--- a/ct/namer.sh
+++ b/ct/namer.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nanja-at-web
+# Co-Author: OpenAI Codex
+# License: MIT
+# Source: https://github.com/Nanja-at-web/namer
+# Description: ProxmoxVED container wrapper for Namer with wizard-first NAS onboarding
+
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+APP="Namer"
+var_tags="media;metadata;python"
+var_cpu="2"
+var_ram="2048"
+var_disk="8"
+var_os="debian"
+var_version="12"
+var_unprivileged="1"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/namer ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if [[ ! -f /opt/namer_version.txt ]]; then
+    msg_error "No ${APP} version file found at /opt/namer_version.txt"
+    exit 1
+  fi
+
+  msg_info "Checking latest ${APP} release"
+  RELEASE=$(curl -fsSL https://pypi.org/pypi/namer/json | grep '"version"' | head -n1 | awk -F'"' '{print $4}')
+  if [[ -z "${RELEASE}" ]]; then
+    msg_error "Unable to determine latest ${APP} release from PyPI"
+    exit 1
+  fi
+
+  CURRENT=$(cat /opt/namer_version.txt)
+  if [[ "${RELEASE}" == "${CURRENT}" ]]; then
+    msg_ok "No update required. ${APP} is already at v${RELEASE}."
+    exit
+  fi
+
+  msg_info "Updating ${APP} from v${CURRENT} to v${RELEASE}"
+  if ! pct exec "$CTID" -- bash -lc 'export NAMER_PIP_SPEC="namer"; bash /opt/namer/namer-install.sh'; then
+    msg_error "Failed to update ${APP}"
+    exit 1
+  fi
+
+  msg_ok "Updated ${APP} to v${RELEASE}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Open the setup wizard using the container address on port 6980.${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:6980${CL}"

--- a/ct/namer.sh
+++ b/ct/namer.sh
@@ -6,7 +6,8 @@
 # Source: https://github.com/Nanja-at-web/namer
 # Description: ProxmoxVED container wrapper for Namer with wizard-first NAS onboarding
 
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+COMMUNITY_SCRIPTS_URL="${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}"
+source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL}/misc/build.func")
 
 APP="Namer"
 var_tags="media;metadata;python"

--- a/ct/namer.sh
+++ b/ct/namer.sh
@@ -38,9 +38,9 @@ function update_script() {
   fi
 
   msg_info "Checking latest ${APP} release"
-  RELEASE=$(curl -fsSL https://pypi.org/pypi/namer/json | grep '"version"' | head -n1 | awk -F'"' '{print $4}')
+  RELEASE=$(curl -fsSL https://api.github.com/repos/Nanja-at-web/namer/releases/latest | grep '"tag_name"' | head -n1 | awk -F'"' '{print $4}')
   if [[ -z "${RELEASE}" ]]; then
-    msg_error "Unable to determine latest ${APP} release from PyPI"
+    msg_error "Unable to determine latest ${APP} release from GitHub"
     exit 1
   fi
 
@@ -51,7 +51,7 @@ function update_script() {
   fi
 
   msg_info "Updating ${APP} from v${CURRENT} to v${RELEASE}"
-  if ! pct exec "$CTID" -- bash -lc 'export NAMER_PIP_SPEC="namer"; bash /opt/namer/namer-install.sh'; then
+  if ! pct exec "$CTID" -- bash -lc 'bash /opt/namer/namer-install.sh'; then
     msg_error "Failed to update ${APP}"
     exit 1
   fi

--- a/ct/namer.sh
+++ b/ct/namer.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: Nanja-at-web
 # Co-Author: OpenAI Codex
-# License: MIT
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://github.com/Nanja-at-web/namer
-# Description: ProxmoxVED container wrapper for Namer with wizard-first NAS onboarding
-
-COMMUNITY_SCRIPTS_URL="${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}"
-source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL}/misc/build.func")
 
 APP="Namer"
-var_tags="media;metadata;python"
-var_cpu="2"
-var_ram="2048"
-var_disk="8"
-var_os="debian"
-var_version="12"
-var_unprivileged="1"
+var_tags="${var_tags:-media;metadata;python}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
 variables
@@ -33,31 +30,36 @@ function update_script() {
     exit
   fi
 
-  if [[ ! -f /opt/namer_version.txt ]]; then
-    msg_error "No ${APP} version file found at /opt/namer_version.txt"
+  msg_info "Stopping Service"
+  systemctl stop namer-watchdog
+  msg_ok "Stopped Service"
+
+  msg_info "Backing up Configuration"
+  cp /etc/namer/namer.cfg /opt/namer.cfg.bak 2>/dev/null || true
+  msg_ok "Backed up Configuration"
+
+  msg_info "Reinstalling Test Branch"
+  if [[ ! -f /opt/community-scripts/install.func ]]; then
+    msg_error "No ProxmoxVED install helpers found at /opt/community-scripts/install.func"
     exit 1
   fi
-
-  msg_info "Checking latest ${APP} release"
-  RELEASE=$(curl -fsSL https://api.github.com/repos/Nanja-at-web/namer/releases/latest | grep '"tag_name"' | head -n1 | awk -F'"' '{print $4}')
-  if [[ -z "${RELEASE}" ]]; then
-    msg_error "Unable to determine latest ${APP} release from GitHub"
+  if ! env FUNCTIONS_FILE_PATH="$(cat /opt/community-scripts/install.func)" \
+    NAMER_PIP_SPEC="git+https://github.com/Nanja-at-web/namer.git@codex/proxmox-setup-wizard" \
+    bash -c "$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/namer-install.sh")"; then
+    msg_error "Failed to reinstall ${APP} from the test branch"
     exit 1
   fi
+  msg_ok "Reinstalled Test Branch"
 
-  CURRENT=$(cat /opt/namer_version.txt)
-  if [[ "${RELEASE}" == "${CURRENT}" ]]; then
-    msg_ok "No update required. ${APP} is already at v${RELEASE}."
-    exit
-  fi
+  msg_info "Restoring Configuration"
+  cp /opt/namer.cfg.bak /etc/namer/namer.cfg 2>/dev/null || true
+  rm -f /opt/namer.cfg.bak
+  msg_ok "Restored Configuration"
 
-  msg_info "Updating ${APP} from v${CURRENT} to v${RELEASE}"
-  if ! pct exec "$CTID" -- bash -lc 'bash /opt/namer/namer-install.sh'; then
-    msg_error "Failed to update ${APP}"
-    exit 1
-  fi
-
-  msg_ok "Updated ${APP} to v${RELEASE}"
+  msg_info "Starting Service"
+  systemctl start namer-watchdog
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
   exit
 }
 
@@ -65,7 +67,7 @@ start
 build_container
 description
 
-msg_ok "Completed successfully!\n"
+msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW} Open the setup wizard using the container address on port 6980.${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
 echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:6980${CL}"

--- a/install/namer-install.sh
+++ b/install/namer-install.sh
@@ -1,29 +1,12 @@
 #!/usr/bin/env bash
+
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: Nanja-at-web
 # Co-Author: OpenAI Codex
-# License: MIT
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://github.com/Nanja-at-web/namer
 
-set -euo pipefail
-
-if [[ -n "${FUNCTIONS_FILE_PATH:-}" ]]; then
-  source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
-else
-  STD=""
-  color() { :; }
-  verb_ip6() { :; }
-  catch_errors() { :; }
-  setting_up_container() { :; }
-  network_check() { :; }
-  update_os() { :; }
-  motd_ssh() { :; }
-  customize() { :; }
-  cleanup_lxc() { :; }
-  msg_info() { printf '==> %s\n' "$1"; }
-  msg_ok() { printf '==> %s\n' "$1"; }
-fi
-
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
 color
 verb_ip6
 catch_errors
@@ -31,100 +14,35 @@ setting_up_container
 network_check
 update_os
 
-APP_USER="namer"
-APP_GROUP="namer"
-APP_HOME="/var/lib/namer"
-APP_ETC="/etc/namer"
-APP_OPT="/opt/namer"
-APP_VENV="/opt/namer/venv"
-APP_VERSION_FILE="/opt/namer_version.txt"
-APP_CONFIG="/etc/namer/namer.cfg"
-APP_ENV_FILE="/etc/default/namer"
-APP_SERVICE="namer-watchdog.service"
-APP_INSTALLER_COPY="/opt/namer/namer-install.sh"
-NAS_MOUNT="/mnt/nas"
-APP_WATCH="${APP_HOME}/watch"
-APP_WORK="${APP_HOME}/work"
-APP_FAILED="${APP_HOME}/failed"
-APP_DEST="${APP_HOME}/dest"
-APP_DATABASE="${APP_HOME}/database"
 APP_PIP_SPEC="${NAMER_PIP_SPEC:-git+https://github.com/Nanja-at-web/namer.git@codex/proxmox-setup-wizard}"
 
-log() {
-  printf '[namer-install] %s\n' "$*"
-}
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  ffmpeg \
+  git \
+  nfs-common
+msg_ok "Installed Dependencies"
 
-require_root() {
-  if [[ "${EUID}" -ne 0 ]]; then
-    log "Run this installer as root inside a Debian-based Proxmox LXC."
-    exit 1
-  fi
-}
+UV_PYTHON="3.11" setup_uv
 
-install_packages() {
-  msg_info "Installing Dependencies"
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get update
-  apt-get install -y \
-    curl \
-    ffmpeg \
-    git \
-    nfs-common \
-    python3-pip \
-    python3 \
-    python3-venv
-  msg_ok "Installed Dependencies"
-}
+msg_info "Setting up Application"
+install -d -m 755 \
+  /opt/namer \
+  /etc/namer \
+  /mnt/nas \
+  /var/lib/namer/watch \
+  /var/lib/namer/work \
+  /var/lib/namer/failed \
+  /var/lib/namer/dest \
+  /var/lib/namer/database
+cd /opt/namer
+$STD uv venv --clear --python 3.11 /opt/namer/.venv
+$STD uv pip install --python /opt/namer/.venv/bin/python --upgrade "${APP_PIP_SPEC}"
+msg_ok "Set up Application"
 
-create_layout() {
-  getent group "${APP_GROUP}" >/dev/null 2>&1 || groupadd --system "${APP_GROUP}"
-
-  if ! id -u "${APP_USER}" >/dev/null 2>&1; then
-    useradd \
-      --system \
-      --gid "${APP_GROUP}" \
-      --home "${APP_HOME}" \
-      --create-home \
-      --shell /usr/sbin/nologin \
-      "${APP_USER}"
-  fi
-
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_HOME}"
-  install -d -o root -g root "${APP_ETC}"
-  install -d -o root -g root "${APP_OPT}"
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_WATCH}"
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_WORK}"
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_FAILED}"
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_DEST}"
-  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_DATABASE}"
-  install -d -o root -g root "${NAS_MOUNT}"
-}
-
-install_namer() {
-  msg_info "Installing Namer"
-  python3 -m venv "${APP_VENV}"
-  "${APP_VENV}/bin/pip" install --upgrade pip
-  if [[ "${APP_PIP_SPEC}" == "namer" ]]; then
-    python3 -m pip install --upgrade "${APP_PIP_SPEC}"
-    "${APP_VENV}/bin/pip" install --upgrade "${APP_PIP_SPEC}"
-  else
-    "${APP_VENV}/bin/pip" install --upgrade "${APP_PIP_SPEC}"
-  fi
-  "${APP_VENV}/bin/python" - <<'PY' >"${APP_VERSION_FILE}"
-import importlib.metadata
-
-print(importlib.metadata.version("namer"))
-PY
-  msg_ok "Installed Namer"
-}
-
-write_default_config() {
-  if [[ -f "${APP_CONFIG}" ]]; then
-    log "Config already exists at ${APP_CONFIG}; leaving it in place."
-    return
-  fi
-
-  "${APP_VENV}/bin/python" - <<'PY'
+if [[ ! -f /etc/namer/namer.cfg ]]; then
+  msg_info "Creating Bootstrap Config"
+  /opt/namer/.venv/bin/python - <<'PY'
 from configupdater import ConfigUpdater
 from importlib import resources
 from pathlib import Path
@@ -153,27 +71,22 @@ updater["watchdog"]["web"].value = "True"
 
 config_path.write_text(str(updater), encoding="utf-8")
 PY
+  chmod 0640 /etc/namer/namer.cfg
+  msg_ok "Created Bootstrap Config"
+fi
 
-  chown "${APP_USER}:${APP_GROUP}" "${APP_CONFIG}"
-  chmod 0640 "${APP_CONFIG}"
-  msg_ok "Created bootstrap config"
-}
-
-write_environment_file() {
-  cat >"${APP_ENV_FILE}" <<EOF
-NAMER_CONFIG=${APP_CONFIG}
+msg_info "Creating Environment File"
+cat <<EOF >/etc/default/namer
+NAMER_CONFIG=/etc/namer/namer.cfg
 EOF
-}
+msg_ok "Created Environment File"
 
-persist_installer_copy() {
-  if [[ -f "${BASH_SOURCE[0]}" ]]; then
-    install -D -m 0755 "${BASH_SOURCE[0]}" "${APP_INSTALLER_COPY}"
-  fi
-}
-
-write_service() {
-  msg_info "Creating Service"
-  cat >"/etc/systemd/system/${APP_SERVICE}" <<EOF
+msg_info "Creating Service"
+SERVICE_EXISTS="no"
+if [[ -f /etc/systemd/system/namer-watchdog.service ]]; then
+  SERVICE_EXISTS="yes"
+fi
+cat <<EOF >/etc/systemd/system/namer-watchdog.service
 [Unit]
 Description=Namer watchdog
 After=network-online.target remote-fs.target
@@ -181,54 +94,22 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=${APP_USER}
-Group=${APP_GROUP}
-EnvironmentFile=${APP_ENV_FILE}
-ExecStart=${APP_VENV}/bin/python -m namer watchdog
+User=root
+WorkingDirectory=/opt/namer
+EnvironmentFile=/etc/default/namer
+ExecStart=/opt/namer/.venv/bin/python -m namer watchdog
 Restart=on-failure
 RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
 EOF
-  msg_ok "Created Service"
-}
-
-print_next_steps() {
-  cat <<EOF
-
-Namer installation completed.
-
-Package source:
-  ${APP_PIP_SPEC}
-
-Next steps:
-  1. Start the service: systemctl enable --now ${APP_SERVICE}
-  2. Open the web UI on port 6980 inside your LXC network.
-  3. Finish the setup wizard with:
-     - TPDB API token
-     - NFS host/share
-     - watch/work/failed/dest paths
-  4. The service starts with local bootstrap directories so the wizard is reachable immediately.
-  5. Persist the NAS mount and switch watch/dest paths after validating your final NFS settings.
-
-EOF
-}
-
-main() {
-  require_root
-  install_packages
-  create_layout
-  install_namer
-  write_default_config
-  write_environment_file
-  write_service
-  persist_installer_copy
+if [[ "${SERVICE_EXISTS}" == "yes" ]]; then
   systemctl daemon-reload
-  motd_ssh
-  customize
-  cleanup_lxc
-  print_next_steps
-}
+fi
+systemctl enable -q --now namer-watchdog
+msg_ok "Created Service"
 
-main "$@"
+motd_ssh
+customize
+cleanup_lxc

--- a/install/namer-install.sh
+++ b/install/namer-install.sh
@@ -67,6 +67,7 @@ install_packages() {
   apt-get install -y \
     curl \
     ffmpeg \
+    git \
     nfs-common \
     python3-pip \
     python3 \

--- a/install/namer-install.sh
+++ b/install/namer-install.sh
@@ -47,7 +47,7 @@ APP_WATCH="${APP_HOME}/watch"
 APP_WORK="${APP_HOME}/work"
 APP_FAILED="${APP_HOME}/failed"
 APP_DEST="${APP_HOME}/dest"
-APP_PIP_SPEC="${NAMER_PIP_SPEC:-namer}"
+APP_PIP_SPEC="${NAMER_PIP_SPEC:-git+https://github.com/Nanja-at-web/namer.git@codex/proxmox-setup-wizard}"
 
 log() {
   printf '[namer-install] %s\n' "$*"
@@ -105,7 +105,7 @@ install_namer() {
     python3 -m pip install --upgrade "${APP_PIP_SPEC}"
     "${APP_VENV}/bin/pip" install --upgrade "${APP_PIP_SPEC}"
   else
-    "${APP_VENV}/bin/pip" install "${APP_PIP_SPEC}"
+    "${APP_VENV}/bin/pip" install --upgrade "${APP_PIP_SPEC}"
   fi
   "${APP_VENV}/bin/python" - <<'PY' >"${APP_VERSION_FILE}"
 import importlib.metadata

--- a/install/namer-install.sh
+++ b/install/namer-install.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nanja-at-web
+# Co-Author: OpenAI Codex
+# License: MIT
+# Source: https://github.com/Nanja-at-web/namer
+
+set -euo pipefail
+
+if [[ -n "${FUNCTIONS_FILE_PATH:-}" ]]; then
+  source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+else
+  STD=""
+  color() { :; }
+  verb_ip6() { :; }
+  catch_errors() { :; }
+  setting_up_container() { :; }
+  network_check() { :; }
+  update_os() { :; }
+  motd_ssh() { :; }
+  customize() { :; }
+  cleanup_lxc() { :; }
+  msg_info() { printf '==> %s\n' "$1"; }
+  msg_ok() { printf '==> %s\n' "$1"; }
+fi
+
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+APP_USER="namer"
+APP_GROUP="namer"
+APP_HOME="/var/lib/namer"
+APP_ETC="/etc/namer"
+APP_OPT="/opt/namer"
+APP_VENV="/opt/namer/venv"
+APP_VERSION_FILE="/opt/namer_version.txt"
+APP_CONFIG="/etc/namer/namer.cfg"
+APP_ENV_FILE="/etc/default/namer"
+APP_SERVICE="namer-watchdog.service"
+APP_INSTALLER_COPY="/opt/namer/namer-install.sh"
+NAS_MOUNT="/mnt/nas"
+APP_WATCH="${APP_HOME}/watch"
+APP_WORK="${APP_HOME}/work"
+APP_FAILED="${APP_HOME}/failed"
+APP_DEST="${APP_HOME}/dest"
+APP_PIP_SPEC="${NAMER_PIP_SPEC:-namer}"
+
+log() {
+  printf '[namer-install] %s\n' "$*"
+}
+
+require_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    log "Run this installer as root inside a Debian-based Proxmox LXC."
+    exit 1
+  fi
+}
+
+install_packages() {
+  msg_info "Installing Dependencies"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y \
+    curl \
+    ffmpeg \
+    nfs-common \
+    python3-pip \
+    python3 \
+    python3-venv
+  msg_ok "Installed Dependencies"
+}
+
+create_layout() {
+  getent group "${APP_GROUP}" >/dev/null 2>&1 || groupadd --system "${APP_GROUP}"
+
+  if ! id -u "${APP_USER}" >/dev/null 2>&1; then
+    useradd \
+      --system \
+      --gid "${APP_GROUP}" \
+      --home "${APP_HOME}" \
+      --create-home \
+      --shell /usr/sbin/nologin \
+      "${APP_USER}"
+  fi
+
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_HOME}"
+  install -d -o root -g root "${APP_ETC}"
+  install -d -o root -g root "${APP_OPT}"
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_WATCH}"
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_WORK}"
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_FAILED}"
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_DEST}"
+  install -d -o root -g root "${NAS_MOUNT}"
+}
+
+install_namer() {
+  msg_info "Installing Namer"
+  python3 -m venv "${APP_VENV}"
+  "${APP_VENV}/bin/pip" install --upgrade pip
+  if [[ "${APP_PIP_SPEC}" == "namer" ]]; then
+    python3 -m pip install --upgrade "${APP_PIP_SPEC}"
+    "${APP_VENV}/bin/pip" install --upgrade "${APP_PIP_SPEC}"
+  else
+    "${APP_VENV}/bin/pip" install "${APP_PIP_SPEC}"
+  fi
+  "${APP_VENV}/bin/python" - <<'PY' >"${APP_VERSION_FILE}"
+import importlib.metadata
+
+print(importlib.metadata.version("namer"))
+PY
+  msg_ok "Installed Namer"
+}
+
+write_default_config() {
+  if [[ -f "${APP_CONFIG}" ]]; then
+    log "Config already exists at ${APP_CONFIG}; leaving it in place."
+    return
+  fi
+
+  "${APP_VENV}/bin/python" - <<'PY'
+from configupdater import ConfigUpdater
+from importlib import resources
+from pathlib import Path
+
+config_path = Path("/etc/namer/namer.cfg")
+config_text = resources.files("namer").joinpath("namer.cfg.default").read_text(encoding="utf-8")
+updater = ConfigUpdater(allow_no_value=True)
+updater.read_string(config_text)
+
+updater["namer"]["porndb_token"].value = ""
+
+updater["setup"]["is_setup_complete"].value = "False"
+updater["setup"]["setup_mode"].value = "wizard"
+updater["setup"]["storage_mode"].value = "nfs"
+updater["setup"]["nas_host"].value = ""
+updater["setup"]["nas_share"].value = ""
+updater["setup"]["nas_mount_path"].value = "/mnt/nas"
+updater["setup"]["nas_mount_options"].value = "defaults,_netdev"
+
+updater["watchdog"]["watch_dir"].value = "/var/lib/namer/watch"
+updater["watchdog"]["work_dir"].value = "/var/lib/namer/work"
+updater["watchdog"]["failed_dir"].value = "/var/lib/namer/failed"
+updater["watchdog"]["dest_dir"].value = "/var/lib/namer/dest"
+updater["watchdog"]["web"].value = "True"
+
+config_path.write_text(str(updater), encoding="utf-8")
+PY
+
+  chown "${APP_USER}:${APP_GROUP}" "${APP_CONFIG}"
+  chmod 0640 "${APP_CONFIG}"
+  msg_ok "Created bootstrap config"
+}
+
+write_environment_file() {
+  cat >"${APP_ENV_FILE}" <<EOF
+NAMER_CONFIG=${APP_CONFIG}
+EOF
+}
+
+persist_installer_copy() {
+  if [[ -f "${BASH_SOURCE[0]}" ]]; then
+    install -D -m 0755 "${BASH_SOURCE[0]}" "${APP_INSTALLER_COPY}"
+  fi
+}
+
+write_service() {
+  msg_info "Creating Service"
+  cat >"/etc/systemd/system/${APP_SERVICE}" <<EOF
+[Unit]
+Description=Namer watchdog
+After=network-online.target remote-fs.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${APP_USER}
+Group=${APP_GROUP}
+EnvironmentFile=${APP_ENV_FILE}
+ExecStart=${APP_VENV}/bin/python -m namer watchdog
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  msg_ok "Created Service"
+}
+
+print_next_steps() {
+  cat <<EOF
+
+Namer installation completed.
+
+Package source:
+  ${APP_PIP_SPEC}
+
+Next steps:
+  1. Start the service: systemctl enable --now ${APP_SERVICE}
+  2. Open the web UI on port 6980 inside your LXC network.
+  3. Finish the setup wizard with:
+     - TPDB API token
+     - NFS host/share
+     - watch/work/failed/dest paths
+  4. The service starts with local bootstrap directories so the wizard is reachable immediately.
+  5. Persist the NAS mount and switch watch/dest paths after validating your final NFS settings.
+
+EOF
+}
+
+main() {
+  require_root
+  install_packages
+  create_layout
+  install_namer
+  write_default_config
+  write_environment_file
+  write_service
+  persist_installer_copy
+  systemctl daemon-reload
+  motd_ssh
+  customize
+  cleanup_lxc
+  print_next_steps
+}
+
+main "$@"

--- a/install/namer-install.sh
+++ b/install/namer-install.sh
@@ -47,6 +47,7 @@ APP_WATCH="${APP_HOME}/watch"
 APP_WORK="${APP_HOME}/work"
 APP_FAILED="${APP_HOME}/failed"
 APP_DEST="${APP_HOME}/dest"
+APP_DATABASE="${APP_HOME}/database"
 APP_PIP_SPEC="${NAMER_PIP_SPEC:-git+https://github.com/Nanja-at-web/namer.git@codex/proxmox-setup-wizard}"
 
 log() {
@@ -95,6 +96,7 @@ create_layout() {
   install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_WORK}"
   install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_FAILED}"
   install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_DEST}"
+  install -d -o "${APP_USER}" -g "${APP_GROUP}" "${APP_DATABASE}"
   install -d -o root -g root "${NAS_MOUNT}"
 }
 
@@ -133,6 +135,7 @@ updater = ConfigUpdater(allow_no_value=True)
 updater.read_string(config_text)
 
 updater["namer"]["porndb_token"].value = ""
+updater["namer"]["database_path"].value = "/var/lib/namer/database"
 
 updater["setup"]["is_setup_complete"].value = "False"
 updater["setup"]["setup_mode"].value = "wizard"

--- a/json/namer.json
+++ b/json/namer.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "Debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/json/namer.json
+++ b/json/namer.json
@@ -1,0 +1,48 @@
+{
+  "name": "Namer",
+  "slug": "namer",
+  "categories": [
+    13
+  ],
+  "date_created": "2026-05-20",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 6980,
+  "documentation": "https://github.com/Nanja-at-web/namer",
+  "website": "https://github.com/Nanja-at-web/namer",
+  "logo": "https://raw.githubusercontent.com/Nanja-at-web/namer/main/logo/namer.png",
+  "description": "Namer is a web app, watchdog service, and command-line tool for renaming and tagging adult video files using ThePornDB metadata, with a wizard-first setup flow for NAS-backed Proxmox LXC deployments.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/namer.sh",
+      "config_path": "/etc/namer/namer.cfg",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "12"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The first login flow is completed through the web setup wizard on port 6980.",
+      "type": "info"
+    },
+    {
+      "text": "This setup is designed for NAS-backed media paths, with NFS as the preferred storage mode.",
+      "type": "info"
+    },
+    {
+      "text": "Have your ThePornDB API token and NAS share details ready before starting the wizard.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- refactor `ct/namer.sh` to standard ProxmoxVED structure and Debian 13 defaults
- replace the custom installer/update plumbing in `install/namer-install.sh` with the normal bootstrap and `setup_uv` flow
- keep the temporary `codex/proxmox-setup-wizard` install source intentionally for transition testing

## Notes
- this is a transition PR, not the final release-based integration
- the update path now reuses `COMMUNITY_SCRIPTS_URL` so branch-based testing stays coherent during review
- config bootstrap permissions are tightened to avoid making the TPDB token world-readable

## Verification
- `C:\Program Files\Git\bin\bash.exe -n ct/namer.sh`
- `C:\Program Files\Git\bin\bash.exe -n install/namer-install.sh`
- `git diff --check`
