### PR TITLE
Add OBS Studio LXC script

### DIFF
--- a/ct/obs-studio.sh
+++ b/ct/obs-studio.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: community-scripts ORG
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://obsproject.com/
+
+APP="OBS-Studio"
+var_tags="${var_tags:-media;streaming}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-10}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-0}"
+var_gpu="${var_gpu:-yes}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if ! command -v obs &>/dev/null; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating Debian packages"
+  $STD apt update
+  $STD apt upgrade -y
+  msg_ok "Updated Debian packages"
+
+  msg_info "Checking OBS Studio version"
+  obs_version=$(dpkg-query -W -f='${Version}' obs-studio 2>/dev/null || echo "unknown")
+  msg_ok "OBS Studio: ${obs_version}"
+
+  msg_ok "OBS Studio is managed via Debian apt repository."
+  msg_info "Updates are included in 'apt upgrade' above."
+  exit
+}
+
+start
+build_container
+description
+
+# USB video capture device passthrough (not handled by framework GPU logic)
+if [[ -e /dev/video0 ]]; then
+  msg_info "Configuring capture device passthrough"
+  LXC_CONF="/etc/pve/lxc/${CTID}.conf"
+  cat <<EOF >>"$LXC_CONF"
+# USB video capture device passthrough
+lxc.cgroup2.devices.allow: c 81:* rwm
+lxc.mount.entry: /dev/video0 dev/video0 none bind,optional,create=file 0 0
+EOF
+  msg_ok "Capture device /dev/video0 configured"
+else
+  msg_warn "/dev/video0 not found on host — no capture card detected"
+fi
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} VNC Connection:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}vnc://<IP>:5901${CL}"
+echo -e "${INFO}${YW} VNC Password: ${GN}obsstudio${CL} (change with: x11vnc -storepasswd)"
+echo -e "${INFO}${YW} Capture Device: ${GN}/dev/video0${CL}"
+echo -e "${INFO}${YW} GPU Device: ${GN}/dev/dri${CL}"
+echo -e "${INFO}${YW} QuickSync: Run ${GN}vainfo${YW} inside container to verify${CL}"
+echo -e "${INFO}${YW} If vainfo shows VAEntrypointEncSlice, select 'QuickSync H.264' in OBS${CL}"

--- a/install/obs-studio-install.sh
+++ b/install/obs-studio-install.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: community-scripts ORG
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://obsproject.com/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# Hardware acceleration (Intel VA-API for Haswell via i965-va-driver)
+setup_hwaccel
+
+# Install OBS Studio and desktop environment
+msg_info "Installing OBS Studio and Desktop Environment"
+$STD apt install -y \
+  obs-studio \
+  xvfb \
+  openbox \
+  x11vnc \
+  lxterminal \
+  dbus \
+  pulseaudio \
+  fonts-dejavu-core
+msg_ok "Installed OBS Studio and Desktop Environment"
+
+# Set up VNC password for root
+msg_info "Configuring VNC password"
+mkdir -p /root/.vnc
+echo "obsstudio" | x11vnc -storepasswd /root/.vnc/passwd >/dev/null 2>&1
+msg_ok "VNC password set (default: obsstudio)"
+
+# Create startup script
+msg_info "Creating startup script"
+cat <<'EOF' >/usr/local/bin/obs-desktop.sh
+#!/bin/bash
+# OBS Studio desktop environment startup
+export DISPLAY=:1
+Xvfb :1 -screen 0 1920x1080x24 +extension GLX &
+sleep 2
+openbox &
+sleep 1
+x11vnc -display :1 -rfbauth /root/.vnc/passwd -forever -shared -rfbport 5901
+EOF
+chmod +x /usr/local/bin/obs-desktop.sh
+msg_ok "Created startup script"
+
+# Create systemd service
+msg_info "Creating systemd service"
+cat <<'EOF' >/etc/systemd/system/obs-desktop.service
+[Unit]
+Description=OBS Studio Desktop (Xvfb + Openbox + x11vnc)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/obs-desktop.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable -q obs-desktop.service
+msg_ok "Created systemd service"
+
+# Verify VAAPI tools installed
+msg_info "Verifying VAAPI tools"
+if command -v vainfo &>/dev/null; then
+  msg_ok "vainfo installed — run manually after container restart to verify QuickSync"
+else
+  msg_warn "vainfo not found — hardware acceleration may not be configured"
+fi
+
+if command -v v4l2-ctl &>/dev/null; then
+  msg_ok "v4l2-ctl installed for capture device diagnostics"
+fi
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/obs-studio.json
+++ b/json/obs-studio.json
@@ -1,0 +1,57 @@
+{
+  "name": "OBS Studio",
+  "slug": "obs-studio",
+  "categories": [
+    13
+  ],
+  "date_created": "2026-06-02",
+  "type": "ct",
+  "updateable": true,
+  "privileged": true,
+  "has_arm": false,
+  "interface_port": 5901,
+  "documentation": "https://obsproject.com/help",
+  "website": "https://obsproject.com/",
+  "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d3/OBS_Studio_Logo.svg/120px-OBS_Studio_Logo.svg.png",
+  "description": "OBS Studio is free and open source software for video recording and live streaming. This LXC provides a lightweight VNC-accessible desktop environment with hardware encoding support (Intel QuickSync/VAAPI) for capturing USB video devices.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/obs-studio.sh",
+      "config_path": "",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 10,
+        "os": "debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": "obsstudio"
+  },
+  "notes": [
+    {
+      "text": "Connect via VNC to port 5901. Default password: obsstudio (change with: x11vnc -storepasswd)",
+      "type": "info"
+    },
+    {
+      "text": "Run 'vainfo' inside the container to verify Intel QuickSync/VAAPI availability after restart.",
+      "type": "info"
+    },
+    {
+      "text": "If vainfo shows VAEntrypointEncSlice, select 'QuickSync H.264' as encoder in OBS Settings → Output.",
+      "type": "info"
+    },
+    {
+      "text": "For Haswell (4th gen Intel) and older: uses i965-va-driver (legacy). For Broadwell (5th gen) and newer: uses intel-media-va-driver. The framework auto-detects your GPU generation.",
+      "type": "info"
+    },
+    {
+      "text": "USB capture card (/dev/video0) and GPU (/dev/dri) are passed through from the Proxmox host. Ensure the capture card is connected before starting the container.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds an OBS Studio LXC container script for video recording and live streaming with hardware encoding support.

## Technical Details

- **Base OS**: Debian 13 (Trixie)
- **Container Type**: Privileged (required for GPU and capture device passthrough)
- **Resources**: 2 CPU, 2GB RAM, 10GB disk
- **Desktop**: Xvfb + Openbox + x11vnc (port 5901)
- **GPU**: Intel QuickSync/VAAPI via framework `setup_hwaccel` (auto-detects i965-va-driver for Haswell, intel-media-va-driver for Broadwell+)
- **Audio**: PulseAudio (virtual audio for OBS)
- **Capture**: USB video capture card (/dev/video0) passthrough

## Files

| File | Purpose |
|------|---------|
| `ct/obs-studio.sh` | CT creation, GPU passthrough, `/dev/video0` passthrough |
| `install/obs-studio-install.sh` | Package install, systemd service, VNC setup |
| `json/obs-studio.json` | Website metadata |

## Use Case

Connect a USB 3.0 UVC capture card (game console, camera) to a Proxmox host, run OBS in an LXC container with hardware-accelerated encoding (QuickSync), and control it via VNC or obs-websocket.

## Testing

- [x] Shell syntax check (`bash -n`) passed
- [x] JSON validation passed
- [x] Follows community-scripts conventions (alpine-cinny, bitfocus-companion patterns)
- [x] Uses framework GPU setup (`setup_hwaccel`) instead of manual driver installation