### PR TITLE
fix(blinko): copy vditor editor assets to public dir

### DIFF
--- a/ct/blinko.sh
+++ b/ct/blinko.sh
@@ -50,6 +50,8 @@ function update_script() {
     cd /opt/blinko
     $STD bun install
     $STD bun run build:web
+    mkdir -p /opt/blinko/dist/public/dist
+    cp -r /opt/blinko/node_modules/vditor/dist/{js,css,images} /opt/blinko/dist/public/dist/
     $STD bun run build:seed
     $STD bun run prisma:generate
     $STD bun run prisma:migrate:deploy

--- a/install/blinko-install.sh
+++ b/install/blinko-install.sh
@@ -46,6 +46,8 @@ NEXT_PUBLIC_BASE_URL=http://${LOCAL_IP}:1111
 EOF
 $STD bun install
 $STD bun run build:web
+mkdir -p /opt/blinko/dist/public/dist
+cp -r /opt/blinko/node_modules/vditor/dist/{js,css,images} /opt/blinko/dist/public/dist/
 $STD bun run build:seed
 $STD bun run prisma:generate
 $STD bun run prisma:migrate:deploy


### PR DESCRIPTION
## Summary

The Blinko editor (text input UI) is completely missing after install/update because the Vditor editor's runtime assets are not served locally.

## Problem

Blinko's frontend passes `cdn:""` to the Vditor markdown editor, which makes all asset requests relative to the domain root:
- `/dist/js/lute/lute.min.js`
- `/dist/js/highlight.js/styles/github-dark.min.css`
- `/dist/css/content-theme/*`
- etc.

In Blinko's Docker image, these files are baked into the container at the correct path. However, in the baremetal LXC install, `node_modules/vditor/dist/` is never copied to the public directory that Express serves. This results in 404s for all Vditor runtime assets and a **completely non-functional editor** — users cannot create notes or todos.

## Fix

Copy `node_modules/vditor/dist/{js,css,images}` into `dist/public/dist/` after `bun run build:web`. This places the files exactly where the browser expects them.

Applied to both:
- `install/blinko-install.sh` (fresh installs)
- `ct/blinko.sh` (updates)

## Testing

Verified on a running Blinko 1.8.7 LXC — editor renders correctly after applying this fix.