### PR TITLE
feat: add Project Nomad container and install scripts

### DIFF
--- a/ct/nomad.sh
+++ b/ct/nomad.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Alex Indigo (alexindigo)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Crosstalk-Solutions/project-nomad | https://www.projectnomad.us
+
+APP="Nomad"
+var_tags="${var_tags:-offline;knowledge;education;ai}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-16}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_gpu="${var_gpu:-yes}"
+var_nesting="${var_nesting:-1}"
+var_keyctl="${var_keyctl:-1}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/project-nomad ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "nomad" "Crosstalk-Solutions/project-nomad"; then
+    msg_info "Updating ${APP}"
+    cd /opt/project-nomad
+
+    # Extract config from current compose before tarball overwrites it
+    APP_KEY=$(grep 'APP_KEY=' /opt/project-nomad/compose.yml | head -1 | sed 's/.*APP_KEY=//')
+    DB_PASS=$(grep 'DB_PASSWORD=' /opt/project-nomad/compose.yml | head -1 | sed 's/.*DB_PASSWORD=//')
+    DB_ROOT_PASS=$(grep 'MYSQL_ROOT_PASSWORD=' /opt/project-nomad/compose.yml | head -1 | sed 's/.*MYSQL_ROOT_PASSWORD=//')
+    DB_USER_PASS=$(grep 'MYSQL_PASSWORD=' /opt/project-nomad/compose.yml | head -1 | sed 's/.*MYSQL_PASSWORD=//')
+    NOMAD_URL=$(grep 'URL=' /opt/project-nomad/compose.yml | head -1 | sed 's/.*URL=//')
+
+    fetch_and_deploy_gh_release "nomad" "Crosstalk-Solutions/project-nomad" "tarball"
+
+    # Refresh non-user files from tarball
+    cp /opt/nomad/install/management_compose.yaml /opt/project-nomad/compose.yml
+    cp /opt/nomad/install/start_nomad.sh /opt/project-nomad/start_nomad.sh 2>/dev/null || true
+    cp /opt/nomad/install/stop_nomad.sh /opt/project-nomad/stop_nomad.sh 2>/dev/null || true
+    cp /opt/nomad/install/update_nomad.sh /opt/project-nomad/update_nomad.sh 2>/dev/null || true
+    chmod +x /opt/project-nomad/*.sh 2>/dev/null || true
+
+    # Re-apply saved config
+    sed -i "s|URL=replaceme|URL=${NOMAD_URL}|g" /opt/project-nomad/compose.yml
+    [[ -n "$APP_KEY" ]] && sed -i "s|APP_KEY=replaceme|APP_KEY=${APP_KEY}|g" /opt/project-nomad/compose.yml
+    [[ -n "$DB_PASS" ]] && sed -i "s|DB_PASSWORD=replaceme|DB_PASSWORD=${DB_PASS}|g" /opt/project-nomad/compose.yml
+    [[ -n "$DB_ROOT_PASS" ]] && sed -i "s|MYSQL_ROOT_PASSWORD=replaceme|MYSQL_ROOT_PASSWORD=${DB_ROOT_PASS}|g" /opt/project-nomad/compose.yml
+    [[ -n "$DB_USER_PASS" ]] && sed -i "s|MYSQL_PASSWORD=replaceme|MYSQL_PASSWORD=${DB_USER_PASS}|g" /opt/project-nomad/compose.yml
+    sed -i 's|"8080:8080"|"80:8080"|g' /opt/project-nomad/compose.yml
+
+    $STD docker compose pull
+    $STD docker compose up -d --force-recreate
+    msg_ok "Updated Successfully"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"

--- a/install/nomad-install.sh
+++ b/install/nomad-install.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Alex Indigo (alexindigo)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Crosstalk-Solutions/project-nomad | https://www.projectnomad.us
+
+# This script is adapted from Project N.O.M.A.D.'s install_nomad.sh
+# to work within the ProxmoxVED infrastructure. Differences:
+#  - Uses setup_docker() instead of get.docker.com
+#  - Uses local tarball files instead of raw.githubusercontent.com URLs
+#  - Port 80 instead of 8080
+#  - setup_hwaccel for GPU driver installation
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+NOMAD_DIR="/opt/project-nomad"
+
+# Accept license (interactive - legal requirement)
+echo ""
+echo "License Agreement & Terms of Use"
+echo "__________________________"
+echo ""
+echo "Project N.O.M.A.D. is licensed under the Apache License 2.0."
+echo "Full license: https://www.apache.org/licenses/LICENSE-2.0"
+echo ""
+read -p "I have read and accept License Agreement & Terms of Use (y/N)? " choice
+case "$choice" in
+  y|Y )
+    echo "License accepted."
+    ;;
+  * )
+    msg_error "License not accepted. Installation cannot continue."
+    exit 1
+    ;;
+esac
+
+# Install Docker
+USE_DOCKER_REPO=true setup_docker
+
+# Install GPU drivers inside LXC (Intel/AMD/NVIDIA)
+setup_hwaccel
+
+# Setup NVIDIA container toolkit (Docker-level GPU support)
+setup_nvidia_container_toolkit() {
+  if ! command -v nvidia-smi &>/dev/null && ! lspci 2>/dev/null | grep -qi nvidia; then
+    return 0
+  fi
+  if command -v nvidia-ctk &>/dev/null; then
+    return 0
+  fi
+  msg_info "Installing NVIDIA Container Toolkit"
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>/dev/null || true
+  curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list 2>/dev/null \
+    | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+    | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null 2>&1 || true
+  $STD apt update 2>/dev/null || true
+  $STD apt install -y nvidia-container-toolkit 2>/dev/null || true
+  if command -v nvidia-ctk &>/dev/null; then
+    nvidia-ctk runtime configure --runtime=docker 2>/dev/null || true
+    systemctl restart docker 2>/dev/null || true
+  fi
+  msg_ok "NVIDIA Container Toolkit configured"
+}
+setup_nvidia_container_toolkit
+
+# Download release tarball for version tracking and local files
+fetch_and_deploy_gh_release "nomad" "Crosstalk-Solutions/project-nomad" "tarball"
+
+msg_info "Setting up Nomad"
+mkdir -p ${NOMAD_DIR}/storage/logs
+cp /opt/nomad/install/management_compose.yaml ${NOMAD_DIR}/compose.yml
+cp /opt/nomad/install/start_nomad.sh ${NOMAD_DIR}/start_nomad.sh
+cp /opt/nomad/install/stop_nomad.sh ${NOMAD_DIR}/stop_nomad.sh
+cp /opt/nomad/install/update_nomad.sh ${NOMAD_DIR}/update_nomad.sh
+chmod +x ${NOMAD_DIR}/*.sh
+
+# Configure compose file
+APP_KEY=$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9' | head -c32)
+DB_ROOT_PASSWORD=$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9' | head -c13)
+DB_USER_PASSWORD=$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9' | head -c13)
+
+sed -i "s|URL=replaceme|URL=http://${LOCAL_IP}|g" ${NOMAD_DIR}/compose.yml
+sed -i "s|APP_KEY=replaceme|APP_KEY=${APP_KEY}|g" ${NOMAD_DIR}/compose.yml
+sed -i "s|DB_PASSWORD=replaceme|DB_PASSWORD=${DB_USER_PASSWORD}|g" ${NOMAD_DIR}/compose.yml
+sed -i "s|MYSQL_ROOT_PASSWORD=replaceme|MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}|g" ${NOMAD_DIR}/compose.yml
+sed -i "s|MYSQL_PASSWORD=replaceme|MYSQL_PASSWORD=${DB_USER_PASSWORD}|g" ${NOMAD_DIR}/compose.yml
+sed -i 's|"8080:8080"|"80:8080"|g' ${NOMAD_DIR}/compose.yml
+msg_ok "Set up Nomad"
+
+msg_info "Starting Nomad"
+cd ${NOMAD_DIR}
+$STD docker compose up -d
+msg_ok "Started Nomad"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/nomad.json
+++ b/json/nomad.json
@@ -1,0 +1,57 @@
+{
+  "name": "Nomad",
+  "slug": "nomad",
+  "categories": [
+    10
+  ],
+  "date_created": "2026-06-07",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 80,
+  "documentation": "https://www.projectnomad.us/install",
+  "website": "https://www.projectnomad.us",
+  "logo": "https://raw.githubusercontent.com/Crosstalk-Solutions/project-nomad/main/admin/public/project_nomad_logo.webp",
+  "description": "Project N.O.M.A.D. is a self-contained, offline-first knowledge and education server with AI chat, Wikipedia, Khan Academy courses, maps, and more. No internet required after setup.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/nomad.sh",
+      "config_path": "/opt/nomad/compose.yml",
+      "resources": {
+        "cpu": 4,
+        "ram": 4096,
+        "hdd": 16,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "N.O.M.A.D. has no built-in authentication. Use network-level controls to manage access. Do not expose directly to the internet.",
+      "type": "warning"
+    },
+    {
+      "text": "The AI Assistant is optional. If you don't need AI, skip it in the setup wizard and everything else still works.",
+      "type": "info"
+    },
+    {
+      "text": "Data is persisted in bind mounts on the host (default: /opt/nomad/{mysql,storage,redis}). Set NOMAD_DATA_DIR env var before install to customize, e.g. NOMAD_DATA_DIR=/mnt/storage.",
+      "type": "info"
+    },
+    {
+      "text": "GPU passthrough is enabled by default. Currently only NVIDIA GPUs are supported for AI acceleration.",
+      "type": "info"
+    },
+    {
+      "text": "Recommended specs for AI features: AMD Ryzen 7 or Intel Core i7 or better, 32 GB RAM, NVIDIA RTX 3060 or better, at least 250 GB free disk space (preferably on SSD).",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description  
Add Project N.O.M.A.D. — a self-contained offline-first knowledge server with AI chat (Ollama), offline Wikipedia (Kiwix), Khan Academy courses (Kolibri), maps, and more. Runs via Docker Compose.

## ✅ Prerequisites
- [x] **Self-review completed**
- [x] **Tested thoroughly**
- [x] **No breaking changes**
- [x] **No security risks**

## 🏗️ arm64 Support
- [ ] **arm64 supported**
- [ ] **arm64 not tested**
- [x] **arm64 not supported** (upstream x86_64 only)

## 🛠️ Type of Change
- [x] 🆕 **New script**

## 🔍 Code & Security Review
- [x] **Follows Code_Audit.md & CONTRIBUTING.md**
- [x] **Correct script structure**
- [x] **No hardcoded credentials**

## 📋 Additional Information
Nomad uses Docker Compose internally. The install script mirrors upstream install_nomad.sh closely, with substitutions for ProxmoxVED infrastructure (setup_docker, setup_hwaccel). GPU passthrough enabled (NVIDIA only). Data dir configurable via NOMAD_DATA_DIR env var.

## 📦 Application Requirements
- [x] **At least 6 months old** (created Jun 2025)
- [x] **Actively maintained** (v1.32.1, May 27 2026)
- [x] **600+ GitHub stars** (29.8k)
- [x] **Release tarballs published**
- [x] **I understand not all scripts are accepted**

## 🌐 Source
- https://github.com/Crosstalk-Solutions/project-nomad
- https://www.projectnomad.us
