### PR TITLE
feat: add Subsyncarr

### DIFF
--- a/ct/subsyncarr.sh
+++ b/ct/subsyncarr.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: johnpc
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/johnpc/subsyncarr
+
+APP="Subsyncarr"
+var_tags="${var_tags:-arr;media}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+var_arm64="${var_arm64:-no}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/subsyncarr ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "subsyncarr" "johnpc/subsyncarr"; then
+    msg_info "Stopping Service"
+    systemctl stop subsyncarr
+    msg_ok "Stopped Service"
+
+    fetch_and_deploy_gh_release "subsyncarr" "johnpc/subsyncarr" "tarball"
+
+    msg_info "Updating ${APP}"
+    cd /opt/subsyncarr
+    $STD npm ci --ignore-scripts
+    $STD npm rebuild better-sqlite3
+    $STD npm run build
+    msg_ok "Updated ${APP}"
+
+    msg_info "Starting Service"
+    systemctl start subsyncarr
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3000${CL}"

--- a/install/subsyncarr-install.sh
+++ b/install/subsyncarr-install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: johnpc
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/johnpc/subsyncarr
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  ffmpeg \
+  python3 \
+  python3-pip \
+  python3-venv \
+  pipx \
+  build-essential \
+  cron
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+fetch_and_deploy_gh_release "subsyncarr" "johnpc/subsyncarr" "tarball"
+
+msg_info "Building ${APPLICATION}"
+cd /opt/subsyncarr
+$STD npm ci --ignore-scripts
+$STD npm rebuild better-sqlite3
+$STD npm run build
+msg_ok "Built ${APPLICATION}"
+
+msg_info "Installing Subtitle Sync Engines"
+$STD pipx install ffsubsync
+$STD pipx inject ffsubsync 'setuptools<82'
+$STD pipx install autosubsync
+$STD pipx inject autosubsync 'setuptools<82'
+cp /opt/subsyncarr/bin/alass /usr/local/bin/alass
+chmod +x /usr/local/bin/alass
+msg_ok "Installed Subtitle Sync Engines"
+
+msg_info "Configuring ${APPLICATION}"
+mkdir -p /opt/subsyncarr/data
+cat <<EOF >/opt/subsyncarr/.env
+CRON_SCHEDULE=0 0 * * *
+NODE_OPTIONS=--max-old-space-size=512
+EOF
+msg_ok "Configured ${APPLICATION}"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/subsyncarr.service
+[Unit]
+Description=Subsyncarr - Automated Subtitle Synchronization
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/subsyncarr
+EnvironmentFile=/opt/subsyncarr/.env
+ExecStart=/usr/bin/node --optimize-for-size /opt/subsyncarr/dist/index-server.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now subsyncarr
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/subsyncarr.json
+++ b/json/subsyncarr.json
@@ -1,0 +1,45 @@
+{
+  "name": "Subsyncarr",
+  "slug": "subsyncarr",
+  "categories": [
+    13
+  ],
+  "date_created": "2026-06-10",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 3000,
+  "documentation": "https://github.com/johnpc/subsyncarr#readme",
+  "website": "https://github.com/johnpc/subsyncarr",
+  "logo": "https://raw.githubusercontent.com/johnpc/subsyncarr/main/logo.png",
+  "description": "Subsyncarr is an automated subtitle synchronization tool that continuously monitors your media directories for video files with out-of-sync subtitles and automatically synchronizes them using ffsubsync, autosubsync, and alass engines.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/subsyncarr.sh",
+      "config_path": "/opt/subsyncarr/.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Mount your media directories into the LXC container to allow Subsyncarr to scan for subtitles.",
+      "type": "warning"
+    },
+    {
+      "text": "Configure your media paths and sync schedule via the web UI at port 3000.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds Proxmox helper scripts for [Subsyncarr](https://github.com/johnpc/subsyncarr), an automated subtitle synchronization tool
- Monitors media directories for video files with out-of-sync subtitles and automatically synchronizes them using ffsubsync, autosubsync, and alass engines
- Native install in Debian 13 LXC (Node 22, Python subtitle tools, systemd service)
- Web UI on port 3000 for configuration and monitoring
- Update support via GitHub releases

## Install details

- **Resources:** 2 CPU, 2GB RAM, 4GB disk
- **Dependencies:** Node.js 22, ffmpeg, ffsubsync, autosubsync, alass (static binary)
- **Service:** systemd unit running on port 3000

## Test plan

- [ ] Create LXC container via `bash -c "$(curl -fsSL ...ct/subsyncarr.sh)"`
- [ ] Verify web UI accessible on port 3000
- [ ] Mount media directory and confirm subtitle scanning works
- [ ] Test update path via the script's update function