### PR TITLE
fix(etherpad): build as the service user so the LXC service starts (#1829)

### DIFF
--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -41,11 +41,15 @@ function update_script() {
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball"
 
     msg_info "Rebuilding Etherpad"
-    cd /opt/etherpad-lite
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     $STD corepack enable
-    $STD pnpm install --frozen-lockfile
-    $STD pnpm run build:etherpad
+    # Rebuild AS the etherpad user so the pnpm store is created under
+    # /var/lib/etherpad (not root's home). A root-built store makes the
+    # service user's startup `pnpm ls` fail with EACCES/exit 243 — see the
+    # install script for the full rationale.
+    chown -R etherpad:etherpad /opt/etherpad-lite
+    $STD runuser -u etherpad -- env HOME=/var/lib/etherpad COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+      bash -c 'cd /opt/etherpad-lite && pnpm install --frozen-lockfile && pnpm run build:etherpad'
     msg_ok "Rebuilt Etherpad"
 
     restore_backup

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -35,9 +35,17 @@ msg_ok "Created etherpad User"
 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball"
 
 msg_info "Building Etherpad"
-cd /opt/etherpad-lite
-$STD pnpm install --frozen-lockfile
-$STD pnpm run build:etherpad
+# Build AS the etherpad service user, not root. pnpm records its
+# content-addressable store path in node_modules/.modules.yaml; if the build
+# runs as root the store is /root/.local/share/pnpm/store (mode 0700). At
+# startup Etherpad runs `pnpm ls` as the etherpad user to migrate plugins,
+# which tries to mkdir that root-owned store, fails with EACCES, exits 243,
+# and the server aborts before binding :9001 ("connection refused"). Building
+# as etherpad keeps the install- and run-time users (and their pnpm store /
+# corepack cache) consistent.
+chown -R etherpad:etherpad /opt/etherpad-lite
+$STD runuser -u etherpad -- env HOME=/var/lib/etherpad COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  bash -c 'cd /opt/etherpad-lite && pnpm install --frozen-lockfile && pnpm run build:etherpad'
 msg_ok "Built Etherpad"
 
 msg_info "Configuring Etherpad"
@@ -70,6 +78,7 @@ User=etherpad
 Group=etherpad
 WorkingDirectory=/opt/etherpad-lite
 Environment=NODE_ENV=production
+Environment=COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 ExecStart=/usr/bin/pnpm run prod
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Why

Closes #1829. The Etherpad service never starts on a fresh container — `:9001` returns **connection refused**, and (as @MickLesk noted) it only works when run manually as `root`.

**Root cause:** `pnpm install` runs as **root**, which persists the pnpm content-addressable store path into `node_modules/.modules.yaml`:

```
storeDir: /root/.local/share/pnpm/store/v11
```

The service runs as the `etherpad` user. At startup Etherpad migrates plugins by running `pnpm ls` (`src/static/js/pluginfw/installer.ts` → `server.ts`). pnpm tries to `mkdir` that root-owned store (`/root` is `0700`), fails, and exits **243**:

```json
{ "error": { "code": "EACCES",
  "message": "EACCES: permission denied, mkdir '/root/.local/share/pnpm/store/v11'" } }
```

The server aborts before binding `:9001`. Root works because root owns the store; `etherpad` can't reach it.

## What changed

Build (install) and rebuild (update) **as the `etherpad` user** so the pnpm store and corepack cache live under `/var/lib/etherpad` and stay consistent with the runtime user. Also set `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in the systemd unit. No change to the deploy/db/Node setup already on `main`.

## Testing

Reproduced and fixed in a clean Debian container:

| | before | after |
|---|---|---|
| `pnpm ls` as `etherpad` | rc=243, `EACCES` | **rc=0** |
| `storeDir` | `/root/.local/...` | `/var/lib/etherpad/.local/...` |
| service boot | `:9001` refused | **`:9001` → 200**, *"Etherpad is running"* |

> Note: validated against the unit's exact `ExecStart` environment in a container (no systemd in Docker). Re-test on a real Proxmox LXC via `systemctl status etherpad` is the remaining step — happy to re-add **Ready For Testing** once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)