### PR TITLE
fix(etherpad): build as the service user so the LXC service starts (#1829)

### DIFF
--- a/ct/etherpad.sh
+++ b/ct/etherpad.sh
@@ -41,11 +41,15 @@ function update_script() {
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball"
 
     msg_info "Rebuilding Etherpad"
-    cd /opt/etherpad-lite
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     $STD corepack enable
-    $STD pnpm install --frozen-lockfile
-    $STD pnpm run build:etherpad
+    # Rebuild AS the etherpad user so the pnpm store is created under
+    # /var/lib/etherpad (not root's home). A root-built store makes the
+    # service user's startup `pnpm ls` fail with EACCES/exit 243 — see the
+    # install script for the full rationale.
+    chown -R etherpad:etherpad /opt/etherpad-lite
+    $STD runuser -u etherpad -- env HOME=/var/lib/etherpad COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+      bash -c 'cd /opt/etherpad-lite && pnpm install --frozen-lockfile && pnpm run build:etherpad'
     msg_ok "Rebuilt Etherpad"
 
     restore_backup

--- a/install/etherpad-install.sh
+++ b/install/etherpad-install.sh
@@ -35,9 +35,17 @@ msg_ok "Created etherpad User"
 fetch_and_deploy_gh_release "etherpad-lite" "ether/etherpad" "tarball"
 
 msg_info "Building Etherpad"
-cd /opt/etherpad-lite
-$STD pnpm install --frozen-lockfile
-$STD pnpm run build:etherpad
+# Build AS the etherpad service user, not root. pnpm records its
+# content-addressable store path in node_modules/.modules.yaml; if the build
+# runs as root the store is /root/.local/share/pnpm/store (mode 0700). At
+# startup Etherpad runs `pnpm ls` as the etherpad user to migrate plugins,
+# which tries to mkdir that root-owned store, fails with EACCES, exits 243,
+# and the server aborts before binding :9001 ("connection refused"). Building
+# as etherpad keeps the install- and run-time users (and their pnpm store /
+# corepack cache) consistent.
+chown -R etherpad:etherpad /opt/etherpad-lite
+$STD runuser -u etherpad -- env HOME=/var/lib/etherpad COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  bash -c 'cd /opt/etherpad-lite && pnpm install --frozen-lockfile && pnpm run build:etherpad'
 msg_ok "Built Etherpad"
 
 msg_info "Configuring Etherpad"
@@ -70,6 +78,7 @@ User=etherpad
 Group=etherpad
 WorkingDirectory=/opt/etherpad-lite
 Environment=NODE_ENV=production
+Environment=COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 ExecStart=/usr/bin/pnpm run prod
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## ✍️ Description

Fixes the Etherpad CT failing to start — `:9001` returns **connection refused**, and it only works when run manually as `root` (reported in #1829).

**Root cause:** `pnpm install` runs as **root**, which persists the pnpm store path into `node_modules/.modules.yaml`:

```
storeDir: /root/.local/share/pnpm/store/v11
```

The systemd service runs as the `etherpad` user. At startup Etherpad migrates plugins by running `pnpm ls` (`src/static/js/pluginfw/installer.ts` → `server.ts`). pnpm tries to `mkdir` that root-owned store (`/root` is `0700`), fails, and exits **243**:

```json
{ "error": { "code": "EACCES",
  "message": "EACCES: permission denied, mkdir '/root/.local/share/pnpm/store/v11'" } }
```

The server aborts before binding `:9001`. Root works because root owns the store; `etherpad` can't reach it.

**Change:** build (install) and rebuild (update) **as the `etherpad` user** via `runuser`, so the pnpm store and corepack cache live under `/var/lib/etherpad` and stay consistent with the runtime user. Also set `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in the unit. Nothing else (deploy/db/Node setup already on `main`) is touched.

Verified in a clean Debian container: `pnpm ls` as `etherpad` now rc=0, `storeDir` under `/var/lib/etherpad`, and the service boots to `HTTP :9001 → 200` ("Etherpad is running"). Container has no systemd, so a real-LXC `systemctl` confirmation is the remaining step.

## 🔗 Related PR / Issue

Link: #1829

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected (container-validated; LXC systemctl re-test pending).
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**

## 📋 Additional Information (optional)

Repro/fix evidence:

| | before | after |
|---|---|---|
| `pnpm ls` as `etherpad` | rc=243, `EACCES` | rc=0 |
| `storeDir` | `/root/.local/...` | `/var/lib/etherpad/.local/...` |
| service boot | `:9001` refused | `:9001` → 200, *"Etherpad is running"* |

---

## 📦 Application Requirements (for new scripts)

> Not a new script — this is a bug fix to the existing Etherpad scripts, so these are left unchecked.

- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- https://etherpad.org
- https://github.com/ether/etherpad