### PR TITLE
fix(rackula): drop self-verification blocks, align nginx -t with repo idiom

### DIFF
--- a/ct/rackula.sh
+++ b/ct/rackula.sh
@@ -62,28 +62,9 @@ function update_script() {
     msg_ok "Updated Configuration"
 
     msg_info "Starting Services"
-    if ! nginx -t >/dev/null 2>&1; then
-      msg_error "nginx configuration test failed (run 'nginx -t' for details)"
-      systemctl start nginx rackula-api || true
-      exit 1
-    fi
+    $STD nginx -t
     systemctl start nginx rackula-api
     msg_ok "Started Services"
-
-    msg_info "Verifying Services"
-    for i in $(seq 1 10); do
-      if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1/api/health >/dev/null 2>&1; then
-        msg_ok "Service running successfully"
-        break
-      fi
-      if [ "$i" -eq 10 ]; then
-        msg_info "Last rackula-api logs"
-        journalctl -u rackula-api --no-pager -n 50 || true
-        msg_error "Service failed to respond on http://127.0.0.1/api/health within 10 seconds"
-        exit 1
-      fi
-      sleep 1
-    done
 
     msg_ok "Updated successfully!"
   fi

--- a/install/rackula-install.sh
+++ b/install/rackula-install.sh
@@ -36,10 +36,6 @@ install -m 755 "$BUN_TMP/bun-linux-${BUN_VARIANT}/bun" /usr/local/bun/bin/bun
 rm -rf "$BUN_TMP"
 ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun
 ln -sf /usr/local/bun/bin/bun /usr/local/bin/bunx
-[ -x /usr/local/bun/bin/bun ] || {
-  msg_error "Bun installation failed"
-  exit 1
-}
 msg_ok "Installed Bun"
 
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
@@ -82,10 +78,7 @@ msg_info "Configuring nginx"
 cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula
 rm -f /etc/nginx/sites-enabled/default
 ln -sf /etc/nginx/sites-available/rackula /etc/nginx/sites-enabled/rackula
-if ! $STD nginx -t; then
-  msg_error "nginx configuration test failed (run 'nginx -t' for details)"
-  exit 1
-fi
+$STD nginx -t
 msg_ok "Configured nginx"
 
 msg_info "Creating Services"
@@ -105,21 +98,6 @@ cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.s
 systemctl enable -q nginx rackula-api
 systemctl restart nginx rackula-api
 msg_ok "Created Services"
-
-msg_info "Verifying Services"
-for i in $(seq 0 9); do
-  if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1/api/health >/dev/null 2>&1; then
-    msg_ok "Service running successfully"
-    break
-  fi
-  sleep 1
-  if [ "$i" -eq 9 ]; then
-    msg_info "Last rackula-api logs"
-    journalctl -u rackula-api --no-pager -n 50 || true
-    msg_error "Service failed to respond on http://127.0.0.1/api/health within 10 seconds"
-    exit 1
-  fi
-done
 
 motd_ssh
 customize


### PR DESCRIPTION
Follow-up to the Rackula scripts, addressing the maintainer feedback that the runtime "verifying" blocks should go and the scripts should work out-of-the-box without gating on self-checks.

## Changes
- **Remove the `Verifying Services` health-check loops** in both the install and update paths. These polled `/api/health` purely to confirm a service this script had just started — and aborted the install on timeout. Of all install scripts in the repo, only these and `fleet` polled like this, and unlike `fleet`'s loop (which waits in order to POST setup data, and is non-fatal) these did nothing functional with the result.
- **Remove the Bun binary `-x` self-check.** The preceding `install -m 755 …/bun` is a bare command under the framework error trap, so a missing/failed binary already aborts there; `install -m 755` guarantees the executable bit.
- **Flatten the hand-rolled `nginx -t` gates to `$STD nginx -t`.** This is the exact one-liner used by every other nginx install script in the repo (aliasvault, simplelogin, discourse, onetimesecret, postiz, pixelfed, stoatchat). A bad config still aborts the run via `silent()`'s non-zero exit — it just uses the framework's standard error path instead of a bespoke message.

## Kept on purpose
The `security-headers.conf` existence check is retained: it validates a file shipped in the **release tarball** (catching an incomplete upstream release), not a file this script authors — a different category from the self-verification above.

## Verification
- `bash -n` passes on both files.
- `shellcheck -S warning` clean apart from the pre-existing SC1090 on the `source <(curl …)` framework bootstrap (present in every `ct/` script).

Net: +2 / −43.