### PR TITLE
fix(rackula): drop self-verification blocks, align nginx -t with repo idiom

### DIFF
--- a/ct/rackula.sh
+++ b/ct/rackula.sh
@@ -62,28 +62,9 @@ function update_script() {
     msg_ok "Updated Configuration"
 
     msg_info "Starting Services"
-    if ! nginx -t >/dev/null 2>&1; then
-      msg_error "nginx configuration test failed (run 'nginx -t' for details)"
-      systemctl start nginx rackula-api || true
-      exit 1
-    fi
+    $STD nginx -t
     systemctl start nginx rackula-api
     msg_ok "Started Services"
-
-    msg_info "Verifying Services"
-    for i in $(seq 1 10); do
-      if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1/api/health >/dev/null 2>&1; then
-        msg_ok "Service running successfully"
-        break
-      fi
-      if [ "$i" -eq 10 ]; then
-        msg_info "Last rackula-api logs"
-        journalctl -u rackula-api --no-pager -n 50 || true
-        msg_error "Service failed to respond on http://127.0.0.1/api/health within 10 seconds"
-        exit 1
-      fi
-      sleep 1
-    done
 
     msg_ok "Updated successfully!"
   fi

--- a/ct/rackula.sh
+++ b/ct/rackula.sh
@@ -36,7 +36,7 @@ function update_script() {
     msg_ok "Stopped Services"
 
     create_backup /opt/rackula/data
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "${var_version}" "/opt/rackula" "rackula-lxc-*.tar.gz"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
     restore_backup
 
     msg_info "Updating Configuration"

--- a/install/rackula-install.sh
+++ b/install/rackula-install.sh
@@ -36,10 +36,6 @@ install -m 755 "$BUN_TMP/bun-linux-${BUN_VARIANT}/bun" /usr/local/bun/bin/bun
 rm -rf "$BUN_TMP"
 ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun
 ln -sf /usr/local/bun/bin/bun /usr/local/bin/bunx
-[ -x /usr/local/bun/bin/bun ] || {
-  msg_error "Bun installation failed"
-  exit 1
-}
 msg_ok "Installed Bun"
 
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
@@ -82,10 +78,7 @@ msg_info "Configuring nginx"
 cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula
 rm -f /etc/nginx/sites-enabled/default
 ln -sf /etc/nginx/sites-available/rackula /etc/nginx/sites-enabled/rackula
-if ! $STD nginx -t; then
-  msg_error "nginx configuration test failed (run 'nginx -t' for details)"
-  exit 1
-fi
+$STD nginx -t
 msg_ok "Configured nginx"
 
 msg_info "Creating Services"
@@ -105,21 +98,6 @@ cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.s
 systemctl enable -q nginx rackula-api
 systemctl restart nginx rackula-api
 msg_ok "Created Services"
-
-msg_info "Verifying Services"
-for i in $(seq 0 9); do
-  if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1/api/health >/dev/null 2>&1; then
-    msg_ok "Service running successfully"
-    break
-  fi
-  sleep 1
-  if [ "$i" -eq 9 ]; then
-    msg_info "Last rackula-api logs"
-    journalctl -u rackula-api --no-pager -n 50 || true
-    msg_error "Service failed to respond on http://127.0.0.1/api/health within 10 seconds"
-    exit 1
-  fi
-done
 
 motd_ssh
 customize


### PR DESCRIPTION
## Description

Follow-up to the Rackula scripts, addressing maintainer feedback on `main` that the runtime "verifying" blocks should be removed and the scripts should work out-of-the-box without gating on self-checks.

**Commit 1 — drop self-verification blocks, align `nginx -t` with repo idiom:**
- **Remove the `Verifying Services` health-check loops** in both the install and update paths. They polled `/api/health` purely to confirm a service this same script had just started, and aborted on timeout. Of all install scripts in the repo, only these and `fleet` polled like this — and unlike `fleet`'s loop (which waits in order to POST setup data, and is non-fatal) these did nothing functional with the result.
- **Remove the Bun binary `-x` self-check.** The preceding `install -m 755 …/bun` runs under the framework error trap, so a missing/failed binary already aborts there; `install -m 755` guarantees the executable bit.
- **Flatten the hand-rolled `nginx -t` gates to `$STD nginx -t`** — the exact one-liner used by every other nginx install script in the repo (aliasvault, simplelogin, discourse, onetimesecret, postiz, pixelfed, stoatchat). A bad config still aborts the run via `silent()`'s non-zero exit; it just uses the framework's standard error path instead of a bespoke message.

**Commit 2 — fix update release fetch (separate, pre-existing bug):**
- The update path passed `${var_version}` (the Debian OS version, e.g. `"13"`) as the GitHub release tag to `fetch_and_deploy_gh_release`, so every real update 404'd — after stopping services and backing up data, leaving the container down. The install path already uses `"latest"`; this realigns the update path. Kept as a separate commit so it can be cherry-picked or dropped independently.

**Kept on purpose:** the `security-headers.conf` existence check, which validates a file shipped in the **release tarball** (catching an incomplete upstream release), not a file this script authors.

## 🔗 Related PR / Issue

Link: #1897

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [x] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**


## 📋 Additional Information (optional)

**Tested on a Proxmox VE 9.1.9 LXC (Debian 13, unprivileged):**
- **Fresh install** completes end-to-end; `nginx` + `rackula-api` come up `active`/`enabled`, `/api/health` → 200, frontend → 200, `nginx -t` passes. No verification step needed.
- **Update** (forced 26.6.2 → 26.6.3) completes; services restart healthy (200/200) and `/opt/rackula/data/.env` is preserved through the backup/restore cycle.
- Static: `bash -n` + `shellcheck -S warning` clean apart from the pre-existing SC1090 on the `source <(curl …)` bootstrap.

On the `nginx -t` change: this converts the gate to the repo idiom rather than removing the test outright. A malformed config still aborts via `silent()`'s non-zero exit. Happy to drop the nginx test entirely if preferred.

> Note: during testing I also noticed the update path no longer runs `systemctl daemon-reload` after copying new unit files (`systemd` warns "unit file changed on disk"). Services still start fine, but a future change to the `.service` files wouldn't take effect until a reload. Left out of this PR's scope — happy to add it here or in a follow-up if maintainers want.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

Rackula upstream: https://github.com/RackulaLives/Rackula
This PR modifies the existing `ct/rackula.sh` and `install/rackula-install.sh` (added in #1897).
