### PR TITLE
Add OpenWrt LXC script

### DIFF
--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -14,8 +14,8 @@ var_disk="${var_disk:-1}"
 var_os="${var_os:-openwrt}"
 var_version="${var_version:-25.12}"
 var_unprivileged="${var_unprivileged:-1}"
-
 var_arm64="${var_arm64:-no}"
+
 var_tun="${var_tun:-yes}"
 var_lan_bridge="${var_lan_bridge:-vmbr0}"
 var_wan_bridge="${var_wan_bridge:-vmbr0}"

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -25,6 +25,13 @@ var_lan_netmask="${var_lan_netmask:-255.255.255.0}"
 var_interface="${var_interface:-yes}"
 var_interface_packages="${var_interface_packages:-luci}"
 
+OPENWRT_TEMPLATE_INDEX_URL="https://images.linuxcontainers.org/meta/1.0/index-system"
+
+function openwrt_fetch_template_index() {
+  curl -fsSL --connect-timeout 10 --max-time 30 "$OPENWRT_TEMPLATE_INDEX_URL" 2>/dev/null ||
+    curl -4 -fsSL --connect-timeout 10 --max-time 30 "$OPENWRT_TEMPLATE_INDEX_URL" 2>/dev/null
+}
+
 function openwrt_normalize_release() {
   local requested="${1:-latest}"
   case "$requested" in
@@ -56,7 +63,7 @@ function openwrt_resolve_template() {
     return 207
   }
 
-  index="$(curl -fsSL https://images.linuxcontainers.org/meta/1.0/index-system)" || {
+  index="$(openwrt_fetch_template_index)" || {
     msg_error "Failed to read OpenWrt LinuxContainers template index"
     return 222
   }
@@ -91,9 +98,7 @@ function openwrt_resolve_template() {
 }
 
 function preflight_template_connectivity() {
-  local http_code
-  http_code="$(curl -sS -o /dev/null -w "%{http_code}" -m 5 https://images.linuxcontainers.org/meta/1.0/index-system 2>/dev/null)" || http_code="000"
-  if [[ "$http_code" =~ ^[23][0-9]{2}$ ]]; then
+  if openwrt_fetch_template_index >/dev/null; then
     preflight_pass "Template server reachable (images.linuxcontainers.org)"
   else
     preflight_fail "LinuxContainers template index unreachable" 222

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-source <(curl -fsSL "${BUILD_FUNC_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func}")
+if [[ -n "${BUILD_FUNC_URL:-}" && -z "${COMMUNITY_SCRIPTS_URL:-}" && "$BUILD_FUNC_URL" == */misc/build.func ]]; then
+  export COMMUNITY_SCRIPTS_URL="${BUILD_FUNC_URL%/misc/build.func}"
+fi
+source <(curl -fsSL "${BUILD_FUNC_URL:-${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func}")
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: community-scripts ORG

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-if [[ -n "${BUILD_FUNC_URL:-}" && -z "${COMMUNITY_SCRIPTS_URL:-}" && "$BUILD_FUNC_URL" == */misc/build.func ]]; then
-  export COMMUNITY_SCRIPTS_URL="${BUILD_FUNC_URL%/misc/build.func}"
-fi
-source <(curl -fsSL "${BUILD_FUNC_URL:-${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func}")
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
 
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: community-scripts ORG
+# Author: Mihael Zamin Sousa (mihazs)
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://openwrt.org/
 
@@ -16,8 +13,9 @@ var_ram="${var_ram:-256}"
 var_disk="${var_disk:-1}"
 var_os="${var_os:-openwrt}"
 var_version="${var_version:-25.12}"
-var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
+
+var_arm64="${var_arm64:-no}"
 var_tun="${var_tun:-yes}"
 var_lan_bridge="${var_lan_bridge:-vmbr0}"
 var_wan_bridge="${var_wan_bridge:-vmbr0}"
@@ -41,7 +39,7 @@ start
 build_container
 description
 
-msg_ok "Completed successfully!\n"
-msg_custom "🚀" "${GN}" "${APP} setup has been successfully initialized!"
-echo -e "${INFO}${YW} Review WAN/LAN bridge assignments before routing production traffic.${CL}"
-echo -e "${INFO}${YW} If you set VLAN tags, ensure the selected Proxmox bridge is VLAN-aware.${CL}"
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+source <(curl -fsSL "${BUILD_FUNC_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func}")
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: community-scripts ORG
@@ -12,7 +12,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-256}"
 var_disk="${var_disk:-1}"
 var_os="${var_os:-openwrt}"
-var_version="${var_version:-24.10}"
+var_version="${var_version:-25.12}"
 var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
 var_tun="${var_tun:-yes}"

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: community-scripts ORG
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://openwrt.org/
+
+APP="OpenWrt"
+var_tags="${var_tags:-os;router;network}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-256}"
+var_disk="${var_disk:-1}"
+var_os="${var_os:-openwrt}"
+var_version="${var_version:-24.10}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+var_tun="${var_tun:-yes}"
+var_lan_bridge="${var_lan_bridge:-vmbr0}"
+var_wan_bridge="${var_wan_bridge:-vmbr0}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  msg_error "Automated OpenWrt LXC upgrades are not supported. Use OpenWrt's sysupgrade process after reviewing container networking and package compatibility."
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+msg_custom "🚀" "${GN}" "${APP} setup has been successfully initialized!"
+echo -e "${INFO}${YW} Review WAN/LAN bridge assignments before routing production traffic.${CL}"
+echo -e "${INFO}${YW} If you set VLAN tags, ensure the selected Proxmox bridge is VLAN-aware.${CL}"

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -19,6 +19,7 @@ var_arm64="${var_arm64:-no}"
 var_tun="${var_tun:-yes}"
 var_lan_bridge="${var_lan_bridge:-vmbr0}"
 var_wan_bridge="${var_wan_bridge:-vmbr0}"
+var_allow_same_bridge="${var_allow_same_bridge:-no}"
 var_interface="${var_interface:-yes}"
 var_interface_packages="${var_interface_packages:-luci}"
 
@@ -120,7 +121,11 @@ function openwrt_template_path() {
     found && /^[^[:space:]]/ { found = 0 }
     found && $1 == "path" { print $2; exit }
   ' /etc/pve/storage.cfg)"
-  echo "${template_base:-/var/lib/vz}/template/cache/${TEMPLATE}"
+  [[ -n "$template_base" ]] || {
+    msg_error "Could not resolve OpenWrt template path for storage ${TEMPLATE_STORAGE}."
+    return 213
+  }
+  echo "${template_base}/template/cache/${TEMPLATE}"
 }
 
 function openwrt_download_template() {
@@ -140,9 +145,11 @@ function openwrt_download_template() {
 }
 
 function openwrt_prepare_template() {
-  openwrt_resolve_template || exit $?
+  if [[ -z "${TEMPLATE:-}" || -z "${OPENWRT_TEMPLATE_URL:-}" ]]; then
+    openwrt_resolve_template || exit $?
+  fi
 
-  TEMPLATE_PATH="$(openwrt_template_path)"
+  TEMPLATE_PATH="$(openwrt_template_path)" || exit $?
   export TEMPLATE_PATH
 
   if [[ ! -f "$TEMPLATE_PATH" ]]; then
@@ -174,6 +181,24 @@ function openwrt_net_option() {
   fi
 
   echo "bridge=${bridge},ip=${ip_mode}${options}"
+}
+
+function openwrt_validate_network_bridges() {
+  local lan_bridge="$1" wan_bridge="$2"
+
+  if [[ "$lan_bridge" != "$wan_bridge" ]]; then
+    return 0
+  fi
+
+  case "${var_allow_same_bridge:-no}" in
+  yes | true | 1 | on)
+    msg_warn "OpenWrt LAN and WAN both use bridge ${lan_bridge}; continuing because var_allow_same_bridge is enabled."
+    ;;
+  *)
+    msg_error "OpenWrt LAN and WAN bridges are both set to ${lan_bridge}. Set var_lan_bridge and var_wan_bridge to different bridges, or set var_allow_same_bridge=yes after reviewing the topology."
+    exit 1
+    ;;
+  esac
 }
 
 function openwrt_select_storages() {
@@ -219,6 +244,8 @@ function openwrt_build_pct_options() {
   local openwrt_mtu="${var_openwrt_mtu:-${MTU:-}}"
   local features=""
   local extra_options=()
+
+  openwrt_validate_network_bridges "$lan_bridge" "$wan_bridge"
 
   if [[ "${ENABLE_NESTING:-1}" == "1" ]]; then
     features="nesting=1"
@@ -286,10 +313,7 @@ function openwrt_create_lxc() {
   fi
 
   openwrt_select_storages
-  openwrt_prepare_template
-  openwrt_build_pct_options
-
-  lockfile="/tmp/template.${TEMPLATE}.lock"
+  lockfile="/tmp/template.openwrt.lock"
   exec 9>"$lockfile" || {
     msg_error "Failed to create lock file '$lockfile'."
     exit 200
@@ -298,6 +322,10 @@ function openwrt_create_lxc() {
     msg_error "Timeout while waiting for template lock."
     exit 211
   }
+
+  openwrt_resolve_template || exit $?
+  openwrt_prepare_template
+  openwrt_build_pct_options
 
   logfile="/tmp/pct_create_${CTID}_$(date +%Y%m%d_%H%M%S)_${SESSION_ID}.log"
   LOGFILE="$logfile"

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -21,6 +21,8 @@ var_unprivileged="${var_unprivileged:-1}"
 var_tun="${var_tun:-yes}"
 var_lan_bridge="${var_lan_bridge:-vmbr0}"
 var_wan_bridge="${var_wan_bridge:-vmbr0}"
+var_interface="${var_interface:-yes}"
+var_interface_packages="${var_interface_packages:-luci}"
 
 header_info "$APP"
 variables

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -22,6 +22,427 @@ var_wan_bridge="${var_wan_bridge:-vmbr0}"
 var_interface="${var_interface:-yes}"
 var_interface_packages="${var_interface_packages:-luci}"
 
+function openwrt_normalize_release() {
+  local requested="${1:-latest}"
+  case "$requested" in
+  "" | latest | stable) echo "latest" ;;
+  snapshot) echo "snapshot" ;;
+  [0-9]*.[0-9]*.[0-9]*) echo "${requested%.*}" ;;
+  *) echo "$requested" ;;
+  esac
+}
+
+function openwrt_latest_stable_release() {
+  awk -F';' '$1 == "openwrt" && $2 != "snapshot" { print $2 }' | sort -uV | tail -n1
+}
+
+function openwrt_lxc_arch() {
+  local arch
+  arch="$(dpkg --print-architecture)"
+  case "$arch" in
+  amd64 | arm64) echo "$arch" ;;
+  *) return 1 ;;
+  esac
+}
+
+function openwrt_resolve_template() {
+  local lxc_arch index requested_release release line template_path build_id
+
+  lxc_arch="$(openwrt_lxc_arch)" || {
+    msg_error "No OpenWrt LinuxContainers template mapping for architecture $(dpkg --print-architecture)"
+    return 207
+  }
+
+  index="$(curl -fsSL https://images.linuxcontainers.org/meta/1.0/index-system)" || {
+    msg_error "Failed to read OpenWrt LinuxContainers template index"
+    return 222
+  }
+
+  requested_release="$(openwrt_normalize_release "${PCT_OSVERSION:-${var_version:-latest}}")"
+  if [[ "$requested_release" == "latest" ]]; then
+    release="$(printf "%s\n" "$index" | openwrt_latest_stable_release)"
+  else
+    release="$requested_release"
+  fi
+
+  [[ -n "$release" ]] || {
+    msg_error "No stable OpenWrt release found in LinuxContainers index"
+    return 225
+  }
+
+  line="$(awk -F';' -v release="$release" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }' <<<"$index")"
+  [[ -n "$line" ]] || {
+    msg_error "No OpenWrt ${release} ${lxc_arch} template found in LinuxContainers index"
+    return 225
+  }
+
+  var_version="$release"
+  PCT_OSVERSION="$release"
+  export var_version PCT_OSVERSION
+
+  template_path="$(awk -F';' '{ print $6 }' <<<"$line")"
+  build_id="$(awk -F';' '{ print $5 }' <<<"$line" | tr ':/' '--')"
+  TEMPLATE="openwrt-${release}-${lxc_arch}-${build_id}-rootfs.tar.xz"
+  OPENWRT_TEMPLATE_URL="https://images.linuxcontainers.org${template_path}rootfs.tar.xz"
+  export TEMPLATE OPENWRT_TEMPLATE_URL
+}
+
+function preflight_template_connectivity() {
+  local http_code
+  http_code="$(curl -sS -o /dev/null -w "%{http_code}" -m 5 https://images.linuxcontainers.org/meta/1.0/index-system 2>/dev/null)" || http_code="000"
+  if [[ "$http_code" =~ ^[23][0-9]{2}$ ]]; then
+    preflight_pass "Template server reachable (images.linuxcontainers.org)"
+  else
+    preflight_fail "LinuxContainers template index unreachable" 222
+    echo -e "    ${TAB}${INFO} Check internet connectivity or manually upload the OpenWrt rootfs template"
+  fi
+}
+
+function preflight_template_available() {
+  if openwrt_resolve_template; then
+    preflight_pass "Template available online for OpenWrt ${var_version} ($(openwrt_lxc_arch))"
+  else
+    preflight_fail "OpenWrt LinuxContainers template unavailable" 225
+  fi
+}
+
+function openwrt_template_path() {
+  local template_path template_base
+
+  template_path="$(pvesm path "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" 2>/dev/null || true)"
+  if [[ -n "$template_path" ]]; then
+    echo "$template_path"
+    return 0
+  fi
+
+  template_base="$(awk -v storage="$TEMPLATE_STORAGE" '
+    $0 ~ "^[^:]+:[[:space:]]*" storage "$" { found = 1; next }
+    found && /^[^[:space:]]/ { found = 0 }
+    found && $1 == "path" { print $2; exit }
+  ' /etc/pve/storage.cfg)"
+  echo "${template_base:-/var/lib/vz}/template/cache/${TEMPLATE}"
+}
+
+function openwrt_download_template() {
+  local template_path="$1"
+
+  mkdir -p "$(dirname "$template_path")" || {
+    msg_error "Cannot create OpenWrt template directory."
+    exit 207
+  }
+
+  msg_info "Downloading OpenWrt rootfs template"
+  curl -fsSL -o "$template_path" "$OPENWRT_TEMPLATE_URL" || {
+    msg_error "Failed to download OpenWrt template from: $OPENWRT_TEMPLATE_URL"
+    exit 222
+  }
+  msg_ok "Downloaded OpenWrt LXC template"
+}
+
+function openwrt_prepare_template() {
+  openwrt_resolve_template || exit $?
+
+  TEMPLATE_PATH="$(openwrt_template_path)"
+  export TEMPLATE_PATH
+
+  if [[ ! -f "$TEMPLATE_PATH" ]]; then
+    openwrt_download_template "$TEMPLATE_PATH"
+  elif ! tar -tf "$TEMPLATE_PATH" &>/dev/null; then
+    msg_warn "Local OpenWrt template is not a readable tar archive; re-downloading."
+    rm -f "$TEMPLATE_PATH"
+    openwrt_download_template "$TEMPLATE_PATH"
+  else
+    msg_ok "Template ${BL}${TEMPLATE}${CL} found locally."
+  fi
+}
+
+function openwrt_net_option() {
+  local bridge="$1" ip_mode="$2" vlan="$3" mtu="$4" options=""
+
+  if [[ -n "$vlan" ]]; then
+    case "$vlan" in
+    ,tag=*) options+="$vlan" ;;
+    *) options+=",tag=$vlan" ;;
+    esac
+  fi
+
+  if [[ -n "$mtu" ]]; then
+    case "$mtu" in
+    ,mtu=*) options+="$mtu" ;;
+    *) options+=",mtu=$mtu" ;;
+    esac
+  fi
+
+  echo "bridge=${bridge},ip=${ip_mode}${options}"
+}
+
+function openwrt_select_storages() {
+  check_storage_support "rootdir" || {
+    msg_error "No valid storage found for 'rootdir' [Container]"
+    exit 1
+  }
+  check_storage_support "vztmpl" || {
+    msg_error "No valid storage found for 'vztmpl' [Template]"
+    exit 1
+  }
+
+  if resolve_storage_preselect template "${TEMPLATE_STORAGE:-${var_template_storage:-}}"; then
+    TEMPLATE_STORAGE="$STORAGE_RESULT"
+    TEMPLATE_STORAGE_INFO="$STORAGE_INFO"
+    msg_ok "Storage ${BL}${TEMPLATE_STORAGE}${CL} (${TEMPLATE_STORAGE_INFO}) [Template]"
+  else
+    select_storage template
+    TEMPLATE_STORAGE="$STORAGE_RESULT"
+    TEMPLATE_STORAGE_INFO="$STORAGE_INFO"
+    msg_ok "Storage ${BL}${TEMPLATE_STORAGE}${CL} (${TEMPLATE_STORAGE_INFO}) [Template]"
+  fi
+
+  if resolve_storage_preselect container "${CONTAINER_STORAGE:-${var_container_storage:-}}"; then
+    CONTAINER_STORAGE="$STORAGE_RESULT"
+    CONTAINER_STORAGE_INFO="$STORAGE_INFO"
+    msg_ok "Storage ${BL}${CONTAINER_STORAGE}${CL} (${CONTAINER_STORAGE_INFO}) [Container]"
+  else
+    select_storage container
+    CONTAINER_STORAGE="$STORAGE_RESULT"
+    CONTAINER_STORAGE_INFO="$STORAGE_INFO"
+    msg_ok "Storage ${BL}${CONTAINER_STORAGE}${CL} (${CONTAINER_STORAGE_INFO}) [Container]"
+  fi
+
+  validate_storage_space "$CONTAINER_STORAGE" "$DISK_SIZE" "yes" || true
+}
+
+function openwrt_build_pct_options() {
+  local lan_bridge="${var_lan_bridge:-${BRG:-vmbr0}}"
+  local wan_bridge="${var_wan_bridge:-${BRG:-vmbr0}}"
+  local lan_vlan="${var_lan_vlan:-}"
+  local wan_vlan="${var_wan_vlan:-${VLAN:-}}"
+  local openwrt_mtu="${var_openwrt_mtu:-${MTU:-}}"
+  local features=""
+  local extra_options=()
+
+  if [[ "${ENABLE_NESTING:-1}" == "1" ]]; then
+    features="nesting=1"
+  fi
+  if [[ "${CT_TYPE:?}" == "1" ]]; then
+    [[ -n "$features" ]] && features+=","
+    features+="keyctl=1"
+  fi
+  if [[ "$ENABLE_FUSE" == "yes" ]]; then
+    [[ -n "$features" ]] && features+=","
+    features+="fuse=1"
+  fi
+
+  OPENWRT_PCT_ARGS=()
+  if [[ -n "$features" ]]; then
+    OPENWRT_PCT_ARGS+=(-features "$features")
+  fi
+  OPENWRT_PCT_ARGS+=(-hostname "$HN")
+  if [[ -n "$TAGS" ]]; then
+    OPENWRT_PCT_ARGS+=(-tags "$TAGS")
+  fi
+  if [[ -n "$SD" ]]; then
+    read -r -a extra_options <<<"$SD"
+    OPENWRT_PCT_ARGS+=("${extra_options[@]}")
+  fi
+  if [[ -n "$NS" ]]; then
+    read -r -a extra_options <<<"$NS"
+    OPENWRT_PCT_ARGS+=("${extra_options[@]}")
+  fi
+
+  OPENWRT_PCT_ARGS+=(
+    -net0 "name=eth0,$(openwrt_net_option "$lan_bridge" manual "$lan_vlan" "$openwrt_mtu")"
+    -net1 "name=eth1,$(openwrt_net_option "$wan_bridge" dhcp "$wan_vlan" "$openwrt_mtu")"
+    -onboot 1
+    -cores "$CORE_COUNT"
+    -memory "$RAM_SIZE"
+    -unprivileged "${CT_TYPE:?}"
+    -ostype unmanaged
+    -rootfs "$CONTAINER_STORAGE:${DISK_SIZE}"
+  )
+
+  if [[ "${PROTECT_CT:-}" == "1" || "${PROTECT_CT:-}" == "yes" ]]; then
+    OPENWRT_PCT_ARGS+=(-protection 1)
+  fi
+  if [[ -n "${CT_TIMEZONE:-}" ]]; then
+    OPENWRT_PCT_ARGS+=(-timezone "$CT_TIMEZONE")
+  fi
+  if [[ -n "$PW" ]]; then
+    read -r -a extra_options <<<"$PW"
+    OPENWRT_PCT_ARGS+=("${extra_options[@]}")
+  fi
+}
+
+function openwrt_create_lxc() {
+  local logfile lockfile
+
+  [[ "$CTID" -ge 100 ]] || {
+    msg_error "ID cannot be less than 100."
+    exit 205
+  }
+  if qm status "$CTID" &>/dev/null || pct status "$CTID" &>/dev/null; then
+    echo -e "ID '$CTID' is already in use."
+    msg_error "Cannot use ID that is already in use."
+    exit 206
+  fi
+
+  openwrt_select_storages
+  openwrt_prepare_template
+  openwrt_build_pct_options
+
+  lockfile="/tmp/template.${TEMPLATE}.lock"
+  exec 9>"$lockfile" || {
+    msg_error "Failed to create lock file '$lockfile'."
+    exit 200
+  }
+  flock -w 300 9 || {
+    msg_error "Timeout while waiting for template lock."
+    exit 211
+  }
+
+  logfile="/tmp/pct_create_${CTID}_$(date +%Y%m%d_%H%M%S)_${SESSION_ID}.log"
+  LOGFILE="$logfile"
+  export LOGFILE
+
+  msg_info "Creating LXC container"
+  grep -q "root:100000:65536" /etc/subuid || echo "root:100000:65536" >>/etc/subuid
+  grep -q "root:100000:65536" /etc/subgid || echo "root:100000:65536" >>/etc/subgid
+
+  if ! pct create "$CTID" "$TEMPLATE_PATH" "${OPENWRT_PCT_ARGS[@]}" >"$logfile" 2>&1; then
+    if grep -qiE 'unable to open|corrupt|invalid' "$logfile"; then
+      msg_warn "Template appears invalid; re-downloading."
+      rm -f "$TEMPLATE_PATH"
+      openwrt_download_template "$TEMPLATE_PATH"
+      pct create "$CTID" "$TEMPLATE_PATH" "${OPENWRT_PCT_ARGS[@]}" >>"$logfile" 2>&1 || {
+        msg_error "Container creation failed. See $logfile"
+        exit 209
+      }
+    else
+      msg_error "Container creation failed. See $logfile"
+      exit 209
+    fi
+  fi
+
+  exec 9>&-
+  pct list | awk '{ print $1 }' | grep -qx "$CTID" || {
+    msg_error "Container ID $CTID not listed in 'pct list'. See $logfile"
+    exit 215
+  }
+  msg_ok "LXC Container ${BL}${CTID}${CL} ${GN}was successfully created."
+}
+
+function openwrt_configure_devices() {
+  LXC_CONFIG="/etc/pve/lxc/${CTID}.conf"
+  export LXC_CONFIG
+
+  if [[ "$ENABLE_TUN" == "yes" ]]; then
+    cat <<EOF >>"$LXC_CONFIG"
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+EOF
+  fi
+}
+
+function openwrt_run_install_script() {
+  local install_script lxc_exit install_exit_code=0 error_flag
+
+  export OPENWRT_INTERFACE="${var_interface:-yes}"
+  export OPENWRT_INTERFACE_PACKAGES="${var_interface_packages:-luci}"
+
+  start_install_timer
+  set +Eeuo pipefail
+  trap - ERR
+  install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install:?}.sh")"
+  lxc-attach -n "$CTID" -- /bin/ash -c "$install_script"
+  lxc_exit=$?
+  set -Eeuo pipefail
+  trap 'error_handler' ERR
+
+  if [[ -n "${SESSION_ID:-}" ]]; then
+    error_flag="/root/.install-${SESSION_ID}.failed"
+    if pct exec "$CTID" -- test -f "$error_flag" 2>/dev/null; then
+      install_exit_code="$(pct exec "$CTID" -- cat "$error_flag" 2>/dev/null || echo "1")"
+      pct exec "$CTID" -- rm -f "$error_flag" 2>/dev/null || true
+    fi
+  fi
+  if [[ "$install_exit_code" -eq 0 && "$lxc_exit" -ne 0 ]]; then
+    install_exit_code="$lxc_exit"
+  fi
+  if [[ "$install_exit_code" -ne 0 ]]; then
+    msg_error "Installation failed in container ${CTID} (exit code: ${install_exit_code})"
+    post_update_to_api "failed" "$install_exit_code"
+    exit "$install_exit_code"
+  fi
+}
+
+function openwrt_build_container() {
+  TEMP_DIR="$(mktemp -d)"
+  pushd "$TEMP_DIR" >/dev/null
+
+  export DIAGNOSTICS="$DIAGNOSTICS"
+  export RANDOM_UUID="$RANDOM_UUID"
+  export EXECUTION_ID="$EXECUTION_ID"
+  export SESSION_ID="$SESSION_ID"
+  export CACHER="$APT_CACHER"
+  export CACHER_IP="$APT_CACHER_IP"
+  export tz="${timezone:-}"
+  export APPLICATION="$APP"
+  export app="$NSAPP"
+  export PASSWORD="$PW"
+  export VERBOSE="$VERBOSE"
+  export SSH_ROOT="${SSH}"
+  export SSH_AUTHORIZED_KEY
+  export CTID="${CT_ID:?}"
+  export CTTYPE="${CT_TYPE:?}"
+  export ENABLE_FUSE="$ENABLE_FUSE"
+  export ENABLE_TUN="$ENABLE_TUN"
+  export PCT_OSTYPE="$var_os"
+  export PCT_OSVERSION="$var_version"
+  export PCT_DISK_SIZE="$DISK_SIZE"
+  export IPV6_METHOD="$IPV6_METHOD"
+  export ENABLE_GPU="$ENABLE_GPU"
+  export APPLICATION_VERSION="${var_appversion:-}"
+  export BUILD_LOG="$BUILD_LOG"
+  export INSTALL_LOG="/root/.install-${SESSION_ID}.log"
+  export COMMUNITY_SCRIPTS_URL="$COMMUNITY_SCRIPTS_URL"
+  export MODE="${METHOD:-default}"
+
+  _HOST_LOGFILE="$BUILD_LOG"
+  export _HOST_LOGFILE
+
+  post_to_api
+  post_progress_to_api "validation"
+  openwrt_create_lxc
+  post_progress_to_api "configuring"
+  openwrt_configure_devices
+
+  msg_info "Starting LXC Container"
+  pct start "$CTID"
+  for i in {1..10}; do
+    if pct status "$CTID" | grep -q "status: running"; then
+      msg_ok "Started LXC Container"
+      break
+    fi
+    sleep 1
+    if [[ "$i" -eq 10 ]]; then
+      msg_error "LXC Container did not reach running state"
+      exit 1
+    fi
+  done
+
+  msg_info "Customizing LXC Container"
+  sleep 3
+  msg_ok "Customized LXC Container"
+
+  install_ssh_keys_into_ct
+  openwrt_run_install_script
+  rm -f "/tmp/.install-capture-${SESSION_ID}.log" 2>/dev/null
+
+  popd >/dev/null
+  rm -rf "$TEMP_DIR"
+}
+
+function build_container() { openwrt_build_container; }
+
 header_info "$APP"
 variables
 color

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -20,6 +20,8 @@ var_tun="${var_tun:-yes}"
 var_lan_bridge="${var_lan_bridge:-vmbr0}"
 var_wan_bridge="${var_wan_bridge:-vmbr0}"
 var_allow_same_bridge="${var_allow_same_bridge:-no}"
+var_lan_ipaddr="${var_lan_ipaddr:-192.168.1.1}"
+var_lan_netmask="${var_lan_netmask:-255.255.255.0}"
 var_interface="${var_interface:-yes}"
 var_interface_packages="${var_interface_packages:-luci}"
 
@@ -375,6 +377,8 @@ function openwrt_run_install_script() {
 
   export OPENWRT_INTERFACE="${var_interface:-yes}"
   export OPENWRT_INTERFACE_PACKAGES="${var_interface_packages:-luci}"
+  export OPENWRT_LAN_IPADDR="${var_lan_ipaddr:-192.168.1.1}"
+  export OPENWRT_LAN_NETMASK="${var_lan_netmask:-255.255.255.0}"
 
   start_install_timer
   set +Eeuo pipefail

--- a/ct/openwrt.sh
+++ b/ct/openwrt.sh
@@ -26,6 +26,7 @@ var_interface="${var_interface:-yes}"
 var_interface_packages="${var_interface_packages:-luci}"
 
 OPENWRT_TEMPLATE_INDEX_URL="https://images.linuxcontainers.org/meta/1.0/index-system"
+OPENWRT_INSTALL_FALLBACK_URL="${OPENWRT_INSTALL_FALLBACK_URL:-https://raw.githubusercontent.com/mihazs/ProxmoxVED/add-openwrt-lxc}"
 
 function openwrt_fetch_template_index() {
   curl -fsSL --connect-timeout 10 --max-time 30 "$OPENWRT_TEMPLATE_INDEX_URL" 2>/dev/null ||
@@ -208,6 +209,28 @@ function openwrt_validate_network_bridges() {
   esac
 }
 
+function openwrt_fetch_install_script() {
+  local primary_url fallback_url install_url fetched_script failed_urls=()
+
+  primary_url="${COMMUNITY_SCRIPTS_URL%/}/install/${var_install:?}.sh"
+  fallback_url="${OPENWRT_INSTALL_FALLBACK_URL%/}/install/${var_install:?}.sh"
+
+  for install_url in "$primary_url" "$fallback_url"; do
+    [[ "$install_url" == "$primary_url" && "${#failed_urls[@]}" -gt 0 ]] && continue
+    if fetched_script="$(curl -fsSL "$install_url" 2>/dev/null)" && [[ -n "$fetched_script" ]]; then
+      OPENWRT_INSTALL_SCRIPT="$fetched_script"
+      return 0
+    fi
+    failed_urls+=("$install_url")
+  done
+
+  for install_url in "${failed_urls[@]}"; do
+    msg_warn "Unavailable OpenWrt install script: ${install_url}"
+  done
+  msg_error "Failed to download OpenWrt install script"
+  return 222
+}
+
 function openwrt_select_storages() {
   check_storage_support "rootdir" || {
     msg_error "No valid storage found for 'rootdir' [Container]"
@@ -386,9 +409,15 @@ function openwrt_run_install_script() {
   export OPENWRT_LAN_NETMASK="${var_lan_netmask:-255.255.255.0}"
 
   start_install_timer
+  openwrt_fetch_install_script || {
+    install_exit_code=$?
+    post_update_to_api "failed" "$install_exit_code"
+    exit "$install_exit_code"
+  }
+  install_script="$OPENWRT_INSTALL_SCRIPT"
+
   set +Eeuo pipefail
   trap - ERR
-  install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install:?}.sh")"
   lxc-attach -n "$CTID" -- /bin/ash -c "$install_script"
   lxc_exit=$?
   set -Eeuo pipefail
@@ -496,6 +525,7 @@ function update_script() {
 start
 build_container
 description
+IP="${IP:-${var_lan_ipaddr:-192.168.1.1}}"
 
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -12,9 +12,12 @@ openwrt_update_package_feeds() {
   package_manager="$1"
   attempt=1
   max_attempts=6
+  package_update_log="/tmp/openwrt-package-feed-update.log"
 
   while [ "$attempt" -le "$max_attempts" ]; do
-    if "$package_manager" update; then
+    if "$package_manager" update >"$package_update_log" 2>&1; then
+      cat "$package_update_log"
+      rm -f "$package_update_log"
       return 0
     fi
 
@@ -25,6 +28,8 @@ openwrt_update_package_feeds() {
     attempt=$((attempt + 1))
   done
 
+  cat "$package_update_log" >&2
+  rm -f "$package_update_log"
   printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
   return 1
 }

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -27,6 +27,6 @@ uci set network.wan.proto='dhcp'
 uci set network.wan.device='eth1'
 uci commit network
 
-if [ -x /etc/init.d/network ]; then
-  /etc/init.d/network restart
+if command -v ubus >/dev/null 2>&1 && ubus list network >/dev/null 2>&1 && [ -x /etc/init.d/network ]; then
+  /etc/init.d/network reload >/dev/null 2>&1 || true
 fi

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -27,6 +27,48 @@ uci set network.wan.proto='dhcp'
 uci set network.wan.device='eth1'
 uci commit network
 
+var_interface="${OPENWRT_INTERFACE:-${var_interface:-yes}}"
+var_interface_packages="${OPENWRT_INTERFACE_PACKAGES:-${var_interface_packages:-luci}}"
+
+case "$var_interface" in
+yes | true | 1 | on)
+  set --
+  for interface_package in $var_interface_packages; do
+    interface_package="${interface_package##*/}"
+    if [ -n "$interface_package" ]; then
+      set -- "$@" "$interface_package"
+    fi
+  done
+
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "At least one OpenWrt interface package is required when var_interface is enabled" >&2
+    exit 1
+  fi
+
+  if command -v opkg >/dev/null 2>&1; then
+    opkg update
+    opkg install "$@"
+  elif command -v apk >/dev/null 2>&1; then
+    apk update
+    apk add "$@"
+  else
+    printf '%s\n' "opkg or apk is required to install OpenWrt interface packages" >&2
+    exit 1
+  fi
+
+  if [ -x /etc/init.d/uhttpd ]; then
+    /etc/init.d/uhttpd enable
+    /etc/init.d/uhttpd start
+  fi
+  ;;
+no | false | 0 | off)
+  ;;
+*)
+  printf '%s\n' "var_interface must be yes or no" >&2
+  exit 1
+  ;;
+esac
+
 if command -v ubus >/dev/null 2>&1 && ubus list network >/dev/null 2>&1 && [ -x /etc/init.d/network ]; then
   /etc/init.d/network reload >/dev/null 2>&1 || true
 fi

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -44,7 +44,7 @@ uci set network.lan='interface' &&
   uci set network.wan.device='eth1' &&
   uci commit network || exit 1
 
-/etc/init.d/network reload >/dev/null 2>&1 || printf '%s\n' "OpenWrt network reload failed; package feed update will verify connectivity" >&2
+/etc/init.d/network reload >/dev/null 2>&1 || true
 
 var_interface="${OPENWRT_INTERFACE:-${var_interface:-yes}}"
 var_interface_packages="${OPENWRT_INTERFACE_PACKAGES:-${var_interface_packages:-luci}}"

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -5,11 +5,14 @@
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://openwrt.org/
 
+lan_ipaddr="${OPENWRT_LAN_IPADDR:-${var_lan_ipaddr:-192.168.1.1}}"
+lan_netmask="${OPENWRT_LAN_NETMASK:-${var_lan_netmask:-255.255.255.0}}"
+
 uci set network.lan='interface' &&
   uci set network.lan.proto='static' &&
   uci set network.lan.device='eth0' &&
-  uci set network.lan.ipaddr='192.168.1.1' &&
-  uci set network.lan.netmask='255.255.255.0' &&
+  uci set network.lan.ipaddr="$lan_ipaddr" &&
+  uci set network.lan.netmask="$lan_netmask" &&
   uci set network.wan='interface' &&
   uci set network.wan.proto='dhcp' &&
   uci set network.wan.device='eth1' &&

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -8,6 +8,27 @@
 lan_ipaddr="${OPENWRT_LAN_IPADDR:-${var_lan_ipaddr:-192.168.1.1}}"
 lan_netmask="${OPENWRT_LAN_NETMASK:-${var_lan_netmask:-255.255.255.0}}"
 
+openwrt_update_package_feeds() {
+  package_manager="$1"
+  attempt=1
+  max_attempts=6
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if "$package_manager" update; then
+      return 0
+    fi
+
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      printf 'OpenWrt package feed update failed; retrying in 5 seconds (%s/%s)\n' "$attempt" "$max_attempts" >&2
+      sleep 5
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
+  return 1
+}
+
 uci set network.lan='interface' &&
   uci set network.lan.proto='static' &&
   uci set network.lan.device='eth0' &&
@@ -39,16 +60,10 @@ yes | true | 1 | on)
   fi
 
   if command -v opkg >/dev/null 2>&1; then
-    opkg update || {
-      printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
-      exit 1
-    }
+    openwrt_update_package_feeds opkg || exit 1
     opkg install "$@" || exit 1
   elif command -v apk >/dev/null 2>&1; then
-    apk update || {
-      printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
-      exit 1
-    }
+    openwrt_update_package_feeds apk || exit 1
     apk add "$@" || exit 1
   else
     printf '%s\n' "opkg or apk is required to install OpenWrt interface packages" >&2

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env ash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: community-scripts ORG
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://openwrt.org/
+
+set -eu
+
+command -v uci >/dev/null 2>&1 || {
+  printf '%s\n' "uci is required to configure OpenWrt networking" >&2
+  exit 1
+}
+
+test -f /etc/config/network || {
+  printf '%s\n' "/etc/config/network is required to configure OpenWrt networking" >&2
+  exit 1
+}
+
+uci set network.lan='interface'
+uci set network.lan.proto='static'
+uci set network.lan.device='eth0'
+uci set network.lan.ipaddr='192.168.1.1'
+uci set network.lan.netmask='255.255.255.0'
+uci set network.wan='interface'
+uci set network.wan.proto='dhcp'
+uci set network.wan.device='eth1'
+uci commit network
+
+if [ -x /etc/init.d/network ]; then
+  /etc/init.d/network restart
+fi

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -27,6 +27,10 @@ uci set network.wan.proto='dhcp'
 uci set network.wan.device='eth1'
 uci commit network
 
+if command -v ubus >/dev/null 2>&1 && ubus list network >/dev/null 2>&1 && [ -x /etc/init.d/network ]; then
+  /etc/init.d/network reload >/dev/null 2>&1 || true
+fi
+
 var_interface="${OPENWRT_INTERFACE:-${var_interface:-yes}}"
 var_interface_packages="${OPENWRT_INTERFACE_PACKAGES:-${var_interface_packages:-luci}}"
 
@@ -46,10 +50,16 @@ yes | true | 1 | on)
   fi
 
   if command -v opkg >/dev/null 2>&1; then
-    opkg update
+    opkg update || {
+      printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
+      exit 1
+    }
     opkg install "$@"
   elif command -v apk >/dev/null 2>&1; then
-    apk update
+    apk update || {
+      printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
+      exit 1
+    }
     apk add "$@"
   else
     printf '%s\n' "opkg or apk is required to install OpenWrt interface packages" >&2
@@ -68,7 +78,3 @@ no | false | 0 | off)
   exit 1
   ;;
 esac
-
-if command -v ubus >/dev/null 2>&1 && ubus list network >/dev/null 2>&1 && [ -x /etc/init.d/network ]; then
-  /etc/init.d/network reload >/dev/null 2>&1 || true
-fi

--- a/install/openwrt-install.sh
+++ b/install/openwrt-install.sh
@@ -1,35 +1,21 @@
 #!/usr/bin/env ash
 
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: community-scripts ORG
+# Author: Mihael Zamin Sousa (mihazs)
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://openwrt.org/
 
-set -eu
+uci set network.lan='interface' &&
+  uci set network.lan.proto='static' &&
+  uci set network.lan.device='eth0' &&
+  uci set network.lan.ipaddr='192.168.1.1' &&
+  uci set network.lan.netmask='255.255.255.0' &&
+  uci set network.wan='interface' &&
+  uci set network.wan.proto='dhcp' &&
+  uci set network.wan.device='eth1' &&
+  uci commit network || exit 1
 
-command -v uci >/dev/null 2>&1 || {
-  printf '%s\n' "uci is required to configure OpenWrt networking" >&2
-  exit 1
-}
-
-test -f /etc/config/network || {
-  printf '%s\n' "/etc/config/network is required to configure OpenWrt networking" >&2
-  exit 1
-}
-
-uci set network.lan='interface'
-uci set network.lan.proto='static'
-uci set network.lan.device='eth0'
-uci set network.lan.ipaddr='192.168.1.1'
-uci set network.lan.netmask='255.255.255.0'
-uci set network.wan='interface'
-uci set network.wan.proto='dhcp'
-uci set network.wan.device='eth1'
-uci commit network
-
-if command -v ubus >/dev/null 2>&1 && ubus list network >/dev/null 2>&1 && [ -x /etc/init.d/network ]; then
-  /etc/init.d/network reload >/dev/null 2>&1 || true
-fi
+/etc/init.d/network reload >/dev/null 2>&1 || printf '%s\n' "OpenWrt network reload failed; package feed update will verify connectivity" >&2
 
 var_interface="${OPENWRT_INTERFACE:-${var_interface:-yes}}"
 var_interface_packages="${OPENWRT_INTERFACE_PACKAGES:-${var_interface_packages:-luci}}"
@@ -54,21 +40,21 @@ yes | true | 1 | on)
       printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
       exit 1
     }
-    opkg install "$@"
+    opkg install "$@" || exit 1
   elif command -v apk >/dev/null 2>&1; then
     apk update || {
       printf '%s\n' "OpenWrt package feed update failed after applying network configuration; verify WAN bridge, DHCP, DNS, and internet connectivity" >&2
       exit 1
     }
-    apk add "$@"
+    apk add "$@" || exit 1
   else
     printf '%s\n' "opkg or apk is required to install OpenWrt interface packages" >&2
     exit 1
   fi
 
   if [ -x /etc/init.d/uhttpd ]; then
-    /etc/init.d/uhttpd enable
-    /etc/init.d/uhttpd start
+    /etc/init.d/uhttpd enable || exit 1
+    /etc/init.d/uhttpd start || exit 1
   fi
   ;;
 no | false | 0 | off)

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -51,6 +51,10 @@
       "type": "warning"
     },
     {
+      "text": "This script does not change Proxmox host network interface, bridge CIDR, or gateway settings; it only attaches the new container NICs to the selected existing bridges.",
+      "type": "info"
+    },
+    {
       "text": "Default networking configures LAN on eth0 as 192.168.1.1/255.255.255.0 and WAN on eth1 via DHCP. Override the LAN address with var_lan_ipaddr and var_lan_netmask.",
       "type": "info"
     },

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -25,7 +25,7 @@
         "ram": 256,
         "hdd": 1,
         "os": "OpenWrt",
-        "version": "24.10"
+        "version": "25.12"
       }
     }
   ],

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -39,6 +39,10 @@
       "type": "warning"
     },
     {
+      "text": "The rootfs template is downloaded from LinuxContainers at images.linuxcontainers.org, not from official OpenWrt release artifacts; trust that third-party template source before routing production traffic.",
+      "type": "warning"
+    },
+    {
       "text": "Review WAN and LAN bridge assignments before routing production traffic, and never expose an unreviewed WAN bridge to untrusted networks.",
       "type": "warning"
     },

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -1,0 +1,58 @@
+{
+  "name": "OpenWrt",
+  "slug": "openwrt",
+  "categories": [
+    2,
+    4
+  ],
+  "date_created": "2026-06-16",
+  "type": "ct",
+  "updateable": false,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": null,
+  "documentation": "https://openwrt.org/docs/start",
+  "website": "https://openwrt.org/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/openwrt.webp",
+  "description": "OpenWrt is a Linux operating system for embedded devices and routers, configured here as an LXC container with LAN and WAN interfaces.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/openwrt.sh",
+      "config_path": "/etc/config/network",
+      "resources": {
+        "cpu": 1,
+        "ram": 256,
+        "hdd": 1,
+        "os": "OpenWrt",
+        "version": "24.10"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "OpenWrt LXC shares the Proxmox host kernel; packages that require unavailable kernel modules may not work.",
+      "type": "warning"
+    },
+    {
+      "text": "Review WAN and LAN bridge assignments before routing production traffic, and never expose an unreviewed WAN bridge to untrusted networks.",
+      "type": "warning"
+    },
+    {
+      "text": "If you set LAN or WAN VLAN tags, the selected Proxmox bridge must be VLAN-aware.",
+      "type": "warning"
+    },
+    {
+      "text": "Default networking configures LAN on eth0 as 192.168.1.1/255.255.255.0 and WAN on eth1 via DHCP.",
+      "type": "info"
+    },
+    {
+      "text": "LuCI is not installed by default; configure OpenWrt from the console or install a web interface after validating network access.",
+      "type": "info"
+    }
+  ]
+}

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -51,7 +51,7 @@
       "type": "warning"
     },
     {
-      "text": "Default networking configures LAN on eth0 as 192.168.1.1/255.255.255.0 and WAN on eth1 via DHCP.",
+      "text": "Default networking configures LAN on eth0 as 192.168.1.1/255.255.255.0 and WAN on eth1 via DHCP. Override the LAN address with var_lan_ipaddr and var_lan_netmask.",
       "type": "info"
     },
     {

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -10,7 +10,7 @@
   "updateable": false,
   "privileged": false,
   "has_arm": false,
-  "interface_port": null,
+  "interface_port": 80,
   "documentation": "https://openwrt.org/docs/start",
   "website": "https://openwrt.org/",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/openwrt.webp",
@@ -51,7 +51,7 @@
       "type": "info"
     },
     {
-      "text": "LuCI is not installed by default; configure OpenWrt from the console or install a web interface after validating network access.",
+      "text": "LuCI is installed by default. Set var_interface=no to skip the web interface, or set var_interface_packages to choose packages such as luci or jerrykuku/luci-theme-argon.",
       "type": "info"
     }
   ]

--- a/misc/build.func
+++ b/misc/build.func
@@ -488,6 +488,18 @@ preflight_container_id() {
 # - Warns but does not fail (local templates may be available)
 # ------------------------------------------------------------------------------
 preflight_template_connectivity() {
+  if [[ "${var_os:-}" == "openwrt" ]]; then
+    local http_code
+    http_code=$(curl -sS -o /dev/null -w "%{http_code}" -m 5 "https://images.linuxcontainers.org/meta/1.0/index-system" 2>/dev/null) || http_code="000"
+    if [[ "$http_code" =~ ^2[0-9]{2}$ || "$http_code" =~ ^3[0-9]{2}$ ]]; then
+      preflight_pass "Template server reachable (images.linuxcontainers.org)"
+    else
+      preflight_fail "LinuxContainers template index unreachable" 222
+      echo -e "    ${TAB}${INFO} Check internet connectivity or manually upload the OpenWrt rootfs template"
+    fi
+    return 0
+  fi
+
   # ARM64 uses custom template sources (GitHub/jenkins), not the pveam catalog
   if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
     preflight_pass "Template connectivity check skipped (ARM64 uses custom template source)"
@@ -528,6 +540,24 @@ preflight_template_connectivity() {
 # - Fails if no matching template can be found anywhere
 # ------------------------------------------------------------------------------
 preflight_template_available() {
+  if [[ "${var_os:-}" == "openwrt" ]]; then
+    local lxc_arch line
+    case "$(dpkg --print-architecture)" in
+    amd64 | arm64) lxc_arch="$(dpkg --print-architecture)" ;;
+    *)
+      preflight_fail "No OpenWrt LinuxContainers template mapping for architecture $(dpkg --print-architecture)" 207
+      return 0
+      ;;
+    esac
+    line=$(curl -fsSL "https://images.linuxcontainers.org/meta/1.0/index-system" | awk -F';' -v release="${var_version:-24.10}" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }')
+    if [[ -n "$line" ]]; then
+      preflight_pass "Template available online for OpenWrt ${var_version:-24.10} (${lxc_arch})"
+    else
+      preflight_fail "No OpenWrt ${var_version:-24.10} ${lxc_arch} template found in LinuxContainers index" 225
+    fi
+    return 0
+  fi
+
   # ARM64 uses custom template sources (GitHub/jenkins), not the pveam catalog
   if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
     preflight_pass "Template check skipped (ARM64 uses custom template source)"
@@ -4078,53 +4108,90 @@ start() {
 build_container() {
   #  if [ "$VERBOSE" == "yes" ]; then set -x; fi
 
-  NET_STRING="-net0 name=eth0,bridge=${BRG:-vmbr0}"
+  if [ "$var_os" == "openwrt" ]; then
+    local lan_bridge="${var_lan_bridge:-${BRG:-vmbr0}}"
+    local wan_bridge="${var_wan_bridge:-${BRG:-vmbr0}}"
+    local lan_vlan="${var_lan_vlan:-}"
+    local wan_vlan="${var_wan_vlan:-${VLAN:-}}"
+    local openwrt_mtu="${var_openwrt_mtu:-${MTU:-}}"
+    local lan_options=""
+    local wan_options=""
 
-  # MAC
-  if [[ -n "$MAC" ]]; then
-    case "$MAC" in
-    ,hwaddr=*) NET_STRING+="$MAC" ;;
-    *) NET_STRING+=",hwaddr=$MAC" ;;
+    if [[ -n "$lan_vlan" ]]; then
+      case "$lan_vlan" in
+      ,tag=*) lan_options+="$lan_vlan" ;;
+      *) lan_options+=",tag=$lan_vlan" ;;
+      esac
+    fi
+    if [[ -n "$wan_vlan" ]]; then
+      case "$wan_vlan" in
+      ,tag=*) wan_options+="$wan_vlan" ;;
+      *) wan_options+=",tag=$wan_vlan" ;;
+      esac
+    fi
+    if [[ -n "$openwrt_mtu" ]]; then
+      case "$openwrt_mtu" in
+      ,mtu=*)
+        lan_options+="$openwrt_mtu"
+        wan_options+="$openwrt_mtu"
+        ;;
+      *)
+        lan_options+=",mtu=$openwrt_mtu"
+        wan_options+=",mtu=$openwrt_mtu"
+        ;;
+      esac
+    fi
+
+    NET_STRING="-net0 name=eth0,bridge=${lan_bridge},ip=manual${lan_options} -net1 name=eth1,bridge=${wan_bridge},ip=dhcp${wan_options}"
+  else
+    NET_STRING="-net0 name=eth0,bridge=${BRG:-vmbr0}"
+
+    # MAC
+    if [[ -n "$MAC" ]]; then
+      case "$MAC" in
+      ,hwaddr=*) NET_STRING+="$MAC" ;;
+      *) NET_STRING+=",hwaddr=$MAC" ;;
+      esac
+    fi
+
+    # IP (always required, default dhcp)
+    NET_STRING+=",ip=${NET:-dhcp}"
+
+    # Gateway
+    if [[ -n "$GATE" ]]; then
+      case "$GATE" in
+      ,gw=*) NET_STRING+="$GATE" ;;
+      *) NET_STRING+=",gw=$GATE" ;;
+      esac
+    fi
+
+    # VLAN
+    if [[ -n "$VLAN" ]]; then
+      case "$VLAN" in
+      ,tag=*) NET_STRING+="$VLAN" ;;
+      *) NET_STRING+=",tag=$VLAN" ;;
+      esac
+    fi
+
+    # MTU
+    if [[ -n "$MTU" ]]; then
+      case "$MTU" in
+      ,mtu=*) NET_STRING+="$MTU" ;;
+      *) NET_STRING+=",mtu=$MTU" ;;
+      esac
+    fi
+
+    # IPv6 Handling
+    case "$IPV6_METHOD" in
+    auto) NET_STRING="$NET_STRING,ip6=auto" ;;
+    dhcp) NET_STRING="$NET_STRING,ip6=dhcp" ;;
+    static)
+      NET_STRING="$NET_STRING,ip6=$IPV6_ADDR"
+      [ -n "$IPV6_GATE" ] && NET_STRING="$NET_STRING,gw6=$IPV6_GATE"
+      ;;
+    none) ;;
     esac
   fi
-
-  # IP (always required, default dhcp)
-  NET_STRING+=",ip=${NET:-dhcp}"
-
-  # Gateway
-  if [[ -n "$GATE" ]]; then
-    case "$GATE" in
-    ,gw=*) NET_STRING+="$GATE" ;;
-    *) NET_STRING+=",gw=$GATE" ;;
-    esac
-  fi
-
-  # VLAN
-  if [[ -n "$VLAN" ]]; then
-    case "$VLAN" in
-    ,tag=*) NET_STRING+="$VLAN" ;;
-    *) NET_STRING+=",tag=$VLAN" ;;
-    esac
-  fi
-
-  # MTU
-  if [[ -n "$MTU" ]]; then
-    case "$MTU" in
-    ,mtu=*) NET_STRING+="$MTU" ;;
-    *) NET_STRING+=",mtu=$MTU" ;;
-    esac
-  fi
-
-  # IPv6 Handling
-  case "$IPV6_METHOD" in
-  auto) NET_STRING="$NET_STRING,ip6=auto" ;;
-  dhcp) NET_STRING="$NET_STRING,ip6=dhcp" ;;
-  static)
-    NET_STRING="$NET_STRING,ip6=$IPV6_ADDR"
-    [ -n "$IPV6_GATE" ] && NET_STRING="$NET_STRING,gw6=$IPV6_GATE"
-    ;;
-  none) ;;
-  esac
 
   # Build FEATURES string based on container type and user choices
   FEATURES=""
@@ -4148,7 +4215,9 @@ build_container() {
   # Build PCT_OPTIONS as string for export
   TEMP_DIR=$(mktemp -d)
   pushd "$TEMP_DIR" >/dev/null
-  if [ "$var_os" == "alpine" ]; then
+  if [ "$var_os" == "openwrt" ]; then
+    export FUNCTIONS_FILE_PATH=""
+  elif [ "$var_os" == "alpine" ]; then
     export FUNCTIONS_FILE_PATH="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/alpine-install.func")"
   else
     export FUNCTIONS_FILE_PATH="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func")"
@@ -4235,6 +4304,11 @@ $PCT_OPTIONS_STRING"
   -cores $CORE_COUNT
   -memory $RAM_SIZE
   -unprivileged $CT_TYPE"
+
+  if [ "$var_os" == "openwrt" ]; then
+    PCT_OPTIONS_STRING="$PCT_OPTIONS_STRING
+  -ostype unmanaged"
+  fi
 
   # Protection flag (if var_protection was set)
   if [ "${PROTECT_CT:-}" == "1" ] || [ "${PROTECT_CT:-}" == "yes" ]; then
@@ -4362,6 +4436,10 @@ $PCT_OPTIONS_STRING"
   # Configure USB passthrough for privileged containers
   configure_usb_passthrough() {
     if [[ "$CT_TYPE" != "0" ]]; then
+      return 0
+    fi
+    if [[ "${var_os:-}" == "openwrt" ]]; then
+      msg_info "Skipping automatic USB passthrough for OpenWrt"
       return 0
     fi
 
@@ -4525,8 +4603,8 @@ EOF
     fi
   done
 
-  # Wait for network (skip for Alpine initially)
-  if [ "$var_os" != "alpine" ]; then
+  # Wait for network (skip for Alpine/OpenWrt initially)
+  if [[ "$var_os" != "alpine" && "$var_os" != "openwrt" ]]; then
     msg_info "Waiting for network in LXC container"
 
     # Wait for IP assignment (IPv4 or IPv6)
@@ -4601,7 +4679,9 @@ EOF
 
   msg_info "Customizing LXC Container"
   # Continue with standard container setup
-  if [ "$var_os" == "alpine" ]; then
+  if [ "$var_os" == "openwrt" ]; then
+    sleep 3
+  elif [ "$var_os" == "alpine" ]; then
     sleep 3
     pct exec "$CTID" -- /bin/sh -c 'cat <<EOF >/etc/apk/repositories
 http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
@@ -4906,7 +4986,11 @@ PROFILE
 
   local _install_script
   _install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh")"
-  lxc-attach -n "$CTID" -- bash -c "$_install_script"
+  if [ "$var_os" == "openwrt" ]; then
+    lxc-attach -n "$CTID" -- /bin/ash -c "$_install_script"
+  else
+    lxc-attach -n "$CTID" -- bash -c "$_install_script"
+  fi
   local lxc_exit=$?
 
   set -Eeuo pipefail       # Re-enable error handling
@@ -5775,9 +5859,51 @@ create_lxc_container() {
     msg_ok "Downloaded ARM64 LXC template"
   }
 
+  linuxcontainers_arch() {
+    case "$ARCH" in
+    amd64 | arm64) echo "$ARCH" ;;
+    *) return 1 ;;
+    esac
+  }
+
+  resolve_openwrt_template() {
+    local lxc_arch openwrt_index line template_path build_id
+    lxc_arch="$(linuxcontainers_arch)" || {
+      msg_error "No OpenWrt LinuxContainers template mapping for architecture ${ARCH}"
+      exit 207
+    }
+    openwrt_index="https://images.linuxcontainers.org/meta/1.0/index-system"
+    line=$(curl -fsSL "$openwrt_index" | awk -F';' -v release="${PCT_OSVERSION:-24.10}" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }')
+    [[ -n "$line" ]] || {
+      msg_error "No OpenWrt ${PCT_OSVERSION:-24.10} ${lxc_arch} template found in LinuxContainers index"
+      exit 225
+    }
+    template_path=$(awk -F';' '{print $6}' <<<"$line")
+    build_id=$(awk -F';' '{print $5}' <<<"$line" | tr ':/' '--')
+    TEMPLATE="openwrt-${PCT_OSVERSION:-24.10}-${lxc_arch}-${build_id}-rootfs.tar.xz"
+    TEMPLATE_SOURCE="linuxcontainers"
+    OPENWRT_TEMPLATE_URL="https://images.linuxcontainers.org${template_path}rootfs.tar.xz"
+  }
+
+  download_openwrt_template() {
+    local dest="$1"
+    mkdir -p "$(dirname "$dest")" || {
+      msg_error "Cannot create OpenWrt template dir."
+      exit 207
+    }
+    msg_info "Downloading OpenWrt rootfs.tar.xz"
+    if ! curl -fsSL -o "$dest" "$OPENWRT_TEMPLATE_URL"; then
+      msg_error "Failed to download OpenWrt template from: $OPENWRT_TEMPLATE_URL"
+      exit 222
+    fi
+    msg_ok "Downloaded OpenWrt LXC template"
+  }
+
   download_template() {
     local dest="${1:-$TEMPLATE_PATH}"
-    if [[ "$ARCH" == "arm64" ]]; then
+    if [[ "$PCT_OSTYPE" == "openwrt" ]]; then
+      download_openwrt_template "$dest"
+    elif [[ "$ARCH" == "arm64" ]]; then
       download_arm64_template "$dest"
     else
       pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >>"${BUILD_LOG:-/dev/null}" 2>&1 || {
@@ -5902,7 +6028,30 @@ create_lxc_container() {
   # ------------------------------------------------------------------------------
   CUSTOM_TEMPLATE_VARIANT=""
 
-  if [[ "$ARCH" == "arm64" ]]; then
+  if [[ "$PCT_OSTYPE" == "openwrt" ]]; then
+    msg_info "Preparing OpenWrt template"
+    resolve_openwrt_template
+    TEMPLATE_PATH="$(pvesm path "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" 2>/dev/null || true)"
+    if [[ -z "$TEMPLATE_PATH" ]]; then
+      local _tpl_base
+      _tpl_base=$(awk -v s="$TEMPLATE_STORAGE" '
+        $0 ~ "^[^:]+:[[:space:]]*" s "$" {f=1; next}
+        f && /^[^[:space:]]/ {f=0}
+        f && $1 == "path" {print $2; exit}
+      ' /etc/pve/storage.cfg)
+      TEMPLATE_PATH="${_tpl_base:-/var/lib/vz}/template/cache/$TEMPLATE"
+    fi
+    if [[ ! -f "$TEMPLATE_PATH" ]]; then
+      download_openwrt_template "$TEMPLATE_PATH"
+    elif [[ "$(stat -c%s "$TEMPLATE_PATH")" -lt 1000000 ]] || ! tar -tf "$TEMPLATE_PATH" &>/dev/null; then
+      msg_warn "Local OpenWrt template invalid - re-downloading."
+      rm -f "$TEMPLATE_PATH"
+      download_openwrt_template "$TEMPLATE_PATH"
+    else
+      msg_ok "Template ${BL}$TEMPLATE${CL} found locally."
+    fi
+
+  elif [[ "$ARCH" == "arm64" ]]; then
     # ARM64: use custom template download from linuxcontainers.org / GitHub
     msg_info "Preparing ARM64 template"
 
@@ -6185,7 +6334,7 @@ create_lxc_container() {
       done
     fi
 
-    if ! pveam list "$TEMPLATE_STORAGE" 2>/dev/null | grep -q "$TEMPLATE"; then
+    if [[ "$PCT_OSTYPE" != "openwrt" ]] && ! pveam list "$TEMPLATE_STORAGE" 2>/dev/null | grep -q "$TEMPLATE"; then
       msg_error "Template $TEMPLATE not available in storage $TEMPLATE_STORAGE after download."
       exit 223
     fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -5011,12 +5011,18 @@ PROFILE
   # Start timer for duration tracking
   start_install_timer
 
+  local _install_script
+  local _install_script_url="$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh"
+  _install_script="$(curl -fsSL "$_install_script_url")" || {
+    local _download_exit=$?
+    msg_error "Failed to download install script from: $_install_script_url"
+    return "$_download_exit"
+  }
+
   # Disable error trap - container errors are handled internally via flag file
   set +Eeuo pipefail # Disable ALL error handling temporarily
   trap - ERR         # Remove ERR trap completely
 
-  local _install_script
-  _install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh")"
   if [ "$var_os" == "openwrt" ]; then
     lxc-attach -n "$CTID" -- /bin/ash -c "$_install_script"
   else
@@ -5340,11 +5346,16 @@ PROFILE
           msg_info "Re-running installation script..."
 
           # Re-run install script in existing container (don't destroy/recreate)
+          local _install_script
+          local _install_script_url="$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh"
+          _install_script="$(curl -fsSL "$_install_script_url")" || {
+            local _download_exit=$?
+            msg_error "Failed to download install script from: $_install_script_url"
+            return "$_download_exit"
+          }
           set +Eeuo pipefail
           trap - ERR
           local _LXC_CAPTURE_LOG="/tmp/.install-capture-${SESSION_ID}.log"
-          local _install_script
-          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/install/${var_install}.sh")"
           lxc-attach -n "$CTID" -- bash -c "$_install_script" 2>&1 | tee "$_LXC_CAPTURE_LOG"
           local apt_retry_exit=${PIPESTATUS[0]}
           set -Eeuo pipefail

--- a/misc/build.func
+++ b/misc/build.func
@@ -532,6 +532,20 @@ preflight_template_connectivity() {
   return 0
 }
 
+openwrt_normalize_release() {
+  local requested="${1:-latest}"
+  case "$requested" in
+  "" | latest | stable) echo "latest" ;;
+  snapshot) echo "snapshot" ;;
+  [0-9]*.[0-9]*.[0-9]*) echo "${requested%.*}" ;;
+  *) echo "$requested" ;;
+  esac
+}
+
+openwrt_latest_stable_release() {
+  awk -F';' '$1 == "openwrt" && $2 != "snapshot" { print $2 }' | sort -uV | tail -n1
+}
+
 # ------------------------------------------------------------------------------
 # preflight_template_available()
 #
@@ -541,7 +555,7 @@ preflight_template_connectivity() {
 # ------------------------------------------------------------------------------
 preflight_template_available() {
   if [[ "${var_os:-}" == "openwrt" ]]; then
-    local lxc_arch line
+    local lxc_arch openwrt_index index requested_release release line
     case "$(dpkg --print-architecture)" in
     amd64 | arm64) lxc_arch="$(dpkg --print-architecture)" ;;
     *)
@@ -549,11 +563,28 @@ preflight_template_available() {
       return 0
       ;;
     esac
-    line=$(curl -fsSL "https://images.linuxcontainers.org/meta/1.0/index-system" | awk -F';' -v release="${var_version:-24.10}" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }')
-    if [[ -n "$line" ]]; then
-      preflight_pass "Template available online for OpenWrt ${var_version:-24.10} (${lxc_arch})"
+    openwrt_index="https://images.linuxcontainers.org/meta/1.0/index-system"
+    index=$(curl -fsSL "$openwrt_index") || {
+      preflight_fail "LinuxContainers template index unreachable" 222
+      echo -e "    ${TAB}${INFO} Check internet connectivity or manually upload the OpenWrt rootfs template"
+      return 0
+    }
+    requested_release="$(openwrt_normalize_release "${var_version:-latest}")"
+    if [[ "$requested_release" == "latest" ]]; then
+      release="$(printf "%s\n" "$index" | openwrt_latest_stable_release)"
     else
-      preflight_fail "No OpenWrt ${var_version:-24.10} ${lxc_arch} template found in LinuxContainers index" 225
+      release="$requested_release"
+    fi
+    if [[ -z "$release" ]]; then
+      preflight_fail "No stable OpenWrt release found in LinuxContainers index" 225
+      return 0
+    fi
+    line=$(awk -F';' -v release="$release" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }' <<<"$index")
+    if [[ -n "$line" ]]; then
+      var_version="$release"
+      preflight_pass "Template available online for OpenWrt ${release} (${lxc_arch})"
+    else
+      preflight_fail "No OpenWrt ${release} ${lxc_arch} template found in LinuxContainers index" 225
     fi
     return 0
   fi
@@ -5867,20 +5898,37 @@ create_lxc_container() {
   }
 
   resolve_openwrt_template() {
-    local lxc_arch openwrt_index line template_path build_id
+    local lxc_arch openwrt_index index requested_release release line template_path build_id
     lxc_arch="$(linuxcontainers_arch)" || {
       msg_error "No OpenWrt LinuxContainers template mapping for architecture ${ARCH}"
       exit 207
     }
     openwrt_index="https://images.linuxcontainers.org/meta/1.0/index-system"
-    line=$(curl -fsSL "$openwrt_index" | awk -F';' -v release="${PCT_OSVERSION:-24.10}" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }')
-    [[ -n "$line" ]] || {
-      msg_error "No OpenWrt ${PCT_OSVERSION:-24.10} ${lxc_arch} template found in LinuxContainers index"
+    index=$(curl -fsSL "$openwrt_index") || {
+      msg_error "Failed to read OpenWrt LinuxContainers index"
+      exit 222
+    }
+    requested_release="$(openwrt_normalize_release "${PCT_OSVERSION:-latest}")"
+    if [[ "$requested_release" == "latest" ]]; then
+      release="$(printf "%s\n" "$index" | openwrt_latest_stable_release)"
+    else
+      release="$requested_release"
+    fi
+    [[ -n "$release" ]] || {
+      msg_error "No stable OpenWrt release found in LinuxContainers index"
       exit 225
     }
+    line=$(awk -F';' -v release="$release" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }' <<<"$index")
+    [[ -n "$line" ]] || {
+      msg_error "No OpenWrt ${release} ${lxc_arch} template found in LinuxContainers index"
+      exit 225
+    }
+    PCT_OSVERSION="$release"
+    var_version="$release"
+    export PCT_OSVERSION var_version
     template_path=$(awk -F';' '{print $6}' <<<"$line")
     build_id=$(awk -F';' '{print $5}' <<<"$line" | tr ':/' '--')
-    TEMPLATE="openwrt-${PCT_OSVERSION:-24.10}-${lxc_arch}-${build_id}-rootfs.tar.xz"
+    TEMPLATE="openwrt-${release}-${lxc_arch}-${build_id}-rootfs.tar.xz"
     TEMPLATE_SOURCE="linuxcontainers"
     OPENWRT_TEMPLATE_URL="https://images.linuxcontainers.org${template_path}rootfs.tar.xz"
   }

--- a/misc/build.func
+++ b/misc/build.func
@@ -1622,7 +1622,7 @@ load_vars_file() {
 
   # Allowed var_* keys
   local VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_keyctl
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages var_keyctl
     var_gateway var_hostname var_ipv6_method var_mac var_mknod var_mount_fs var_mtu
     var_net var_nesting var_ns var_protection var_pw var_ram var_tags var_timezone var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage
@@ -1761,7 +1761,7 @@ load_vars_file() {
             fi
           fi
           ;;
-        var_fuse | var_tun | var_gpu | var_ssh | var_verbose | var_protection)
+        var_fuse | var_interface | var_tun | var_gpu | var_ssh | var_verbose | var_protection)
           if [[ "$var_val" != "yes" && "$var_val" != "no" ]]; then
             msg_warn "Invalid boolean '$var_val' for $var_key in $file (must be yes/no), ignoring"
             continue
@@ -1800,7 +1800,7 @@ default_var_settings() {
   # Allowed var_* keys (alphabetically sorted)
   # Note: Removed var_ctid (can only exist once), var_ipv6_static (static IPs are unique)
   local VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_keyctl
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages var_keyctl
     var_gateway var_hostname var_ipv6_method var_mac var_mknod var_mount_fs var_mtu
     var_net var_nesting var_ns var_protection var_pw var_ram var_tags var_timezone var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage
@@ -1962,7 +1962,7 @@ get_app_defaults_path() {
 if ! declare -p VAR_WHITELIST >/dev/null 2>&1; then
   # Note: Removed var_ctid (can only exist once), var_ipv6_static (static IPs are unique)
   declare -ag VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages
     var_gateway var_hostname var_ipv6_method var_mac var_mtu
     var_net var_ns var_pw var_ram var_tags var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage
@@ -4296,6 +4296,8 @@ build_container() {
   export DEV_MODE_BREAKPOINT="${DEV_MODE_BREAKPOINT:-false}"
   export DEV_MODE_LOGS="${DEV_MODE_LOGS:-false}"
   export DEV_MODE_DRYRUN="${DEV_MODE_DRYRUN:-false}"
+  export OPENWRT_INTERFACE="${var_interface:-yes}"
+  export OPENWRT_INTERFACE_PACKAGES="${var_interface_packages:-luci}"
 
   # MODE export for unattended detection in install scripts
   # This tells install scripts whether to prompt for input or use defaults

--- a/misc/build.func
+++ b/misc/build.func
@@ -488,18 +488,6 @@ preflight_container_id() {
 # - Warns but does not fail (local templates may be available)
 # ------------------------------------------------------------------------------
 preflight_template_connectivity() {
-  if [[ "${var_os:-}" == "openwrt" ]]; then
-    local http_code
-    http_code=$(curl -sS -o /dev/null -w "%{http_code}" -m 5 "https://images.linuxcontainers.org/meta/1.0/index-system" 2>/dev/null) || http_code="000"
-    if [[ "$http_code" =~ ^2[0-9]{2}$ || "$http_code" =~ ^3[0-9]{2}$ ]]; then
-      preflight_pass "Template server reachable (images.linuxcontainers.org)"
-    else
-      preflight_fail "LinuxContainers template index unreachable" 222
-      echo -e "    ${TAB}${INFO} Check internet connectivity or manually upload the OpenWrt rootfs template"
-    fi
-    return 0
-  fi
-
   # ARM64 uses custom template sources (GitHub/jenkins), not the pveam catalog
   if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
     preflight_pass "Template connectivity check skipped (ARM64 uses custom template source)"
@@ -532,20 +520,6 @@ preflight_template_connectivity() {
   return 0
 }
 
-openwrt_normalize_release() {
-  local requested="${1:-latest}"
-  case "$requested" in
-  "" | latest | stable) echo "latest" ;;
-  snapshot) echo "snapshot" ;;
-  [0-9]*.[0-9]*.[0-9]*) echo "${requested%.*}" ;;
-  *) echo "$requested" ;;
-  esac
-}
-
-openwrt_latest_stable_release() {
-  awk -F';' '$1 == "openwrt" && $2 != "snapshot" { print $2 }' | sort -uV | tail -n1
-}
-
 # ------------------------------------------------------------------------------
 # preflight_template_available()
 #
@@ -554,41 +528,6 @@ openwrt_latest_stable_release() {
 # - Fails if no matching template can be found anywhere
 # ------------------------------------------------------------------------------
 preflight_template_available() {
-  if [[ "${var_os:-}" == "openwrt" ]]; then
-    local lxc_arch openwrt_index index requested_release release line
-    case "$(dpkg --print-architecture)" in
-    amd64 | arm64) lxc_arch="$(dpkg --print-architecture)" ;;
-    *)
-      preflight_fail "No OpenWrt LinuxContainers template mapping for architecture $(dpkg --print-architecture)" 207
-      return 0
-      ;;
-    esac
-    openwrt_index="https://images.linuxcontainers.org/meta/1.0/index-system"
-    index=$(curl -fsSL "$openwrt_index") || {
-      preflight_fail "LinuxContainers template index unreachable" 222
-      echo -e "    ${TAB}${INFO} Check internet connectivity or manually upload the OpenWrt rootfs template"
-      return 0
-    }
-    requested_release="$(openwrt_normalize_release "${var_version:-latest}")"
-    if [[ "$requested_release" == "latest" ]]; then
-      release="$(printf "%s\n" "$index" | openwrt_latest_stable_release)"
-    else
-      release="$requested_release"
-    fi
-    if [[ -z "$release" ]]; then
-      preflight_fail "No stable OpenWrt release found in LinuxContainers index" 225
-      return 0
-    fi
-    line=$(awk -F';' -v release="$release" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }' <<<"$index")
-    if [[ -n "$line" ]]; then
-      var_version="$release"
-      preflight_pass "Template available online for OpenWrt ${release} (${lxc_arch})"
-    else
-      preflight_fail "No OpenWrt ${release} ${lxc_arch} template found in LinuxContainers index" 225
-    fi
-    return 0
-  fi
-
   # ARM64 uses custom template sources (GitHub/jenkins), not the pveam catalog
   if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
     preflight_pass "Template check skipped (ARM64 uses custom template source)"
@@ -4139,90 +4078,53 @@ start() {
 build_container() {
   #  if [ "$VERBOSE" == "yes" ]; then set -x; fi
 
-  if [ "$var_os" == "openwrt" ]; then
-    local lan_bridge="${var_lan_bridge:-${BRG:-vmbr0}}"
-    local wan_bridge="${var_wan_bridge:-${BRG:-vmbr0}}"
-    local lan_vlan="${var_lan_vlan:-}"
-    local wan_vlan="${var_wan_vlan:-${VLAN:-}}"
-    local openwrt_mtu="${var_openwrt_mtu:-${MTU:-}}"
-    local lan_options=""
-    local wan_options=""
+  NET_STRING="-net0 name=eth0,bridge=${BRG:-vmbr0}"
 
-    if [[ -n "$lan_vlan" ]]; then
-      case "$lan_vlan" in
-      ,tag=*) lan_options+="$lan_vlan" ;;
-      *) lan_options+=",tag=$lan_vlan" ;;
-      esac
-    fi
-    if [[ -n "$wan_vlan" ]]; then
-      case "$wan_vlan" in
-      ,tag=*) wan_options+="$wan_vlan" ;;
-      *) wan_options+=",tag=$wan_vlan" ;;
-      esac
-    fi
-    if [[ -n "$openwrt_mtu" ]]; then
-      case "$openwrt_mtu" in
-      ,mtu=*)
-        lan_options+="$openwrt_mtu"
-        wan_options+="$openwrt_mtu"
-        ;;
-      *)
-        lan_options+=",mtu=$openwrt_mtu"
-        wan_options+=",mtu=$openwrt_mtu"
-        ;;
-      esac
-    fi
-
-    NET_STRING="-net0 name=eth0,bridge=${lan_bridge},ip=manual${lan_options} -net1 name=eth1,bridge=${wan_bridge},ip=dhcp${wan_options}"
-  else
-    NET_STRING="-net0 name=eth0,bridge=${BRG:-vmbr0}"
-
-    # MAC
-    if [[ -n "$MAC" ]]; then
-      case "$MAC" in
-      ,hwaddr=*) NET_STRING+="$MAC" ;;
-      *) NET_STRING+=",hwaddr=$MAC" ;;
-      esac
-    fi
-
-    # IP (always required, default dhcp)
-    NET_STRING+=",ip=${NET:-dhcp}"
-
-    # Gateway
-    if [[ -n "$GATE" ]]; then
-      case "$GATE" in
-      ,gw=*) NET_STRING+="$GATE" ;;
-      *) NET_STRING+=",gw=$GATE" ;;
-      esac
-    fi
-
-    # VLAN
-    if [[ -n "$VLAN" ]]; then
-      case "$VLAN" in
-      ,tag=*) NET_STRING+="$VLAN" ;;
-      *) NET_STRING+=",tag=$VLAN" ;;
-      esac
-    fi
-
-    # MTU
-    if [[ -n "$MTU" ]]; then
-      case "$MTU" in
-      ,mtu=*) NET_STRING+="$MTU" ;;
-      *) NET_STRING+=",mtu=$MTU" ;;
-      esac
-    fi
-
-    # IPv6 Handling
-    case "$IPV6_METHOD" in
-    auto) NET_STRING="$NET_STRING,ip6=auto" ;;
-    dhcp) NET_STRING="$NET_STRING,ip6=dhcp" ;;
-    static)
-      NET_STRING="$NET_STRING,ip6=$IPV6_ADDR"
-      [ -n "$IPV6_GATE" ] && NET_STRING="$NET_STRING,gw6=$IPV6_GATE"
-      ;;
-    none) ;;
+  # MAC
+  if [[ -n "$MAC" ]]; then
+    case "$MAC" in
+    ,hwaddr=*) NET_STRING+="$MAC" ;;
+    *) NET_STRING+=",hwaddr=$MAC" ;;
     esac
   fi
+
+  # IP (always required, default dhcp)
+  NET_STRING+=",ip=${NET:-dhcp}"
+
+  # Gateway
+  if [[ -n "$GATE" ]]; then
+    case "$GATE" in
+    ,gw=*) NET_STRING+="$GATE" ;;
+    *) NET_STRING+=",gw=$GATE" ;;
+    esac
+  fi
+
+  # VLAN
+  if [[ -n "$VLAN" ]]; then
+    case "$VLAN" in
+    ,tag=*) NET_STRING+="$VLAN" ;;
+    *) NET_STRING+=",tag=$VLAN" ;;
+    esac
+  fi
+
+  # MTU
+  if [[ -n "$MTU" ]]; then
+    case "$MTU" in
+    ,mtu=*) NET_STRING+="$MTU" ;;
+    *) NET_STRING+=",mtu=$MTU" ;;
+    esac
+  fi
+
+  # IPv6 Handling
+  case "$IPV6_METHOD" in
+  auto) NET_STRING="$NET_STRING,ip6=auto" ;;
+  dhcp) NET_STRING="$NET_STRING,ip6=dhcp" ;;
+  static)
+    NET_STRING="$NET_STRING,ip6=$IPV6_ADDR"
+    [ -n "$IPV6_GATE" ] && NET_STRING="$NET_STRING,gw6=$IPV6_GATE"
+    ;;
+  none) ;;
+  esac
 
   # Build FEATURES string based on container type and user choices
   FEATURES=""
@@ -4246,9 +4148,7 @@ build_container() {
   # Build PCT_OPTIONS as string for export
   TEMP_DIR=$(mktemp -d)
   pushd "$TEMP_DIR" >/dev/null
-  if [ "$var_os" == "openwrt" ]; then
-    export FUNCTIONS_FILE_PATH=""
-  elif [ "$var_os" == "alpine" ]; then
+  if [ "$var_os" == "alpine" ]; then
     export FUNCTIONS_FILE_PATH="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/alpine-install.func")"
   else
     export FUNCTIONS_FILE_PATH="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func")"
@@ -4296,8 +4196,6 @@ build_container() {
   export DEV_MODE_BREAKPOINT="${DEV_MODE_BREAKPOINT:-false}"
   export DEV_MODE_LOGS="${DEV_MODE_LOGS:-false}"
   export DEV_MODE_DRYRUN="${DEV_MODE_DRYRUN:-false}"
-  export OPENWRT_INTERFACE="${var_interface:-yes}"
-  export OPENWRT_INTERFACE_PACKAGES="${var_interface_packages:-luci}"
 
   # MODE export for unattended detection in install scripts
   # This tells install scripts whether to prompt for input or use defaults
@@ -4337,11 +4235,6 @@ $PCT_OPTIONS_STRING"
   -cores $CORE_COUNT
   -memory $RAM_SIZE
   -unprivileged $CT_TYPE"
-
-  if [ "$var_os" == "openwrt" ]; then
-    PCT_OPTIONS_STRING="$PCT_OPTIONS_STRING
-  -ostype unmanaged"
-  fi
 
   # Protection flag (if var_protection was set)
   if [ "${PROTECT_CT:-}" == "1" ] || [ "${PROTECT_CT:-}" == "yes" ]; then
@@ -4471,6 +4364,7 @@ $PCT_OPTIONS_STRING"
     if [[ "$CT_TYPE" != "0" ]]; then
       return 0
     fi
+
     msg_info "Configuring automatic USB passthrough (privileged container)"
     cat <<EOF >>"$LXC_CONFIG"
 # Automatic USB passthrough (privileged container)
@@ -4631,8 +4525,8 @@ EOF
     fi
   done
 
-  # Wait for network (skip for Alpine/OpenWrt initially)
-  if [[ "$var_os" != "alpine" && "$var_os" != "openwrt" ]]; then
+  # Wait for network (skip for Alpine initially)
+  if [ "$var_os" != "alpine" ]; then
     msg_info "Waiting for network in LXC container"
 
     # Wait for IP assignment (IPv4 or IPv6)
@@ -4707,9 +4601,7 @@ EOF
 
   msg_info "Customizing LXC Container"
   # Continue with standard container setup
-  if [ "$var_os" == "openwrt" ]; then
-    sleep 3
-  elif [ "$var_os" == "alpine" ]; then
+  if [ "$var_os" == "alpine" ]; then
     sleep 3
     pct exec "$CTID" -- /bin/sh -c 'cat <<EOF >/etc/apk/repositories
 http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
@@ -5014,11 +4906,7 @@ PROFILE
 
   local _install_script
   _install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh")"
-  if [ "$var_os" == "openwrt" ]; then
-    lxc-attach -n "$CTID" -- /bin/ash -c "$_install_script"
-  else
-    lxc-attach -n "$CTID" -- bash -c "$_install_script"
-  fi
+  lxc-attach -n "$CTID" -- bash -c "$_install_script"
   local lxc_exit=$?
 
   set -Eeuo pipefail       # Re-enable error handling
@@ -5887,68 +5775,9 @@ create_lxc_container() {
     msg_ok "Downloaded ARM64 LXC template"
   }
 
-  linuxcontainers_arch() {
-    case "$ARCH" in
-    amd64 | arm64) echo "$ARCH" ;;
-    *) return 1 ;;
-    esac
-  }
-
-  resolve_openwrt_template() {
-    local lxc_arch openwrt_index index requested_release release line template_path build_id
-    lxc_arch="$(linuxcontainers_arch)" || {
-      msg_error "No OpenWrt LinuxContainers template mapping for architecture ${ARCH}"
-      exit 207
-    }
-    openwrt_index="https://images.linuxcontainers.org/meta/1.0/index-system"
-    index=$(curl -fsSL "$openwrt_index") || {
-      msg_error "Failed to read OpenWrt LinuxContainers index"
-      exit 222
-    }
-    requested_release="$(openwrt_normalize_release "${PCT_OSVERSION:-latest}")"
-    if [[ "$requested_release" == "latest" ]]; then
-      release="$(printf "%s\n" "$index" | openwrt_latest_stable_release)"
-    else
-      release="$requested_release"
-    fi
-    [[ -n "$release" ]] || {
-      msg_error "No stable OpenWrt release found in LinuxContainers index"
-      exit 225
-    }
-    line=$(awk -F';' -v release="$release" -v arch="$lxc_arch" '$1 == "openwrt" && $2 == release && $3 == arch && $4 == "default" { selected = $0 } END { print selected }' <<<"$index")
-    [[ -n "$line" ]] || {
-      msg_error "No OpenWrt ${release} ${lxc_arch} template found in LinuxContainers index"
-      exit 225
-    }
-    PCT_OSVERSION="$release"
-    var_version="$release"
-    export PCT_OSVERSION var_version
-    template_path=$(awk -F';' '{print $6}' <<<"$line")
-    build_id=$(awk -F';' '{print $5}' <<<"$line" | tr ':/' '--')
-    TEMPLATE="openwrt-${release}-${lxc_arch}-${build_id}-rootfs.tar.xz"
-    TEMPLATE_SOURCE="linuxcontainers"
-    OPENWRT_TEMPLATE_URL="https://images.linuxcontainers.org${template_path}rootfs.tar.xz"
-  }
-
-  download_openwrt_template() {
-    local dest="$1"
-    mkdir -p "$(dirname "$dest")" || {
-      msg_error "Cannot create OpenWrt template dir."
-      exit 207
-    }
-    msg_info "Downloading OpenWrt rootfs.tar.xz"
-    if ! curl -fsSL -o "$dest" "$OPENWRT_TEMPLATE_URL"; then
-      msg_error "Failed to download OpenWrt template from: $OPENWRT_TEMPLATE_URL"
-      exit 222
-    fi
-    msg_ok "Downloaded OpenWrt LXC template"
-  }
-
   download_template() {
     local dest="${1:-$TEMPLATE_PATH}"
-    if [[ "$PCT_OSTYPE" == "openwrt" ]]; then
-      download_openwrt_template "$dest"
-    elif [[ "$ARCH" == "arm64" ]]; then
+    if [[ "$ARCH" == "arm64" ]]; then
       download_arm64_template "$dest"
     else
       pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >>"${BUILD_LOG:-/dev/null}" 2>&1 || {
@@ -6073,30 +5902,7 @@ create_lxc_container() {
   # ------------------------------------------------------------------------------
   CUSTOM_TEMPLATE_VARIANT=""
 
-  if [[ "$PCT_OSTYPE" == "openwrt" ]]; then
-    msg_info "Preparing OpenWrt template"
-    resolve_openwrt_template
-    TEMPLATE_PATH="$(pvesm path "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" 2>/dev/null || true)"
-    if [[ -z "$TEMPLATE_PATH" ]]; then
-      local _tpl_base
-      _tpl_base=$(awk -v s="$TEMPLATE_STORAGE" '
-        $0 ~ "^[^:]+:[[:space:]]*" s "$" {f=1; next}
-        f && /^[^[:space:]]/ {f=0}
-        f && $1 == "path" {print $2; exit}
-      ' /etc/pve/storage.cfg)
-      TEMPLATE_PATH="${_tpl_base:-/var/lib/vz}/template/cache/$TEMPLATE"
-    fi
-    if [[ ! -f "$TEMPLATE_PATH" ]]; then
-      download_openwrt_template "$TEMPLATE_PATH"
-    elif [[ "$(stat -c%s "$TEMPLATE_PATH")" -lt 1000000 ]] || ! tar -tf "$TEMPLATE_PATH" &>/dev/null; then
-      msg_warn "Local OpenWrt template invalid - re-downloading."
-      rm -f "$TEMPLATE_PATH"
-      download_openwrt_template "$TEMPLATE_PATH"
-    else
-      msg_ok "Template ${BL}$TEMPLATE${CL} found locally."
-    fi
-
-  elif [[ "$ARCH" == "arm64" ]]; then
+  if [[ "$ARCH" == "arm64" ]]; then
     # ARM64: use custom template download from linuxcontainers.org / GitHub
     msg_info "Preparing ARM64 template"
 
@@ -6379,7 +6185,7 @@ create_lxc_container() {
       done
     fi
 
-    if [[ "$PCT_OSTYPE" != "openwrt" ]] && ! pveam list "$TEMPLATE_STORAGE" 2>/dev/null | grep -q "$TEMPLATE"; then
+    if ! pveam list "$TEMPLATE_STORAGE" 2>/dev/null | grep -q "$TEMPLATE"; then
       msg_error "Template $TEMPLATE not available in storage $TEMPLATE_STORAGE after download."
       exit 223
     fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -4471,11 +4471,6 @@ $PCT_OPTIONS_STRING"
     if [[ "$CT_TYPE" != "0" ]]; then
       return 0
     fi
-    if [[ "${var_os:-}" == "openwrt" ]]; then
-      msg_info "Skipping automatic USB passthrough for OpenWrt"
-      return 0
-    fi
-
     msg_info "Configuring automatic USB passthrough (privileged container)"
     cat <<EOF >>"$LXC_CONFIG"
 # Automatic USB passthrough (privileged container)
@@ -5013,18 +5008,12 @@ PROFILE
   # Start timer for duration tracking
   start_install_timer
 
-  local _install_script
-  local _install_script_url="$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh"
-  _install_script="$(curl -fsSL "$_install_script_url")" || {
-    local _download_exit=$?
-    msg_error "Failed to download install script from: $_install_script_url"
-    return "$_download_exit"
-  }
-
   # Disable error trap - container errors are handled internally via flag file
   set +Eeuo pipefail # Disable ALL error handling temporarily
   trap - ERR         # Remove ERR trap completely
 
+  local _install_script
+  _install_script="$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh")"
   if [ "$var_os" == "openwrt" ]; then
     lxc-attach -n "$CTID" -- /bin/ash -c "$_install_script"
   else
@@ -5348,16 +5337,11 @@ PROFILE
           msg_info "Re-running installation script..."
 
           # Re-run install script in existing container (don't destroy/recreate)
-          local _install_script
-          local _install_script_url="$COMMUNITY_SCRIPTS_URL/install/${var_install}.sh"
-          _install_script="$(curl -fsSL "$_install_script_url")" || {
-            local _download_exit=$?
-            msg_error "Failed to download install script from: $_install_script_url"
-            return "$_download_exit"
-          }
           set +Eeuo pipefail
           trap - ERR
           local _LXC_CAPTURE_LOG="/tmp/.install-capture-${SESSION_ID}.log"
+          local _install_script
+          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/install/${var_install}.sh")"
           lxc-attach -n "$CTID" -- bash -c "$_install_script" 2>&1 | tee "$_LXC_CAPTURE_LOG"
           local apt_retry_exit=${PIPESTATUS[0]}
           set -Eeuo pipefail

--- a/misc/build.func
+++ b/misc/build.func
@@ -1622,7 +1622,7 @@ load_vars_file() {
 
   # Allowed var_* keys
   local VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages var_keyctl
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_keyctl
     var_gateway var_hostname var_ipv6_method var_mac var_mknod var_mount_fs var_mtu
     var_net var_nesting var_ns var_protection var_pw var_ram var_tags var_timezone var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage
@@ -1761,7 +1761,7 @@ load_vars_file() {
             fi
           fi
           ;;
-        var_fuse | var_interface | var_tun | var_gpu | var_ssh | var_verbose | var_protection)
+        var_fuse | var_tun | var_gpu | var_ssh | var_verbose | var_protection)
           if [[ "$var_val" != "yes" && "$var_val" != "no" ]]; then
             msg_warn "Invalid boolean '$var_val' for $var_key in $file (must be yes/no), ignoring"
             continue
@@ -1800,7 +1800,7 @@ default_var_settings() {
   # Allowed var_* keys (alphabetically sorted)
   # Note: Removed var_ctid (can only exist once), var_ipv6_static (static IPs are unique)
   local VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages var_keyctl
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_keyctl
     var_gateway var_hostname var_ipv6_method var_mac var_mknod var_mount_fs var_mtu
     var_net var_nesting var_ns var_protection var_pw var_ram var_tags var_timezone var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage
@@ -1962,7 +1962,7 @@ get_app_defaults_path() {
 if ! declare -p VAR_WHITELIST >/dev/null 2>&1; then
   # Note: Removed var_ctid (can only exist once), var_ipv6_static (static IPs are unique)
   declare -ag VAR_WHITELIST=(
-    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu var_interface var_interface_packages
+    var_apt_cacher var_apt_cacher_ip var_brg var_cpu var_disk var_fuse var_gpu
     var_gateway var_hostname var_ipv6_method var_mac var_mtu
     var_net var_ns var_pw var_ram var_tags var_tun var_unprivileged
     var_verbose var_vlan var_ssh var_ssh_authorized_key var_container_storage var_template_storage


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description
Adds OpenWrt LXC support using LinuxContainers OpenWrt rootfs images.

Current PR scope is limited to the new script files:
- `ct/openwrt.sh`
- `install/openwrt-install.sh`
- `json/openwrt.json`

There are no `misc/build.func` changes in the current PR diff. OpenWrt-specific behavior is local to `ct/openwrt.sh`, including LinuxContainers template resolution/download, unmanaged `pct create`, LAN/WAN NIC setup, TUN config, and `/bin/ash` install execution.

OpenWrt-specific notes:
- Defaults to an unprivileged CT.
- Uses LinuxContainers OpenWrt images because Proxmox templates do not reliably include OpenWrt.
- Uses `ostype unmanaged` and OpenWrt `ash`/`uci` conventions.
- Installs LuCI by default, so `interface_port` is `80`; set `var_interface=no` to skip the web interface.
- Configures LAN on `eth0` as `192.168.1.1/24` by default and WAN on `eth1` via DHCP; override LAN defaults with `var_lan_ipaddr` and `var_lan_netmask`.
- Requires LAN and WAN bridges to differ by default; set `var_allow_same_bridge=yes` only after reviewing that topology.

Validation performed:
- `bash /tmp/openwrt-review-regression-check.sh /tmp/opencode/ProxmoxVED-openwrt-pr1932`
- `bash -n ct/openwrt.sh install/openwrt-install.sh misc/build.func`
- `shellcheck -e SC1090 -s bash ct/openwrt.sh`
- `shellcheck -s sh install/openwrt-install.sh`
- `jq . json/openwrt.json >/dev/null`
- `GIT_MASTER=1 git diff --check`
- `bash /tmp/openwrt-core-refactor-check.sh /tmp/opencode/ProxmoxVED-openwrt-pr1932`
- `bash /tmp/openwrt-surface-qa.sh /tmp/opencode/ProxmoxVED-openwrt-pr1932`
- Mocked surface QA verifies custom `OPENWRT_LAN_IPADDR`/`OPENWRT_LAN_NETMASK` values are applied through UCI.

Runtime limitations in this environment:
- No local Proxmox runtime was available, so real `pct`/`pvesm` execution was not performed.
- The OpenWrt path was exercised with a mocked Proxmox surface QA script.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- https://openwrt.org/
- https://github.com/openwrt/openwrt
- https://images.linuxcontainers.org/images/openwrt/