### PR TITLE
fix(rackula): daemon-reload before starting services on install and update

### DIFF
--- a/ct/rackula.sh
+++ b/ct/rackula.sh
@@ -63,6 +63,7 @@ function update_script() {
 
     msg_info "Starting Services"
     $STD nginx -t
+    systemctl daemon-reload
     systemctl start nginx rackula-api
     msg_ok "Started Services"
 

--- a/install/rackula-install.sh
+++ b/install/rackula-install.sh
@@ -95,6 +95,7 @@ else
 fi
 mkdir -p /etc/systemd/system/nginx.service.d
 cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
+systemctl daemon-reload
 systemctl enable -q nginx rackula-api
 systemctl restart nginx rackula-api
 msg_ok "Created Services"


### PR DESCRIPTION
## What

Add `systemctl daemon-reload` before (re)starting services in both the Rackula install and update paths.

## Why

The install and update copy systemd unit files (`rackula-api.service` and the `nginx.service.d` drop-in) but never run `systemctl daemon-reload` before starting/restarting. systemd keeps the previously loaded unit definitions in memory, so when a release changes those units the services start from the stale definitions.

On a unit-changing update this is a real outage, not just the cosmetic "changed on disk" warning. Reproduced on PVE 9.2 / Debian 13 unprivileged LXC by updating an older install whose hardened units differ from the current release:

- the update reports "Updated successfully" and the version marker advances, but
- nginx fails to start with `status=226/NAMESPACE`
- rackula-api is SIGSYS-killed in a restart loop with `status=31/SYS`
- the web UI is unreachable

With `systemctl daemon-reload` added before the start, the same update brings both services up healthy and the warning is gone (verified on the same setup).

## Changes

- `ct/rackula.sh`: daemon-reload before `systemctl start nginx rackula-api` in `update_script`
- `install/rackula-install.sh`: daemon-reload before `systemctl enable`/`restart` (the install adds an nginx drop-in after apt has already loaded `nginx.service`)

Refs #1883.
