### PR TITLE
fix(rackula): daemon-reload before starting services on install and update

### DIFF
--- a/ct/rackula.sh
+++ b/ct/rackula.sh
@@ -63,6 +63,7 @@ function update_script() {
 
     msg_info "Starting Services"
     $STD nginx -t
+    systemctl daemon-reload
     systemctl start nginx rackula-api
     msg_ok "Started Services"
 

--- a/install/rackula-install.sh
+++ b/install/rackula-install.sh
@@ -95,6 +95,7 @@ else
 fi
 mkdir -p /etc/systemd/system/nginx.service.d
 cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
+systemctl daemon-reload
 systemctl enable -q nginx rackula-api
 systemctl restart nginx rackula-api
 msg_ok "Created Services"


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description

Add `systemctl daemon-reload` before (re)starting services in the Rackula install and update paths.

The install and update copy systemd unit files (`rackula-api.service` and the `nginx.service.d` drop-in) but never run `systemctl daemon-reload` before starting/restarting. systemd keeps the previously loaded unit definitions in memory, so when a release changes those units the services start from the stale definitions.

On a unit-changing update this is a real outage, not just the cosmetic "changed on disk" warning. Reproduced by updating an older install whose hardened units differ from the current release: the update reports "Updated successfully" and the version marker advances, but nginx fails with `status=226/NAMESPACE`, rackula-api is SIGSYS-killed in a restart loop (`status=31/SYS`), and the web UI is unreachable. With `daemon-reload` added before the start, the same update brings both services up healthy and the warning is gone.

Changes:
- `ct/rackula.sh`: daemon-reload before `systemctl start nginx rackula-api` in `update_script`
- `install/rackula-install.sh`: daemon-reload before `systemctl enable`/`restart` (install adds an nginx drop-in after apt has already loaded `nginx.service`)

## 🔗 Related PR / Issue

Link: #1883

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [x] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**


## 📋 Additional Information (optional)

Reproduced and fix verified on PVE 9.2.3 / Debian 13 unprivileged LXC (amd64) across multiple fresh containers, and on native arm64 (Apple Silicon / Debian 13, systemd): fresh install comes up healthy (bun aarch64 and @node-rs/argon2 load, `/api/health` 200), the outage reproduces (`226/NAMESPACE` + `31/SYS`), and the patched update heals it with no warning. A normal update on an already-current install is unaffected (no-op). Refs #1883.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

Rackula: https://github.com/RackulaLives/Rackula
