### PR TITLE
feat(maintainerr): add Maintainerr CT LXC

### DIFF
--- a/ct/maintainerr.sh
+++ b/ct/maintainerr.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Karolis Stanelis
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Maintainerr/Maintainerr
+
+APP="Maintainerr"
+var_tags="${var_tags:-media;arr;cleanup}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/maintainerr ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "maintainerr" "Maintainerr/Maintainerr"; then
+    msg_info "Stopping Service"
+    systemctl stop maintainerr
+    msg_ok "Stopped Service"
+
+    create_backup /opt/data /opt/maintainerr/.env
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "maintainerr" "Maintainerr/Maintainerr" "tarball" "latest" "/opt/maintainerr"
+
+    msg_info "Rebuilding Maintainerr (Patience)"
+    $STD apt install -y \
+      build-essential \
+      python3 \
+      pkg-config \
+      libcairo2-dev \
+      libpango1.0-dev \
+      libjpeg-dev \
+      libgif-dev \
+      libpixman-1-dev \
+      librsvg2-dev
+    cd /opt/maintainerr
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    export NODE_OPTIONS="--max-old-space-size=768"
+    $STD corepack enable
+    $STD corepack prepare yarn@4.11.0 --activate
+    $STD yarn config set enableTelemetry 0
+    $STD yarn install --network-timeout 99999999
+    $STD yarn turbo build --concurrency=1
+    cp -r apps/ui/dist apps/server/dist/ui
+    cp -r apps/server/assets apps/server/dist/assets
+    find apps/server/dist/ui -type f -not -path '*/node_modules/*' -print0 | xargs -0 sed -i "s,/__PATH_PREFIX__,,g"
+    $STD yarn workspaces focus --all --production
+    rm -rf /opt/maintainerr/.yarn/cache /opt/maintainerr/.turbo /opt/maintainerr/apps/ui
+    # Do NOT purge python3: NodeSource nodejs depends on it (purging cascades node out).
+    $STD apt purge -y \
+      build-essential \
+      pkg-config \
+      libcairo2-dev \
+      libpango1.0-dev \
+      libjpeg-dev \
+      libgif-dev \
+      libpixman-1-dev \
+      librsvg2-dev
+    $STD apt autoremove -y
+    msg_ok "Rebuilt Maintainerr"
+
+    restore_backup
+
+    msg_info "Starting Service"
+    systemctl start maintainerr
+    msg_ok "Started Service"
+    msg_ok "Updated Successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:6246${CL}"

--- a/ct/maintainerr.sh
+++ b/ct/maintainerr.sh
@@ -47,7 +47,7 @@ function update_script() {
     $STD corepack enable
     $STD corepack prepare yarn@4.11.0 --activate
     $STD yarn config set enableTelemetry 0
-    $STD yarn install --network-timeout 99999999
+    $STD yarn install --network-timeout 300000
     $STD yarn turbo build --concurrency=1
     cp -r apps/ui/dist apps/server/dist/ui
     cp -r apps/server/assets apps/server/dist/assets

--- a/ct/maintainerr.sh
+++ b/ct/maintainerr.sh
@@ -41,19 +41,9 @@ function update_script() {
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "maintainerr" "Maintainerr/Maintainerr" "tarball" "latest" "/opt/maintainerr"
 
     msg_info "Rebuilding Maintainerr (Patience)"
-    $STD apt install -y \
-      build-essential \
-      python3 \
-      pkg-config \
-      libcairo2-dev \
-      libpango1.0-dev \
-      libjpeg-dev \
-      libgif-dev \
-      libpixman-1-dev \
-      librsvg2-dev
     cd /opt/maintainerr
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-    export NODE_OPTIONS="--max-old-space-size=768"
+    export NODE_OPTIONS="--max-old-space-size=1024"
     $STD corepack enable
     $STD corepack prepare yarn@4.11.0 --activate
     $STD yarn config set enableTelemetry 0
@@ -64,16 +54,6 @@ function update_script() {
     find apps/server/dist/ui -type f -not -path '*/node_modules/*' -print0 | xargs -0 sed -i "s,/__PATH_PREFIX__,,g"
     $STD yarn workspaces focus --all --production
     rm -rf /opt/maintainerr/.yarn/cache /opt/maintainerr/.turbo /opt/maintainerr/apps/ui
-    # Do NOT purge python3: NodeSource nodejs depends on it (purging cascades node out).
-    $STD apt purge -y \
-      build-essential \
-      pkg-config \
-      libcairo2-dev \
-      libpango1.0-dev \
-      libjpeg-dev \
-      libgif-dev \
-      libpixman-1-dev \
-      librsvg2-dev
     $STD apt autoremove -y
     msg_ok "Rebuilt Maintainerr"
 

--- a/install/maintainerr-install.sh
+++ b/install/maintainerr-install.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Karolis Stanelis
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Maintainerr/Maintainerr
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  libcairo2 \
+  libpango-1.0-0 \
+  libjpeg62-turbo \
+  libgif7 \
+  libpixman-1-0 \
+  librsvg2-2
+$STD apt install -y \
+  build-essential \
+  python3 \
+  pkg-config \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  libpixman-1-dev \
+  librsvg2-dev
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="24" setup_nodejs
+
+fetch_and_deploy_gh_release "maintainerr" "Maintainerr/Maintainerr" "tarball" "latest" "/opt/maintainerr"
+
+msg_info "Building Maintainerr (Patience)"
+cd /opt/maintainerr
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export NODE_OPTIONS="--max-old-space-size=768"
+$STD corepack enable
+$STD corepack prepare yarn@4.11.0 --activate
+$STD yarn config set enableTelemetry 0
+$STD yarn install --network-timeout 99999999
+$STD yarn turbo build --concurrency=1
+# Replicate the upstream Dockerfile artifact layout: the server serves the UI
+# from dist/ui and loads fonts from dist/assets.
+cp -r apps/ui/dist apps/server/dist/ui
+cp -r apps/server/assets apps/server/dist/assets
+# Replicate docker/start.sh: rewrite the base-path placeholder in the built UI
+# (empty BASE_PATH = served from root).
+find apps/server/dist/ui -type f -not -path '*/node_modules/*' -print0 | xargs -0 sed -i "s,/__PATH_PREFIX__,,g"
+msg_ok "Built Maintainerr"
+
+msg_info "Reclaiming Disk Space"
+$STD yarn workspaces focus --all --production
+rm -rf /opt/maintainerr/.yarn/cache /opt/maintainerr/.turbo /opt/maintainerr/apps/ui
+# NOTE: do NOT purge python3 here. The NodeSource nodejs package depends on it,
+# so removing python3 cascades into removing node (and system pkgs like ifupdown2).
+$STD apt purge -y \
+  build-essential \
+  pkg-config \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  libpixman-1-dev \
+  librsvg2-dev
+$STD apt autoremove -y
+msg_ok "Reclaimed Disk Space"
+
+msg_info "Configuring Environment"
+mkdir -p /opt/data/logs
+# The app's production TypeORM config hardcodes the migrations path to
+# /opt/app/apps/server/dist/database/migrations (the upstream Docker WORKDIR).
+# Symlink it so migrationsRun=true finds the migrations and creates the schema.
+ln -sfn /opt/maintainerr /opt/app
+cat <<EOF >/opt/maintainerr/.env
+NODE_ENV=production
+DATA_DIR=/opt/data
+UI_PORT=6246
+UI_HOSTNAME=0.0.0.0
+BASE_PATH=
+EOF
+msg_ok "Configured Environment"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/maintainerr.service
+[Unit]
+Description=Maintainerr
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/maintainerr/apps/server
+EnvironmentFile=/opt/maintainerr/.env
+ExecStart=/usr/bin/node dist/main
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now maintainerr
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/maintainerr-install.sh
+++ b/install/maintainerr-install.sh
@@ -15,15 +15,7 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt install -y \
-  libcairo2 \
-  libpango-1.0-0 \
-  libjpeg62-turbo \
-  libgif7 \
-  libpixman-1-0 \
-  librsvg2-2
-$STD apt install -y \
   build-essential \
-  python3 \
   pkg-config \
   libcairo2-dev \
   libpango1.0-dev \
@@ -40,43 +32,25 @@ fetch_and_deploy_gh_release "maintainerr" "Maintainerr/Maintainerr" "tarball" "l
 msg_info "Building Maintainerr (Patience)"
 cd /opt/maintainerr
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-export NODE_OPTIONS="--max-old-space-size=768"
+export NODE_OPTIONS="--max-old-space-size=1024"
 $STD corepack enable
 $STD corepack prepare yarn@4.11.0 --activate
 $STD yarn config set enableTelemetry 0
 $STD yarn install --network-timeout 99999999
 $STD yarn turbo build --concurrency=1
-# Replicate the upstream Dockerfile artifact layout: the server serves the UI
-# from dist/ui and loads fonts from dist/assets.
 cp -r apps/ui/dist apps/server/dist/ui
 cp -r apps/server/assets apps/server/dist/assets
-# Replicate docker/start.sh: rewrite the base-path placeholder in the built UI
-# (empty BASE_PATH = served from root).
 find apps/server/dist/ui -type f -not -path '*/node_modules/*' -print0 | xargs -0 sed -i "s,/__PATH_PREFIX__,,g"
 msg_ok "Built Maintainerr"
 
 msg_info "Reclaiming Disk Space"
 $STD yarn workspaces focus --all --production
 rm -rf /opt/maintainerr/.yarn/cache /opt/maintainerr/.turbo /opt/maintainerr/apps/ui
-# NOTE: do NOT purge python3 here. The NodeSource nodejs package depends on it,
-# so removing python3 cascades into removing node (and system pkgs like ifupdown2).
-$STD apt purge -y \
-  build-essential \
-  pkg-config \
-  libcairo2-dev \
-  libpango1.0-dev \
-  libjpeg-dev \
-  libgif-dev \
-  libpixman-1-dev \
-  librsvg2-dev
 $STD apt autoremove -y
 msg_ok "Reclaimed Disk Space"
 
 msg_info "Configuring Environment"
 mkdir -p /opt/data/logs
-# The app's production TypeORM config hardcodes the migrations path to
-# /opt/app/apps/server/dist/database/migrations (the upstream Docker WORKDIR).
-# Symlink it so migrationsRun=true finds the migrations and creates the schema.
 ln -sfn /opt/maintainerr /opt/app
 cat <<EOF >/opt/maintainerr/.env
 NODE_ENV=production

--- a/install/maintainerr-install.sh
+++ b/install/maintainerr-install.sh
@@ -36,7 +36,7 @@ export NODE_OPTIONS="--max-old-space-size=1024"
 $STD corepack enable
 $STD corepack prepare yarn@4.11.0 --activate
 $STD yarn config set enableTelemetry 0
-$STD yarn install --network-timeout 99999999
+$STD yarn install --network-timeout 300000
 $STD yarn turbo build --concurrency=1
 cp -r apps/ui/dist apps/server/dist/ui
 cp -r apps/server/assets apps/server/dist/assets

--- a/json/maintainerr.json
+++ b/json/maintainerr.json
@@ -37,10 +37,6 @@
     {
       "text": "Complete the setup wizard via the web interface on first access, then connect Maintainerr to your media servers (Plex/Jellyfin/Emby) and to Radarr/Sonarr/Seerr.",
       "type": "info"
-    },
-    {
-      "text": "Maintainerr is built from source, so the 2048 MB default is sized for the build (Vite UI + native canvas compile). Runtime needs far less — you can reduce RAM after the install completes.",
-      "type": "warning"
     }
   ]
 }

--- a/json/maintainerr.json
+++ b/json/maintainerr.json
@@ -1,0 +1,46 @@
+{
+  "name": "Maintainerr",
+  "slug": "maintainerr",
+  "categories": [
+    13,
+    14
+  ],
+  "date_created": "2026-06-24",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 6246,
+  "documentation": "https://docs.maintainerr.info",
+  "website": "https://maintainerr.info",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/maintainerr.webp",
+  "description": "Maintainerr automates media-library cleanup by building rule-based collections of unwatched or unrequested titles, applying a grace period, then removing them from Plex/Jellyfin/Emby and the connected Radarr, Sonarr and Seerr apps.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/maintainerr.sh",
+      "config_path": "/opt/data",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Complete the setup wizard via the web interface on first access, then connect Maintainerr to your media servers (Plex/Jellyfin/Emby) and to Radarr/Sonarr/Seerr.",
+      "type": "info"
+    },
+    {
+      "text": "Maintainerr is built from source, so the 2048 MB default is sized for the build (Vite UI + native canvas compile). Runtime needs far less — you can reduce RAM after the install completes.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION

## ✍️ Description

Adds a new CT (LXC) script set for **Maintainerr**, a rule-based media-library cleanup tool. Maintainerr builds collections of unwatched/unrequested titles, applies a grace period, then removes them from Plex/Jellyfin/Emby and the connected Radarr, Sonarr and Seerr apps.

Implemented as the standard three-file pattern:
- `ct/maintainerr.sh` — entry point (defaults: 2 CPU / 2048 MB / 8 GB, Debian 13), with `update_script()`.
- `install/maintainerr-install.sh` — in-container install.
- `json/maintainerr.json` — website/API metadata.

Built from source (yarn4 + turbo NestJS monorepo) because upstream publishes no prebuilt binary release asset — only Docker images and source tarballs. The install pulls the latest tagged source tarball via `fetch_and_deploy_gh_release` and builds it. The server serves the Vite UI on port **6246** with data in `/opt/data`.

Build tuned for a small footprint: sequential turbo, capped `NODE_OPTIONS`, dev-dep prune, and build-toolchain purge after the native canvas compile.

Two upstream-Docker assumptions handled:
- The reclaim step does **not** purge python3 (NodeSource nodejs depends on it; purging cascades node out).
- The production TypeORM config hardcodes the migrations path to `/opt/app/...`; we symlink `/opt/app -> /opt/maintainerr` so `migrationsRun` creates the schema on first boot.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.


## 📋 Additional Information (optional)
- Default RAM (2048 MB) is sized for the from-source build (Vite UI + native canvas compile); runtime needs far less and can be reduced after install.
- Interface port: `6246`. Config path: `/opt/data`.
- **arm64:** upstream publishes arm64 Docker images and the toolchain (Node 24 + node-canvas) builds on arm64, so the script is expected to work there — marked "not tested" because it was only validated on amd64.
- Builds with Node 24 + yarn 4.11.0, `turbo build --concurrency=1` and `NODE_OPTIONS=--max-old-space-size=768` to keep the build footprint small; build toolchain (`build-essential`, `*-dev`) is purged and dev deps pruned afterward.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- Website: https://maintainerr.info
- Docs: https://docs.maintainerr.info
- GitHub: https://github.com/Maintainerr/Maintainerr/
