### PR TITLE
feat(core.func): add arch_resolve() helper for architecture-specific values

### DIFF
--- a/misc/core.func
+++ b/misc/core.func
@@ -1703,5 +1703,26 @@ on_hup_keepalive() {
   log_msg "[WARN] Received SIGHUP (terminal hangup). Continuing execution in background."
 }
 
+# ------------------------------------------------------------------------------
+# arch_resolve()
+#
+# - Selects an architecture-specific value while preserving amd64 defaults
+# - Usage: arch_resolve "amd64-value" "arm64-value"
+# - Defaults: amd64="amd64", arm64="arm64"
+# ------------------------------------------------------------------------------
+arch_resolve() {
+  local amd64_val="${1:-amd64}"
+  local arm64_val="${2:-arm64}"
+  local arch="${PCT_ARCH:-$(dpkg --print-architecture 2>/dev/null || uname -m)}"
+  case "$arch" in
+  amd64 | x86_64) echo "$amd64_val" ;;
+  arm64 | aarch64) echo "$arm64_val" ;;
+  *)
+    msg_error "Unsupported architecture: $arch"
+    return 106
+    ;;
+  esac
+}
+
 trap 'on_hup_keepalive' HUP
 trap 'stop_spinner' EXIT INT TERM


### PR DESCRIPTION
## ✍️ Description

Adds a small reusable helper `arch_resolve()` to `misc/core.func` that returns an amd64- or arm64-specific value based on the detected architecture.

- Detects arch via `PCT_ARCH`, falling back to `dpkg --print-architecture`, then `uname -m`.
- Usage: `arch_resolve "amd64-value" "arm64-value"` (defaults: `amd64="amd64"`, `arm64="arm64"`).
- Keeps **amd64 as the default**, so existing behavior is unchanged.
- Unknown architectures fail loudly with `msg_error` and `return 106`.

This supports the ongoing arm64 port effort, letting install scripts cleanly select architecture-correct download assets (e.g. release tarball/`.deb` names) instead of hardcoding amd64.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [x] **arm64 supported** - Tested and supported on arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] ✨ **New feature** – Adds new, non-breaking functionality.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **No hardcoded credentials**

## 📋 Additional Information (optional)

This is a framework helper only (no script changes); consuming install scripts will call `arch_resolve` in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)