### PR TITLE
feat: add Newt (Pangolin tunnel client)

### DIFF
--- a/ct/newt.sh
+++ b/ct/newt.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Arubinu
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/fosrl/newt
+
+APP="Newt"
+var_tags="${var_tags:-network;tunnel}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-256}"
+var_disk="${var_disk:-2}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /etc/newt/newt.env ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "newt" "fosrl/newt"; then
+    msg_info "Stopping Service"
+    systemctl stop newt
+    msg_ok "Stopped Service"
+
+    ARCH=$(get_system_arch dpkg)
+    fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_${ARCH}"
+    ln -sf /opt/newt/newt /usr/local/bin/newt
+
+    msg_info "Starting Service"
+    systemctl start newt
+    msg_ok "Started Service"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${INFO}${YW} Newt is a headless tunnel client — there is no web interface.${CL}"
+echo -e "${INFO}${YW} Check the site status in your Pangolin dashboard.${CL}"

--- a/ct/newt.sh
+++ b/ct/newt.sh
@@ -13,6 +13,7 @@ var_ram="${var_ram:-256}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/newt.sh
+++ b/ct/newt.sh
@@ -35,8 +35,7 @@ function update_script() {
     systemctl stop newt
     msg_ok "Stopped Service"
 
-    ARCH=$(get_system_arch dpkg)
-    fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_${ARCH}"
+    fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_$(arch_resolve)"
     ln -sf /opt/newt/newt /usr/local/bin/newt
 
     msg_info "Starting Service"

--- a/ct/newt.sh
+++ b/ct/newt.sh
@@ -51,5 +51,4 @@ build_container
 description
 
 msg_ok "Completed Successfully!\n"
-echo -e "${INFO}${YW} Newt is a headless tunnel client — there is no web interface.${CL}"
 echo -e "${INFO}${YW} Check the site status in your Pangolin dashboard.${CL}"

--- a/install/newt-install.sh
+++ b/install/newt-install.sh
@@ -17,18 +17,16 @@ ARCH=$(get_system_arch dpkg)
 fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_${ARCH}"
 ln -sf /opt/newt/newt /usr/local/bin/newt
 
-ensure_whiptail
-NEWT_ID="${NEWT_ID:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
-  --title "Newt Site ID" \
-  --inputbox "Newt ID (from your Pangolin dashboard)" 8 70 3>&1 1>&2 2>&3)}"
-
-NEWT_SECRET="${NEWT_SECRET:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
-  --title "Newt Secret" \
-  --passwordbox "Newt Secret" 8 70 3>&1 1>&2 2>&3)}"
-
-PANGOLIN_ENDPOINT="${PANGOLIN_ENDPOINT:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
-  --title "Pangolin Endpoint" \
-  --inputbox "Pangolin server URL (e.g. https://pangolin.example.com)" 8 70 3>&1 1>&2 2>&3)}"
+if [[ -z "${NEWT_ID:-}" ]]; then
+  read -rp "Newt ID (from your Pangolin dashboard): " NEWT_ID
+fi
+if [[ -z "${NEWT_SECRET:-}" ]]; then
+  read -rsp "Newt Secret: " NEWT_SECRET
+  echo
+fi
+if [[ -z "${PANGOLIN_ENDPOINT:-}" ]]; then
+  read -rp "Pangolin endpoint (e.g. https://pangolin.example.com): " PANGOLIN_ENDPOINT
+fi
 
 if [[ -z "$NEWT_ID" || -z "$NEWT_SECRET" || -z "$PANGOLIN_ENDPOINT" ]]; then
   msg_error "Newt ID, Secret and Endpoint are all required. Aborting."

--- a/install/newt-install.sh
+++ b/install/newt-install.sh
@@ -34,16 +34,16 @@ fi
 
 msg_info "Configuring Newt"
 mkdir -p /etc/newt
-cat >/etc/newt/newt.env <<ENVEOF
+cat <<EOF >/etc/newt/newt.env
 NEWT_ID=${NEWT_ID}
 NEWT_SECRET=${NEWT_SECRET}
 PANGOLIN_ENDPOINT=${PANGOLIN_ENDPOINT}
-ENVEOF
+EOF
 chmod 600 /etc/newt/newt.env
 msg_ok "Configured Newt"
 
 msg_info "Creating Service"
-cat >/etc/systemd/system/newt.service <<SVCEOF
+cat <<EOF >/etc/systemd/system/newt.service
 [Unit]
 Description=Newt (Pangolin tunnel client)
 Wants=network-online.target
@@ -60,7 +60,7 @@ PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target
-SVCEOF
+EOF
 systemctl enable -q --now newt
 msg_ok "Created Service"
 

--- a/install/newt-install.sh
+++ b/install/newt-install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Arubinu
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/fosrl/newt
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+ARCH=$(get_system_arch dpkg)
+fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_${ARCH}"
+ln -sf /opt/newt/newt /usr/local/bin/newt
+
+ensure_whiptail
+NEWT_ID="${NEWT_ID:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
+  --title "Newt Site ID" \
+  --inputbox "Newt ID (from your Pangolin dashboard)" 8 70 3>&1 1>&2 2>&3)}"
+
+NEWT_SECRET="${NEWT_SECRET:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
+  --title "Newt Secret" \
+  --passwordbox "Newt Secret" 8 70 3>&1 1>&2 2>&3)}"
+
+PANGOLIN_ENDPOINT="${PANGOLIN_ENDPOINT:-$(whiptail --backtitle "Proxmox VE Helper Scripts" \
+  --title "Pangolin Endpoint" \
+  --inputbox "Pangolin server URL (e.g. https://pangolin.example.com)" 8 70 3>&1 1>&2 2>&3)}"
+
+if [[ -z "$NEWT_ID" || -z "$NEWT_SECRET" || -z "$PANGOLIN_ENDPOINT" ]]; then
+  msg_error "Newt ID, Secret and Endpoint are all required. Aborting."
+  exit 1
+fi
+
+msg_info "Configuring Newt"
+mkdir -p /etc/newt
+cat >/etc/newt/newt.env <<ENVEOF
+NEWT_ID=${NEWT_ID}
+NEWT_SECRET=${NEWT_SECRET}
+PANGOLIN_ENDPOINT=${PANGOLIN_ENDPOINT}
+ENVEOF
+chmod 600 /etc/newt/newt.env
+msg_ok "Configured Newt"
+
+msg_info "Creating Service"
+cat >/etc/systemd/system/newt.service <<SVCEOF
+[Unit]
+Description=Newt (Pangolin tunnel client)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/newt/newt.env
+ExecStart=/usr/local/bin/newt
+Restart=always
+RestartSec=2
+UMask=0077
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+systemctl enable -q --now newt
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/newt-install.sh
+++ b/install/newt-install.sh
@@ -13,8 +13,7 @@ setting_up_container
 network_check
 update_os
 
-ARCH=$(get_system_arch dpkg)
-fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_${ARCH}"
+fetch_and_deploy_gh_release "newt" "fosrl/newt" "singlefile" "latest" "/opt/newt" "newt_linux_$(arch_resolve)"
 ln -sf /opt/newt/newt /usr/local/bin/newt
 
 if [[ -z "${NEWT_ID:-}" ]]; then

--- a/json/newt.json
+++ b/json/newt.json
@@ -13,7 +13,7 @@
   "documentation": "https://docs.pangolin.net/manage/sites/install-site",
   "config_path": "/etc/newt/newt.env",
   "website": "https://pangolin.net",
-  "logo": null,
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/pangolin.webp",
   "description": "Newt is a lightweight, fully user-space WireGuard tunnel client and TCP/UDP proxy for Pangolin. It connects a site to a Pangolin server to securely expose private resources without port forwarding or opening inbound firewall ports. Headless service with no web interface.",
   "install_methods": [
     {

--- a/json/newt.json
+++ b/json/newt.json
@@ -38,7 +38,7 @@
       "type": "warning"
     },
     {
-      "text": "Get the Newt ID, Newt Secret and Pangolin endpoint by creating a site/node in your Pangolin dashboard; see the documentation link for the exact steps. The installer prompts for these, or set NEWT_ID / NEWT_SECRET / PANGOLIN_ENDPOINT as environment variables for an unattended install.",
+      "text": "Requires a Newt ID, Newt Secret and Pangolin endpoint, which can be obtained by creating a site/node in your Pangolin dashboard.",
       "type": "info"
     }
   ]

--- a/json/newt.json
+++ b/json/newt.json
@@ -35,7 +35,7 @@
   "notes": [
     {
       "text": "Requires a running Pangolin server to connect to.",
-      "type": "warning"
+      "type": "info"
     },
     {
       "text": "Requires a Newt ID, Newt Secret and Pangolin endpoint, which can be obtained by creating a site/node in your Pangolin dashboard.",

--- a/json/newt.json
+++ b/json/newt.json
@@ -1,0 +1,49 @@
+{
+  "name": "Newt",
+  "slug": "newt",
+  "categories": [
+    4
+  ],
+  "date_created": "2026-06-26",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": null,
+  "documentation": "https://docs.pangolin.net/manage/sites/install-site",
+  "config_path": "/etc/newt/newt.env",
+  "website": "https://pangolin.net",
+  "logo": null,
+  "description": "Newt is a lightweight, fully user-space WireGuard tunnel client and TCP/UDP proxy for Pangolin. It connects a site to a Pangolin server to securely expose private resources without port forwarding or opening inbound firewall ports. Headless service with no web interface.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/newt.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 256,
+        "hdd": 2,
+        "os": "debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Requires a running Pangolin server (self-hosted or Pangolin Cloud) to connect to. Newt is the client component only and does nothing on its own.",
+      "type": "warning"
+    },
+    {
+      "text": "Get the Newt ID, Newt Secret and Pangolin endpoint by creating a site/node in your Pangolin dashboard; see the documentation link for the exact steps. The installer prompts for these, or set NEWT_ID / NEWT_SECRET / PANGOLIN_ENDPOINT as environment variables for an unattended install.",
+      "type": "info"
+    },
+    {
+      "text": "Headless service with no web UI. Manage the connection from the Pangolin dashboard. To change credentials, edit /etc/newt/newt.env then run 'systemctl restart newt'.",
+      "type": "info"
+    }
+  ]
+}

--- a/json/newt.json
+++ b/json/newt.json
@@ -34,7 +34,7 @@
   },
   "notes": [
     {
-      "text": "Requires a running Pangolin server (self-hosted or Pangolin Cloud) to connect to. Newt is the client component only and does nothing on its own.",
+      "text": "Requires a running Pangolin server to connect to.",
       "type": "warning"
     },
     {

--- a/json/newt.json
+++ b/json/newt.json
@@ -8,7 +8,7 @@
   "type": "ct",
   "updateable": true,
   "privileged": false,
-  "has_arm": true,
+  "has_arm": false,
   "interface_port": null,
   "documentation": "https://docs.pangolin.net/manage/sites/install-site",
   "config_path": "/etc/newt/newt.env",

--- a/json/newt.json
+++ b/json/newt.json
@@ -14,7 +14,7 @@
   "config_path": "/etc/newt/newt.env",
   "website": "https://pangolin.net",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/pangolin.webp",
-  "description": "Newt is a lightweight, fully user-space WireGuard tunnel client and TCP/UDP proxy for Pangolin. It connects a site to a Pangolin server to securely expose private resources without port forwarding or opening inbound firewall ports. Headless service with no web interface.",
+  "description": "Newt is a lightweight, headless, fully user-space WireGuard tunnel client and TCP/UDP proxy for Pangolin. It connects a site to a Pangolin server to securely expose private resources without port forwarding or opening inbound firewall ports.",
   "install_methods": [
     {
       "type": "default",

--- a/json/newt.json
+++ b/json/newt.json
@@ -40,10 +40,6 @@
     {
       "text": "Get the Newt ID, Newt Secret and Pangolin endpoint by creating a site/node in your Pangolin dashboard; see the documentation link for the exact steps. The installer prompts for these, or set NEWT_ID / NEWT_SECRET / PANGOLIN_ENDPOINT as environment variables for an unattended install.",
       "type": "info"
-    },
-    {
-      "text": "Headless service with no web UI. Manage the connection from the Pangolin dashboard. To change credentials, edit /etc/newt/newt.env then run 'systemctl restart newt'.",
-      "type": "info"
     }
   ]
 }


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

Apologies for the mess on the previous PR. I'm still getting comfortable with the Git workflow, and a botched rebase pulled an unrelated file into the branch, which is why it was closed. I've recreated everything on a clean branch that contains only the three Newt files (script, install, JSON). Thanks for your patience and for the time you spent reviewing.

## ✍️ Description
Adds a new LXC script for Newt, the lightweight user-space WireGuard tunnel client for Pangolin. It deploys the official `newt` binary via `fetch_and_deploy_gh_release`, writes `/etc/newt/newt.env` (chmod 600), and runs it as a systemd service.
Credentials (Newt ID, Secret, Pangolin endpoint) are collected via whiptail, or passed as `NEWT_ID` / `NEWT_SECRET` / `PANGOLIN_ENDPOINT` for unattended installs. Headless — managed from the Pangolin dashboard.

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.


## 📋 Additional Information (optional)
Headless service with no web interface — the connection is managed from the Pangolin dashboard. Requires an existing Pangolin server (self-hosted or Pangolin Cloud) to connect to. Tested on Debian 13.

Newt publishes official versioned single-file binaries (e.g. `newt_linux_amd64`, `newt_linux_arm64`) on GitHub Releases rather than `.tar.gz` tarballs. The install script consumes them via `fetch_and_deploy_gh_release` in `singlefile` mode.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- Application: https://github.com/fosrl/newt
- Project site: https://pangolin.net
- Docs: https://docs.pangolin.net
