### PR TITLE
feat: add Satisfactory dedicated server

### DIFF
--- a/ct/satisfactory.sh
+++ b/ct/satisfactory.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: n8flx
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.satisfactorygame.com/
+
+APP="Satisfactory"
+var_tags="${var_tags:-gaming;server}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-8192}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -x /opt/steamcmd/steamcmd.sh || ! -d /opt/satisfactory/server ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Stopping ${APP}"
+  systemctl stop satisfactory
+  msg_ok "Stopped ${APP}"
+
+  create_backup /root/.config/Epic/FactoryGame/Saved
+
+  msg_info "Updating ${APP}"
+  if $STD /opt/steamcmd/steamcmd.sh \
+    +force_install_dir /opt/satisfactory/server \
+    +login anonymous \
+    +app_update 1690800 validate \
+    +quit; then
+    msg_ok "Updated ${APP}"
+  else
+    restore_backup
+    systemctl start satisfactory
+    msg_error "Failed to update ${APP}"
+    exit 1
+  fi
+
+  restore_backup
+
+  msg_info "Starting ${APP}"
+  systemctl start satisfactory
+  msg_ok "Started ${APP}"
+  msg_ok "Updated Successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Add the server in Satisfactory Server Manager:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}${IP}:7777${CL}"
+echo -e "${INFO}${YW} Required ports:${CL} ${BGN}7777 TCP/UDP and 8888 TCP${CL}"

--- a/install/satisfactory-install.sh
+++ b/install/satisfactory-install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: n8flx
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.satisfactorygame.com/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  lib32gcc-s1 \
+  lib32stdc++6
+msg_ok "Installed Dependencies"
+
+msg_info "Creating Application Directories"
+mkdir -p /opt/satisfactory/server
+msg_ok "Created Application Directories"
+
+fetch_and_deploy_from_url \
+  "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" \
+  "/opt/steamcmd"
+
+msg_info "Installing Satisfactory Dedicated Server"
+$STD /opt/steamcmd/steamcmd.sh \
+  +force_install_dir /opt/satisfactory/server \
+  +login anonymous \
+  +app_update 1690800 validate \
+  +quit
+msg_ok "Installed Satisfactory Dedicated Server"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/satisfactory.service
+[Unit]
+Description=Satisfactory Dedicated Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/satisfactory/server
+Environment=LANG=C.UTF-8
+ExecStart=/opt/satisfactory/server/FactoryServer.sh -log
+Restart=on-failure
+RestartSec=10
+KillSignal=SIGINT
+TimeoutStopSec=120
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now satisfactory
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## Description
Adds a Community Scripts-style LXC installer for the Satisfactory Dedicated Server. It installs SteamCMD and App ID 1690800 on Debian 13, creates a systemd service, exposes journal/console logs, and provides an update flow with save-data backup and restore.

Satisfactory is proprietary Steam content. This submission is intentionally transparent about that and asks the maintainers whether a dedicated-server helper is eligible for an exception to the open-source application policy.

## Type of Change
- [x] New application (ct + install scripts)

## Testing
- [x] Bash syntax checks pass
- [x] ShellCheck 0.11.0 reports no error-severity findings
- [x] Underlying SteamCMD installation and Satisfactory server startup tested successfully on Proxmox VE with Debian 13
- [ ] Community Scripts Default flow tested end-to-end from this fork
- [ ] Community Scripts Advanced flow tested end-to-end
- [ ] Community Scripts update action tested end-to-end

## Application Details
- **App Name:** Satisfactory
- **Source:** https://www.satisfactorygame.com/
- **Documentation:** https://satisfactory.wiki.gg/wiki/Dedicated_servers
- **Default OS:** Debian 13
- **Recommended Resources:** 4 CPU, 8 GB RAM, 20 GB disk
- **Tags:** gaming;server
- **Access:** Add the container IP with port 7777 in Satisfactory Server Manager
- **Ports:** 7777 TCP/UDP and 8888 TCP

## Checklist
- [x] Code follows the current style and AI coding guidelines
- [x] Self-review completed
- [x] PR contains only the CT and install scripts
- [x] No temporary files are left by the installer
- [x] User data is backed up and restored during updates
- [x] Documentation and licensing caveat stated clearly