### PR TITLE
feat: add Satisfactory dedicated server

### DIFF
--- a/ct/satisfactory.sh
+++ b/ct/satisfactory.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: n8flx
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.satisfactorygame.com/
+
+APP="Satisfactory"
+var_tags="${var_tags:-gaming;server}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-8192}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -x /opt/steamcmd/steamcmd.sh || ! -d /opt/satisfactory/server ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Stopping ${APP}"
+  systemctl stop satisfactory
+  msg_ok "Stopped ${APP}"
+
+  create_backup /root/.config/Epic/FactoryGame/Saved
+
+  msg_info "Updating ${APP}"
+  if $STD /opt/steamcmd/steamcmd.sh \
+    +force_install_dir /opt/satisfactory/server \
+    +login anonymous \
+    +app_update 1690800 validate \
+    +quit; then
+    msg_ok "Updated ${APP}"
+  else
+    restore_backup
+    systemctl start satisfactory
+    msg_error "Failed to update ${APP}"
+    exit 1
+  fi
+
+  restore_backup
+
+  msg_info "Starting ${APP}"
+  systemctl start satisfactory
+  msg_ok "Started ${APP}"
+  msg_ok "Updated Successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Add the server in Satisfactory Server Manager:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}${IP}:7777${CL}"
+echo -e "${INFO}${YW} Required ports:${CL} ${BGN}7777 TCP/UDP and 8888 TCP${CL}"

--- a/install/satisfactory-install.sh
+++ b/install/satisfactory-install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: n8flx
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.satisfactorygame.com/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  lib32gcc-s1 \
+  lib32stdc++6
+msg_ok "Installed Dependencies"
+
+msg_info "Creating Application Directories"
+mkdir -p /opt/satisfactory/server
+msg_ok "Created Application Directories"
+
+fetch_and_deploy_from_url \
+  "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" \
+  "/opt/steamcmd"
+
+msg_info "Installing Satisfactory Dedicated Server"
+$STD /opt/steamcmd/steamcmd.sh \
+  +force_install_dir /opt/satisfactory/server \
+  +login anonymous \
+  +app_update 1690800 validate \
+  +quit
+msg_ok "Installed Satisfactory Dedicated Server"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/satisfactory.service
+[Unit]
+Description=Satisfactory Dedicated Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/satisfactory/server
+Environment=LANG=C.UTF-8
+ExecStart=/opt/satisfactory/server/FactoryServer.sh -log
+Restart=on-failure
+RestartSec=10
+KillSignal=SIGINT
+TimeoutStopSec=120
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now satisfactory
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/satisfactory.json
+++ b/json/satisfactory.json
@@ -1,0 +1,49 @@
+{
+  "name": "Satisfactory",
+  "slug": "satisfactory",
+  "categories": [
+    24
+  ],
+  "date_created": "2026-07-02",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 7777,
+  "documentation": "https://satisfactory.wiki.gg/wiki/Dedicated_servers",
+  "website": "https://www.satisfactorygame.com/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/satisfactory.webp",
+  "description": "Host a persistent Satisfactory world for PC players using the official Linux dedicated server and SteamCMD.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/satisfactory.sh",
+      "config_path": "/root/.config/Epic/FactoryGame/Saved/Config/LinuxServer",
+      "resources": {
+        "cpu": 4,
+        "ram": 8192,
+        "hdd": 20,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Open or forward ports 7777 TCP/UDP and 8888 TCP. External and internal port 7777 must match.",
+      "type": "info"
+    },
+    {
+      "text": "The server is managed and claimed from the in-game Server Manager.",
+      "type": "info"
+    },
+    {
+      "text": "Updates stop and restart the game server; schedule them when no players are connected.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description
Adds a Community Scripts LXC installer for the Satisfactory Dedicated Server. It installs SteamCMD and App ID 1690800 on Debian 13, creates a systemd service, exposes journal and console logs, and provides an update flow with save-data backup and restore.

Satisfactory is proprietary Steam content. This submission asks whether a dedicated-server helper can receive an exception to the open-source and GitHub-based application requirements.

## 🔗 Related PR / Issue

Link: #1969 (automatically closed because the required template was missing)

## ✅ Prerequisites (X in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – The Community Scripts Default, Advanced and update flows still require end-to-end testing.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets or unnecessary privilege escalation.

---

## 🏗️ arm64 Support (X in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [x] **arm64 not supported** - Upstream server binaries target x86_64.

---

## 🛠️ Type of Change (X in brackets)

- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script**
- [ ] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**

---

## 🔍 Code & Security Review (X in brackets)

- [x] **Follows CODE-AUDIT.md & CONTRIBUTING.md guidelines**
- [x] **Uses correct script structure (AppName.sh, AppName-install.sh, AppName.json)**
- [x] **No hardcoded credentials**

---

## 🤖 AI Assistance (X in brackets)

- [ ] **No AI used**
- [x] **AI was used** – The scripts were built using AGENTS.md and .github/agents/pve-script-creator.agent.md as guidance, then reviewed and corrected against those guidelines.

---

## 📋 Additional Information

Static validation completed: bash syntax checks pass, git diff --check passes, and ShellCheck 0.11.0 reports no error-severity findings. The underlying standalone SteamCMD installation has successfully created and started a Satisfactory server on Proxmox VE with Debian 13. The Community Scripts wrapper has not yet been tested end-to-end.

Default resources: 4 CPU, 8192 MiB RAM, 20 GiB disk. Required ports: 7777 TCP/UDP and 8888 TCP.

---

## 📦 Application Requirements (for new scripts)

- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars** – Satisfactory is not developed on a public GitHub repository.
- [x] Official **release tarballs** are published – The dedicated server is distributed through SteamCMD instead.
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

note from @asylumexp: it doesn't publish tarballs nor is it open source, but I reopened it anyways.
## 🌐 Source

- https://www.satisfactorygame.com/
- https://satisfactory.wiki.gg/wiki/Dedicated_servers
- SteamCMD App ID: 1690800