### PR TITLE
Add OpenVoice AI LXC helper script

### DIFF
--- a/ct/openvoice-ai.sh
+++ b/ct/openvoice-ai.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Draft for community-scripts/ProxmoxVED.
+# Copy this file into ProxmoxVED/ct/openvoice-ai.sh before submission.
+
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2026 OpenVoice AI contributors
+# License: MIT
+# Source: https://github.com/nikpottbecker/openvoice-ai
+
+APP="OpenVoice AI"
+var_tags="${var_tags:-ai;communication;phone}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-6144}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/phone-agent ]]; then
+    msg_error "No ${APP} installation found."
+    exit 1
+  fi
+
+  msg_info "Updating ${APP}"
+  bash /opt/phone-agent/scripts/update.sh
+  msg_ok "Updated ${APP}"
+  exit
+}
+
+start
+build_container
+description
+msg_ok "Completed successfully!\n"
+echo -e "${INFO}${YW}Dashboard:${CL} ${BGN}http://${IP}:8088${CL}"

--- a/install/openvoice-ai-install.sh
+++ b/install/openvoice-ai-install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 OpenVoice AI contributors
+# License: MIT
+# Source: https://github.com/nikpottbecker/openvoice-ai
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y --no-install-recommends \
+  asterisk \
+  ca-certificates \
+  curl \
+  ffmpeg \
+  git \
+  jq \
+  python3 \
+  python3-pip \
+  python3-venv \
+  rsync \
+  sox \
+  unzip
+msg_ok "Installed Dependencies"
+
+msg_info "Installing OpenVoice AI"
+git clone --depth 1 https://github.com/nikpottbecker/openvoice-ai.git /opt/phone-agent
+cd /opt/phone-agent
+bash scripts/install.sh
+msg_ok "Installed OpenVoice AI"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
OpenVoice AI is a self-hosted AI communication platform with phone agent, dashboard, STT/TTS, AI providers and automation support.

This PR adds draft Proxmox LXC helper scripts for installing OpenVoice AI in a Debian container.

Files added:
- `ct/openvoice-ai.sh`
- `install/openvoice-ai-install.sh`

Notes:
- OpenVoice AI is currently a preview / early alpha project.
- Users configure runtime settings after install through `.env` / the upcoming web setup flow.
- No API keys, SIP credentials, SMTP passwords, recordings, transcripts or private data are included.

Validation performed:
- `bash -n ct/openvoice-ai.sh`
- `bash -n install/openvoice-ai-install.sh`

Still expected before merge:
- maintainer review against current ProxmoxVED metadata requirements
- ShellCheck in the upstream CI environment
- fresh LXC install validation
