### PR TITLE
feat(litellm): reactivate via official Docker Compose

### DIFF
--- a/ct/litellm.sh
+++ b/ct/litellm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: stout01
+# Co-Authors: MickLesk, tremor021 (prior pip/Prisma versions)
+# Refactor: Docker Compose official stack (community contribution preserved)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/BerriAI/litellm
+
+APP="LiteLLM"
+var_tags="${var_tags:-ai;proxy;llm}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_nesting="${var_nesting:-1}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /opt/litellm/docker-compose.yml ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating LiteLLM (Docker Compose)"
+  cd /opt/litellm
+  $STD docker compose pull
+  $STD docker compose up -d
+  msg_ok "Updated LiteLLM containers"
+
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:4000${CL}"
+echo -e "${INFO}${YW} Master key saved to:${CL} ${TAB}${BGN}~/litellm.creds${CL}"

--- a/install/litellm-install.sh
+++ b/install/litellm-install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: stout01
+# Co-Authors: MickLesk, tremor021 (prior pip/Prisma versions)
+# Refactor: Docker Compose official stack (community contribution preserved)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/BerriAI/litellm
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# Pinned upstream compose artifacts (BerriAI/litellm)
+LITELLM_REF="79a6b8f7f0cd"
+LITELLM_RAW="https://raw.githubusercontent.com/BerriAI/litellm/${LITELLM_REF}"
+LITELLM_DIR="/opt/litellm"
+
+setup_docker
+
+msg_info "Fetching LiteLLM Docker Compose stack (${LITELLM_REF})"
+mkdir -p "$LITELLM_DIR"
+cd "$LITELLM_DIR"
+curl -fsSL "${LITELLM_RAW}/docker-compose.yml" -o docker-compose.yml
+curl -fsSL "${LITELLM_RAW}/prometheus.yml" -o prometheus.yml
+msg_ok "Fetched compose files"
+
+msg_info "Generating secrets"
+LITELLM_MASTER_KEY="sk-$(openssl rand -hex 16)"
+LITELLM_SALT_KEY="sk-$(openssl rand -hex 16)"
+POSTGRES_PASSWORD="$(openssl rand -hex 16)"
+
+cat <<EOF >"$LITELLM_DIR/.env"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY}"
+LITELLM_SALT_KEY="${LITELLM_SALT_KEY}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD}"
+EOF
+
+# Replace example credentials from upstream compose with generated secrets
+sed -i "s/dbpassword9090/${POSTGRES_PASSWORD}/g" "$LITELLM_DIR/docker-compose.yml"
+if grep -q "dbpassword9090" "$LITELLM_DIR/docker-compose.yml"; then
+  msg_error "Failed to replace default Postgres password in docker-compose.yml"
+  exit 150
+fi
+
+# Bind auxiliary services to localhost only (proxy stays on :4000)
+sed -i 's/- "5432:5432"/- "127.0.0.1:5432:5432"/' "$LITELLM_DIR/docker-compose.yml"
+sed -i 's/- "9090:9090"/- "127.0.0.1:9090:9090"/' "$LITELLM_DIR/docker-compose.yml"
+msg_ok "Generated secrets and hardened port bindings"
+
+msg_info "Starting LiteLLM stack (Patience)"
+cd "$LITELLM_DIR"
+$STD docker compose up -d
+
+msg_info "Waiting for LiteLLM health check"
+CONTAINER_ID=""
+for i in $(seq 1 90); do
+  if curl -sf "http://127.0.0.1:4000/health/liveliness" >/dev/null 2>&1; then
+    msg_ok "LiteLLM is healthy"
+    break
+  fi
+  CONTAINER_ID=$(docker ps -q --filter "name=litellm-litellm" | head -1)
+  if [[ -n "$CONTAINER_ID" ]]; then
+    STATUS=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}starting{{end}}' "$CONTAINER_ID" 2>/dev/null || echo "starting")
+    if [[ "$STATUS" == "unhealthy" ]]; then
+      msg_error "LiteLLM container is unhealthy — check: docker compose logs litellm"
+      docker compose logs litellm 2>/dev/null | tail -30
+      exit 150
+    fi
+  fi
+  sleep 2
+  if [[ "$i" -eq 90 ]]; then
+    msg_error "LiteLLM did not become healthy within 180s"
+    docker compose logs litellm 2>/dev/null | tail -30
+    exit 150
+  fi
+done
+
+cat <<EOF >~/litellm.creds
+LiteLLM Credentials
+URL: http://${LOCAL_IP}:4000
+Master Key: ${LITELLM_MASTER_KEY}
+Salt Key: ${LITELLM_SALT_KEY}
+Postgres Password: ${POSTGRES_PASSWORD}
+
+Note: LITELLM_SALT_KEY cannot be changed after adding models to the proxy.
+EOF
+chmod 600 ~/litellm.creds
+msg_ok "Saved credentials to ~/litellm.creds"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## Summary

Reactivates the LiteLLM helper script using the **official BerriAI Docker Compose stack**
(litellm + PostgreSQL 16 + Prometheus) instead of the removed pip/venv/Prisma/systemd path.

## Why it was removed

- PR #14294 removed LiteLLM due to recurring Prisma/schema failures on self-hosted pip installs.
- See also [BerriAI/litellm#26097](https://github.com/BerriAI/litellm/issues/26097).

## Why this approach is safe now

- Uses upstream `docker-compose.yml` and `prometheus.yml` from BerriAI/litellm (pinned ref).
- No `pip install litellm`, no `prisma generate`, no systemd proxy service.
- Secrets generated at install time (`LITELLM_MASTER_KEY`, `LITELLM_SALT_KEY`, Postgres password).
- Postgres and Prometheus bound to `127.0.0.1` inside the LXC; proxy exposed on `:4000`.
- `update_script()` runs `docker compose pull && up -d` (same pattern as npmplus).

## Community contribution preserved

- Based on last functional commit `9fc822d` (stout01, prior work by MickLesk/tremor021 in #12550, #13835).
- Same `APP`, port 4000, `~/litellm.creds` pattern, `ct/` + `install/` structure.

## Test plan

- [x] Installed on Proxmox VE 9.2.x with `dev_mode=keep,logs`
- [x] LXC created with nesting enabled (`features: nesting=1`)
- [x] `curl http://<lxc-ip>:4000/health/liveliness` returns OK
- [x] `docker compose ps` shows litellm + postgres + prometheus
- [ ] UI accessible with generated master key (manual check)
- [ ] Update script pulls new images without data loss (manual check)

## Files changed

- `ct/litellm.sh`
- `install/litellm-install.sh`

Made with [Cursor](https://cursor.com)