### PR TITLE
New Script: Penpot (VM)

### DIFF
--- a/json/penpot-vm.json
+++ b/json/penpot-vm.json
@@ -33,10 +33,37 @@
     "password": null
   },
   "notes": [
-    "First boot pulls the official Penpot Docker Compose stack and can take several minutes depending on network speed.",
-    "Access Penpot at http://<VM-IP>:9001 once first-boot setup completes (check with: journalctl -u penpot-setup -f).",
-    "Public self-registration is disabled by default; enable it via the whiptail prompt during install or by editing PENPOT_FLAGS in /root/penpot/docker-compose.yaml.",
-    "This is a LAN-HTTP setup with no TLS. For internet-facing deployments, put a reverse proxy in front and update PENPOT_PUBLIC_URI accordingly.",
-    "As a rule of thumb, start with a minimum database size of 50GB to 100GB with elastic sizing capability — this configuration should adequately support up to 10 editors. For environments with more than 10 users, we recommend adding approximately 5GB of capacity per additional editor."
+    {
+      "text": "Defaults: 2 vCPU, 4096 MB RAM, 40G disk, Debian 13 (Trixie), Q35 machine type.",
+      "type": "info"
+    },
+    {
+      "text": "Telemetry is enabled by default (change in Advanced Settings during install).",
+      "type": "info"
+    },
+    {
+      "text": "Public registration is disabled by default (change in Advanced Settings during install, or later by editing PENPOT_FLAGS in /root/penpot/docker-compose.yaml).",
+      "type": "info"
+    },
+    {
+      "text": "VM Protection is disabled by default (change in Advanced Settings during install).",
+      "type": "info"
+    },
+    {
+      "text": "First boot pulls the official Penpot Docker Compose stack and can take several minutes depending on network speed.",
+      "type": "warning"
+    },
+    {
+      "text": "Access Penpot at http://<VM-IP>:9001 once first-boot setup completes (check with: journalctl -u penpot-setup -f).",
+      "type": "info"
+    },
+    {
+      "text": "This is a LAN-HTTP setup with no TLS. For internet-facing deployments, put a reverse proxy in front and update PENPOT_PUBLIC_URI accordingly.",
+      "type": "warning"
+    },
+    {
+      "text": "As a rule of thumb, start with a minimum database size of 50GB to 100GB with elastic sizing capability - this configuration should adequately support up to 10 editors. For environments with more than 10 users, we recommend adding approximately 5GB of capacity per additional editor.",
+      "type": "info"
+    }
   ]
 }

--- a/json/penpot-vm.json
+++ b/json/penpot-vm.json
@@ -1,0 +1,42 @@
+{
+  "name": "Penpot",
+  "slug": "penpot-vm",
+  "categories": [
+    12
+  ],
+  "date_created": "2026-07-04",
+  "type": "vm",
+  "updateable": false,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 9001,
+  "documentation": "https://help.penpot.app/",
+  "website": "https://penpot.app/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/penpot.webp",
+  "description": "Penpot is the open-source design and prototyping platform for cross-domain teams. Runs as a Docker Compose stack (frontend, backend, exporter, MCP, PostgreSQL, Valkey) inside a Debian VM, since the project's LXC standards forbid Docker in container-based install scripts.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "vm/penpot-vm.sh",
+      "config_path": "",
+      "resources": {
+        "cpu": 2,
+        "ram": 4096,
+        "hdd": 40,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    "First boot pulls the official Penpot Docker Compose stack and can take several minutes depending on network speed.",
+    "Access Penpot at http://<VM-IP>:9001 once first-boot setup completes (check with: journalctl -u penpot-setup -f).",
+    "Public self-registration is disabled by default; enable it via the whiptail prompt during install or by editing PENPOT_FLAGS in /root/penpot/docker-compose.yaml.",
+    "This is a LAN-HTTP setup with no TLS. For internet-facing deployments, put a reverse proxy in front and update PENPOT_PUBLIC_URI accordingly.",
+    "As a rule of thumb, start with a minimum database size of 50GB to 100GB with elastic sizing capability — this configuration should adequately support up to 10 editors. For environments with more than 10 users, we recommend adding approximately 5GB of capacity per additional editor."
+  ]
+}

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -1,0 +1,748 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: thost96 (thost96) | michelroegl-brunner | MickLesk
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+
+# ==============================================================================
+# Docker VM - Creates a Docker-ready Virtual Machine
+# ==============================================================================
+
+source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxVE/raw/branch/main/misc/api.func) 2>/dev/null
+source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxVE/raw/branch/main/misc/vm-core.func) 2>/dev/null
+source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxVE/raw/branch/main/misc/cloud-init.func) 2>/dev/null || true
+load_functions
+
+# ==============================================================================
+# SCRIPT VARIABLES
+# ==============================================================================
+APP="Docker"
+APP_TYPE="vm"
+NSAPP="docker-vm"
+var_os="debian"
+var_version="13"
+
+GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
+RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
+METHOD=""
+DISK_SIZE="10G"
+USE_CLOUD_INIT="no"
+OS_TYPE=""
+OS_VERSION=""
+THIN="discard=on,ssd=1,"
+
+# ==============================================================================
+# ERROR HANDLING & CLEANUP
+# ==============================================================================
+set -e
+trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
+trap cleanup EXIT
+trap 'post_update_to_api "failed" "130"' SIGINT
+trap 'post_update_to_api "failed" "143"' SIGTERM
+trap 'post_update_to_api "failed" "129"; exit 129' SIGHUP
+
+function error_handler() {
+  local exit_code="$?"
+  local line_number="$1"
+  local command="$2"
+  local error_message="${RD}[ERROR]${CL} in line ${RD}$line_number${CL}: exit code ${RD}$exit_code${CL}: while executing command ${YW}$command${CL}"
+  post_update_to_api "failed" "${exit_code}"
+  echo -e "\n$error_message\n"
+  cleanup_vmid
+}
+
+# ==============================================================================
+# OS SELECTION FUNCTIONS
+# ==============================================================================
+function select_os() {
+  if OS_CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "SELECT OS" --radiolist \
+    "Choose Operating System for Docker VM" 14 68 4 \
+    "debian13" "Debian 13 (Trixie) - Latest" ON \
+    "debian12" "Debian 12 (Bookworm) - Stable" OFF \
+    "ubuntu2404" "Ubuntu 24.04 LTS (Noble)" OFF \
+    "ubuntu2204" "Ubuntu 22.04 LTS (Jammy)" OFF \
+    3>&1 1>&2 2>&3); then
+    case $OS_CHOICE in
+    debian13)
+      OS_TYPE="debian"
+      OS_VERSION="13"
+      OS_CODENAME="trixie"
+      OS_DISPLAY="Debian 13 (Trixie)"
+      ;;
+    debian12)
+      OS_TYPE="debian"
+      OS_VERSION="12"
+      OS_CODENAME="bookworm"
+      OS_DISPLAY="Debian 12 (Bookworm)"
+      ;;
+    ubuntu2404)
+      OS_TYPE="ubuntu"
+      OS_VERSION="24.04"
+      OS_CODENAME="noble"
+      OS_DISPLAY="Ubuntu 24.04 LTS"
+      ;;
+    ubuntu2204)
+      OS_TYPE="ubuntu"
+      OS_VERSION="22.04"
+      OS_CODENAME="jammy"
+      OS_DISPLAY="Ubuntu 22.04 LTS"
+      ;;
+    esac
+    echo -e "${OS}${BOLD}${DGN}Operating System: ${BGN}${OS_DISPLAY}${CL}"
+  else
+    exit_script
+  fi
+}
+
+function select_cloud_init() {
+  if [ "$OS_TYPE" = "ubuntu" ]; then
+    USE_CLOUD_INIT="yes"
+    echo -e "${CLOUD:-${TAB}☁️${TAB}${CL}}${BOLD}${DGN}Cloud-Init: ${BGN}yes (Ubuntu requires Cloud-Init)${CL}"
+    return
+  fi
+
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "CLOUD-INIT" \
+    --yesno "Enable Cloud-Init for VM configuration?\n\nCloud-Init allows automatic configuration of:\n- User accounts and passwords\n- SSH keys\n- Network settings (DHCP/Static)\n- DNS configuration\n\nYou can also configure these settings later in Proxmox UI.\n\nNote: Debian without Cloud-Init will use nocloud image with console auto-login." 18 68); then
+    USE_CLOUD_INIT="yes"
+    echo -e "${CLOUD:-${TAB}☁️${TAB}${CL}}${BOLD}${DGN}Cloud-Init: ${BGN}yes${CL}"
+  else
+    USE_CLOUD_INIT="no"
+    echo -e "${CLOUD:-${TAB}☁️${TAB}${CL}}${BOLD}${DGN}Cloud-Init: ${BGN}no${CL}"
+  fi
+}
+
+function get_image_url() {
+  local arch=$(dpkg --print-architecture)
+  case $OS_TYPE in
+  debian)
+    if [ "$USE_CLOUD_INIT" = "yes" ]; then
+      echo "https://cloud.debian.org/images/cloud/${OS_CODENAME}/latest/debian-${OS_VERSION}-generic-${arch}.qcow2"
+    else
+      echo "https://cloud.debian.org/images/cloud/${OS_CODENAME}/latest/debian-${OS_VERSION}-nocloud-${arch}.qcow2"
+    fi
+    ;;
+  ubuntu)
+    echo "https://cloud-images.ubuntu.com/${OS_CODENAME}/current/${OS_CODENAME}-server-cloudimg-${arch}.img"
+    ;;
+  esac
+}
+
+# ==============================================================================
+# SETTINGS FUNCTIONS
+# ==============================================================================
+function default_settings() {
+  select_os
+  select_cloud_init
+
+  VMID=$(get_valid_nextid)
+  FORMAT=""
+  MACHINE=" -machine q35"
+  DISK_CACHE=""
+  DISK_SIZE="10G"
+  HN="docker"
+  CPU_TYPE=" -cpu host"
+  CORE_COUNT="2"
+  RAM_SIZE="4096"
+  BRG="vmbr0"
+  MAC="$GEN_MAC"
+  VLAN=""
+  MTU=""
+  START_VM="yes"
+  METHOD="default"
+
+  echo -e "${CONTAINERID}${BOLD}${DGN}Virtual Machine ID: ${BGN}${VMID}${CL}"
+  echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}Q35 (Modern)${CL}"
+  echo -e "${DISKSIZE}${BOLD}${DGN}Disk Size: ${BGN}${DISK_SIZE}${CL}"
+  echo -e "${DISKSIZE}${BOLD}${DGN}Disk Cache: ${BGN}None${CL}"
+  echo -e "${HOSTNAME}${BOLD}${DGN}Hostname: ${BGN}${HN}${CL}"
+  echo -e "${OS}${BOLD}${DGN}CPU Model: ${BGN}Host${CL}"
+  echo -e "${CPUCORE}${BOLD}${DGN}CPU Cores: ${BGN}${CORE_COUNT}${CL}"
+  echo -e "${RAMSIZE}${BOLD}${DGN}RAM Size: ${BGN}${RAM_SIZE}${CL}"
+  echo -e "${BRIDGE}${BOLD}${DGN}Bridge: ${BGN}${BRG}${CL}"
+  echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}${MAC}${CL}"
+  echo -e "${VLANTAG}${BOLD}${DGN}VLAN: ${BGN}Default${CL}"
+  echo -e "${DEFAULT}${BOLD}${DGN}Interface MTU Size: ${BGN}Default${CL}"
+  echo -e "${GATEWAY}${BOLD}${DGN}Start VM when completed: ${BGN}yes${CL}"
+  echo -e "${CREATING}${BOLD}${DGN}Creating a Docker VM using the above settings${CL}"
+}
+
+function advanced_settings() {
+  select_os
+  select_cloud_init
+
+  # SSH Key selection for Cloud-Init VMs
+  if [ "$USE_CLOUD_INIT" = "yes" ]; then
+    configure_cloudinit_ssh_keys || true
+  fi
+
+  METHOD="advanced"
+  [ -z "${VMID:-}" ] && VMID=$(get_valid_nextid)
+
+  # VM ID
+  while true; do
+    if VMID=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Virtual Machine ID" 8 58 $VMID --title "VIRTUAL MACHINE ID" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$VMID" ]; then
+        VMID=$(get_valid_nextid)
+      fi
+      if pct status "$VMID" &>/dev/null || qm status "$VMID" &>/dev/null; then
+        echo -e "${CROSS}${RD} ID $VMID is already in use${CL}"
+        sleep 2
+        continue
+      fi
+      echo -e "${CONTAINERID}${BOLD}${DGN}Virtual Machine ID: ${BGN}$VMID${CL}"
+      break
+    else
+      exit_script
+    fi
+  done
+
+  # Machine Type
+  if MACH=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "MACHINE TYPE" --radiolist --cancel-button Exit-Script "Choose Type" 10 58 2 \
+    "q35" "Q35 (Modern, PCIe)" ON \
+    "i440fx" "i440fx (Legacy, PCI)" OFF \
+    3>&1 1>&2 2>&3); then
+    if [ $MACH = q35 ]; then
+      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}Q35 (Modern)${CL}"
+      FORMAT=""
+      MACHINE=" -machine q35"
+    else
+      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}i440fx (Legacy)${CL}"
+      FORMAT=",efitype=4m"
+      MACHINE=""
+    fi
+  else
+    exit_script
+  fi
+
+  # Disk Size
+  if DISK_SIZE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Disk Size in GiB (e.g., 10, 20)" 8 58 "$DISK_SIZE" --title "DISK SIZE" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+    DISK_SIZE=$(echo "$DISK_SIZE" | tr -d ' ')
+    if [[ "$DISK_SIZE" =~ ^[0-9]+$ ]]; then
+      DISK_SIZE="${DISK_SIZE}G"
+      echo -e "${DISKSIZE}${BOLD}${DGN}Disk Size: ${BGN}$DISK_SIZE${CL}"
+    elif [[ "$DISK_SIZE" =~ ^[0-9]+G$ ]]; then
+      echo -e "${DISKSIZE}${BOLD}${DGN}Disk Size: ${BGN}$DISK_SIZE${CL}"
+    else
+      echo -e "${DISKSIZE}${BOLD}${RD}Invalid Disk Size. Please use a number (e.g., 10 or 10G).${CL}"
+      exit_script
+    fi
+  else
+    exit_script
+  fi
+
+  # Disk Cache
+  if DISK_CACHE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "DISK CACHE" --radiolist "Choose" --cancel-button Exit-Script 10 58 2 \
+    "0" "None (Default)" ON \
+    "1" "Write Through" OFF \
+    3>&1 1>&2 2>&3); then
+    if [ $DISK_CACHE = "1" ]; then
+      echo -e "${DISKSIZE}${BOLD}${DGN}Disk Cache: ${BGN}Write Through${CL}"
+      DISK_CACHE="cache=writethrough,"
+    else
+      echo -e "${DISKSIZE}${BOLD}${DGN}Disk Cache: ${BGN}None${CL}"
+      DISK_CACHE=""
+    fi
+  else
+    exit_script
+  fi
+
+  # Hostname
+  if VM_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Hostname" 8 58 docker --title "HOSTNAME" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+    if [ -z $VM_NAME ]; then
+      HN="docker"
+    else
+      HN=$(echo "${VM_NAME,,}" | tr -cs 'a-z0-9-' '-' | sed 's/^-//;s/-$//')
+      if [ "$HN" != "${VM_NAME,,}" ]; then
+        whiptail --backtitle "Proxmox VE Helper Scripts" --title "HOSTNAME ADJUSTED" --msgbox "Invalid characters detected. Hostname has been adjusted to:\n\n  $HN" 10 58
+      fi
+    fi
+    echo -e "${HOSTNAME}${BOLD}${DGN}Hostname: ${BGN}$HN${CL}"
+  else
+    exit_script
+  fi
+
+  # CPU Model
+  if CPU_TYPE1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU MODEL" --radiolist "Choose" --cancel-button Exit-Script 10 58 2 \
+    "1" "Host (Recommended)" ON \
+    "0" "KVM64" OFF \
+    3>&1 1>&2 2>&3); then
+    if [ $CPU_TYPE1 = "1" ]; then
+      echo -e "${OS}${BOLD}${DGN}CPU Model: ${BGN}Host${CL}"
+      CPU_TYPE=" -cpu host"
+    else
+      echo -e "${OS}${BOLD}${DGN}CPU Model: ${BGN}KVM64${CL}"
+      CPU_TYPE=""
+    fi
+  else
+    exit_script
+  fi
+
+  # CPU Cores
+  while true; do
+    if CORE_COUNT=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Allocate CPU Cores" 8 58 2 --title "CORE COUNT" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$CORE_COUNT" ]; then CORE_COUNT="2"; fi
+      if [[ "$CORE_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+        echo -e "${CPUCORE}${BOLD}${DGN}CPU Cores: ${BGN}$CORE_COUNT${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "CPU Cores must be a positive integer (e.g., 2)." 8 58
+    else
+      exit_script
+    fi
+  done
+
+  # RAM Size
+  while true; do
+    if RAM_SIZE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Allocate RAM in MiB" 8 58 4096 --title "RAM" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$RAM_SIZE" ]; then RAM_SIZE="4096"; fi
+      if [[ "$RAM_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+        echo -e "${RAMSIZE}${BOLD}${DGN}RAM Size: ${BGN}$RAM_SIZE${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "RAM Size must be a positive integer in MiB (e.g., 4096)." 8 58
+    else
+      exit_script
+    fi
+  done
+
+  # Bridge
+  if BRG=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a Bridge" 8 58 vmbr0 --title "BRIDGE" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+    if [ -z $BRG ]; then
+      BRG="vmbr0"
+    fi
+    echo -e "${BRIDGE}${BOLD}${DGN}Bridge: ${BGN}$BRG${CL}"
+  else
+    exit_script
+  fi
+
+  # MAC Address
+  while true; do
+    if MAC1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a MAC Address" 8 58 $GEN_MAC --title "MAC ADDRESS" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$MAC1" ]; then
+        MAC="$GEN_MAC"
+        echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}$MAC${CL}"
+        break
+      fi
+      if [[ "$MAC1" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+        MAC="$MAC1"
+        echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}$MAC${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "Invalid MAC address format. Use XX:XX:XX:XX:XX:XX (e.g., AA:BB:CC:DD:EE:FF)." 8 58
+    else
+      exit_script
+    fi
+  done
+
+  # VLAN
+  while true; do
+    if VLAN1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a Vlan (leave blank for default)" 8 58 --title "VLAN" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$VLAN1" ]; then
+        VLAN1="Default"
+        VLAN=""
+        echo -e "${VLANTAG}${BOLD}${DGN}VLAN: ${BGN}$VLAN1${CL}"
+        break
+      fi
+      if [[ "$VLAN1" =~ ^[0-9]+$ ]] && [ "$VLAN1" -ge 1 ] && [ "$VLAN1" -le 4094 ]; then
+        VLAN=",tag=$VLAN1"
+        echo -e "${VLANTAG}${BOLD}${DGN}VLAN: ${BGN}$VLAN1${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "VLAN must be a number between 1 and 4094, or leave blank for default." 8 58
+    else
+      exit_script
+    fi
+  done
+
+  # MTU
+  while true; do
+    if MTU1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Interface MTU Size (leave blank for default)" 8 58 --title "MTU SIZE" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ -z "$MTU1" ]; then
+        MTU1="Default"
+        MTU=""
+        echo -e "${DEFAULT}${BOLD}${DGN}Interface MTU Size: ${BGN}$MTU1${CL}"
+        break
+      fi
+      if [[ "$MTU1" =~ ^[0-9]+$ ]] && [ "$MTU1" -ge 576 ] && [ "$MTU1" -le 65520 ]; then
+        MTU=",mtu=$MTU1"
+        echo -e "${DEFAULT}${BOLD}${DGN}Interface MTU Size: ${BGN}$MTU1${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "MTU Size must be a number between 576 and 65520, or leave blank for default." 8 58
+    else
+      exit_script
+    fi
+  done
+
+  # Start VM
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "START VIRTUAL MACHINE" --yesno "Start VM when completed?" 10 58); then
+    echo -e "${GATEWAY}${BOLD}${DGN}Start VM when completed: ${BGN}yes${CL}"
+    START_VM="yes"
+  else
+    echo -e "${GATEWAY}${BOLD}${DGN}Start VM when completed: ${BGN}no${CL}"
+    START_VM="no"
+  fi
+
+  # Confirm
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "ADVANCED SETTINGS COMPLETE" --yesno "Ready to create a Docker VM?" --no-button Do-Over 10 58); then
+    echo -e "${CREATING}${BOLD}${DGN}Creating a Docker VM using the above advanced settings${CL}"
+  else
+    header_info
+    echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
+    advanced_settings
+  fi
+}
+
+function start_script() {
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "SETTINGS" --yesno "Use Default Settings?" --no-button Advanced 10 58); then
+    header_info
+    echo -e "${DEFAULT}${BOLD}${BL}Using Default Settings${CL}"
+    default_settings
+  else
+    header_info
+    echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
+    advanced_settings
+  fi
+}
+
+# ==============================================================================
+# MAIN EXECUTION
+# ==============================================================================
+header_info
+
+check_root
+arch_check
+pve_check
+
+if whiptail --backtitle "Proxmox VE Helper Scripts" --title "Docker VM" --yesno "This will create a New Docker VM. Proceed?" 10 58; then
+  :
+else
+  header_info && echo -e "${CROSS}${RD}User exited script${CL}\n" && exit
+fi
+
+start_script
+post_to_api_vm
+
+# ==============================================================================
+# STORAGE SELECTION
+# ==============================================================================
+msg_info "Validating Storage"
+while read -r line; do
+  TAG=$(echo $line | awk '{print $1}')
+  TYPE=$(echo $line | awk '{printf "%-10s", $2}')
+  FREE=$(echo $line | numfmt --field 4-6 --from-unit=K --to=iec --format %.2f | awk '{printf( "%9sB", $6)}')
+  ITEM="  Type: $TYPE Free: $FREE "
+  OFFSET=2
+  if [[ $((${#ITEM} + $OFFSET)) -gt ${MSG_MAX_LENGTH:-} ]]; then
+    MSG_MAX_LENGTH=$((${#ITEM} + $OFFSET))
+  fi
+  STORAGE_MENU+=("$TAG" "$ITEM" "OFF")
+done < <(pvesm status -content images | awk 'NR>1')
+
+VALID=$(pvesm status -content images | awk 'NR>1')
+if [ -z "$VALID" ]; then
+  msg_error "Unable to detect a valid storage location."
+  exit
+elif [ $((${#STORAGE_MENU[@]} / 3)) -eq 1 ]; then
+  STORAGE=${STORAGE_MENU[0]}
+else
+  if [ -n "$SPINNER_PID" ] && ps -p $SPINNER_PID >/dev/null; then kill $SPINNER_PID >/dev/null; fi
+  printf "\e[?25h"
+  while [ -z "${STORAGE:+x}" ]; do
+    STORAGE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Storage Pools" --radiolist \
+      "Which storage pool would you like to use for ${HN}?\nTo make a selection, use the Spacebar.\n" \
+      16 $(($MSG_MAX_LENGTH + 23)) 6 \
+      "${STORAGE_MENU[@]}" 3>&1 1>&2 2>&3)
+  done
+fi
+msg_ok "Using ${CL}${BL}$STORAGE${CL} ${GN}for Storage Location."
+msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
+
+# ==============================================================================
+# PREREQUISITES
+# ==============================================================================
+if ! command -v virt-customize &>/dev/null; then
+  msg_info "Installing libguestfs-tools"
+  apt-get -qq update >/dev/null
+  apt-get -qq install libguestfs-tools lsb-release -y >/dev/null
+  apt-get -qq install dhcpcd-base -y >/dev/null 2>&1 || true
+  msg_ok "Installed libguestfs-tools"
+fi
+
+# ==============================================================================
+# IMAGE DOWNLOAD
+# ==============================================================================
+msg_info "Retrieving the URL for the ${OS_DISPLAY} Qcow2 Disk Image"
+URL=$(get_image_url)
+CACHE_DIR="/var/lib/vz/template/cache"
+CACHE_FILE="$CACHE_DIR/$(basename "$URL")"
+mkdir -p "$CACHE_DIR"
+msg_ok "${CL}${BL}${URL}${CL}"
+
+if [[ ! -s "$CACHE_FILE" ]]; then
+  curl -f#SL -o "$CACHE_FILE" "$URL"
+  echo -en "\e[1A\e[0K"
+  msg_ok "Downloaded ${CL}${BL}$(basename "$CACHE_FILE")${CL}"
+else
+  msg_ok "Using cached image ${CL}${BL}$(basename "$CACHE_FILE")${CL}"
+fi
+
+# ==============================================================================
+# STORAGE TYPE DETECTION
+# ==============================================================================
+STORAGE_TYPE=$(pvesm status -storage "$STORAGE" | awk 'NR>1 {print $2}')
+case $STORAGE_TYPE in
+nfs | dir)
+  DISK_EXT=".qcow2"
+  DISK_REF="$VMID/"
+  DISK_IMPORT="--format qcow2"
+  THIN=""
+  ;;
+btrfs)
+  DISK_EXT=".raw"
+  DISK_REF="$VMID/"
+  DISK_IMPORT="--format raw"
+  FORMAT=",efitype=4m"
+  THIN=""
+  ;;
+*)
+  DISK_EXT=""
+  DISK_REF=""
+  DISK_IMPORT="--format raw"
+  ;;
+esac
+
+# ==============================================================================
+# IMAGE CUSTOMIZATION WITH DOCKER
+# ==============================================================================
+msg_info "Preparing ${OS_DISPLAY} image with Docker"
+
+WORK_FILE=$(mktemp --suffix=.qcow2)
+cp "$CACHE_FILE" "$WORK_FILE"
+
+export LIBGUESTFS_BACKEND_SETTINGS=dns=8.8.8.8,1.1.1.1
+
+DOCKER_PREINSTALLED="no"
+
+# Install qemu-guest-agent and Docker during image customization
+msg_info "Installing base packages in image"
+if virt-customize -a "$WORK_FILE" --install qemu-guest-agent,curl,ca-certificates >/dev/null 2>&1; then
+  msg_ok "Installed base packages"
+
+  msg_info "Installing Docker (this may take 2-5 minutes)"
+  if virt-customize -q -a "$WORK_FILE" --run-command "curl -fsSL https://get.docker.com | sh" >/dev/null 2>&1 &&
+    virt-customize -q -a "$WORK_FILE" --run-command "systemctl enable docker" >/dev/null 2>&1; then
+    msg_ok "Installed Docker"
+
+    msg_info "Configuring Docker daemon"
+    # Optimize Docker daemon configuration
+    virt-customize -q -a "$WORK_FILE" --run-command "mkdir -p /etc/docker" >/dev/null 2>&1
+    virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/docker/daemon.json << EOF
+{
+  "storage-driver": "overlay2",
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF' >/dev/null 2>&1
+    DOCKER_PREINSTALLED="yes"
+    msg_ok "Configured Docker daemon"
+  else
+    msg_ok "Docker will be installed on first boot"
+  fi
+else
+  msg_ok "Packages will be installed on first boot"
+fi
+
+msg_info "Finalizing image (hostname, SSH config)"
+# Set hostname and prepare for unique machine-id
+virt-customize -q -a "$WORK_FILE" --hostname "${HN}" >/dev/null 2>&1 || true
+virt-customize -q -a "$WORK_FILE" --run-command "truncate -s 0 /etc/machine-id" >/dev/null 2>&1 || true
+virt-customize -q -a "$WORK_FILE" --run-command "rm -f /var/lib/dbus/machine-id" >/dev/null 2>&1 || true
+
+# Configure SSH for Cloud-Init
+if [ "$USE_CLOUD_INIT" = "yes" ]; then
+  virt-customize -q -a "$WORK_FILE" --run-command "sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config" >/dev/null 2>&1 || true
+  virt-customize -q -a "$WORK_FILE" --run-command "sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config" >/dev/null 2>&1 || true
+else
+  # Configure auto-login for nocloud images (no Cloud-Init)
+  virt-customize -q -a "$WORK_FILE" --run-command "mkdir -p /etc/systemd/system/serial-getty@ttyS0.service.d" >/dev/null 2>&1 || true
+  virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/systemd/system/serial-getty@ttyS0.service.d/autologin.conf << EOF
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I \$TERM
+EOF' >/dev/null 2>&1 || true
+  virt-customize -q -a "$WORK_FILE" --run-command "mkdir -p /etc/systemd/system/getty@tty1.service.d" >/dev/null 2>&1 || true
+  virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/systemd/system/getty@tty1.service.d/autologin.conf << EOF
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I \$TERM
+EOF' >/dev/null 2>&1 || true
+fi
+msg_ok "Finalized image"
+
+# Create first-boot Docker install script (fallback if virt-customize failed)
+if [ "$DOCKER_PREINSTALLED" = "no" ]; then
+  if virt-customize -q -a "$WORK_FILE" --run-command 'cat > /root/install-docker.sh << "DOCKERSCRIPT"
+#!/bin/bash
+exec > /var/log/install-docker.log 2>&1
+echo "[$(date)] Starting Docker installation"
+
+for i in {1..30}; do
+  ping -c 1 8.8.8.8 >/dev/null 2>&1 && break
+  sleep 2
+done
+
+apt-get update
+apt-get install -y qemu-guest-agent curl ca-certificates
+curl -fsSL https://get.docker.com | sh
+systemctl enable docker
+systemctl start docker
+
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json << DAEMON
+{
+  "storage-driver": "overlay2",
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-file": "3" }
+}
+DAEMON
+systemctl restart docker
+
+touch /root/.docker-installed
+echo "[$(date)] Docker installation completed"
+DOCKERSCRIPT
+chmod +x /root/install-docker.sh' >/dev/null 2>&1; then
+
+    virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/systemd/system/install-docker.service << "DOCKERSERVICE"
+[Unit]
+Description=Install Docker on First Boot
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=!/root/.docker-installed
+
+[Service]
+Type=oneshot
+ExecStart=/root/install-docker.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+DOCKERSERVICE
+systemctl enable install-docker.service' >/dev/null 2>&1 || true
+  else
+    msg_warn "virt-customize failed for this image. Docker must be installed manually after first boot:"
+    msg_warn "  curl -fsSL https://get.docker.com | sh"
+  fi
+fi
+
+# Resize disk to target size
+msg_info "Resizing disk image to ${DISK_SIZE}"
+qemu-img resize "$WORK_FILE" "${DISK_SIZE}" >/dev/null 2>&1
+msg_ok "Resized disk image"
+
+# ==============================================================================
+# VM CREATION
+# ==============================================================================
+msg_info "Creating Docker VM shell"
+
+qm create $VMID -agent 1${MACHINE} -tablet 0 -localtime 1 -bios ovmf${CPU_TYPE} -cores $CORE_COUNT -memory $RAM_SIZE \
+  -name $HN -tags community-script -net0 virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
+
+msg_ok "Created VM shell"
+
+# ==============================================================================
+# DISK IMPORT
+# ==============================================================================
+msg_info "Importing disk into storage ($STORAGE)"
+
+if qm disk import --help >/dev/null 2>&1; then
+  IMPORT_CMD=(qm disk import)
+else
+  IMPORT_CMD=(qm importdisk)
+fi
+
+IMPORT_OUT="$("${IMPORT_CMD[@]}" "$VMID" "$WORK_FILE" "$STORAGE" ${DISK_IMPORT:-} 2>&1 || true)"
+DISK_REF_IMPORTED="$(printf '%s\n' "$IMPORT_OUT" | sed -n "s/.*successfully imported disk '\([^']\+\)'.*/\1/p" | tr -d "\r\"'")"
+[[ -z "$DISK_REF_IMPORTED" ]] && DISK_REF_IMPORTED="$(pvesm list "$STORAGE" | awk -v id="$VMID" '$5 ~ ("vm-"id"-disk-") {print $1":"$5}' | sort | tail -n1)"
+[[ -z "$DISK_REF_IMPORTED" ]] && {
+  msg_error "Unable to determine imported disk reference."
+  echo "$IMPORT_OUT"
+  exit 226
+}
+
+msg_ok "Imported disk (${CL}${BL}${DISK_REF_IMPORTED}${CL})"
+
+# Clean up work file
+rm -f "$WORK_FILE"
+
+# ==============================================================================
+# VM CONFIGURATION
+# ==============================================================================
+msg_info "Attaching EFI and root disk"
+
+qm set "$VMID" \
+  --efidisk0 "${STORAGE}:0,efitype=4m" \
+  --scsi0 "${DISK_REF_IMPORTED},${DISK_CACHE}${THIN%,}" \
+  --boot order=scsi0 \
+  --serial0 socket >/dev/null
+
+qm set $VMID --agent enabled=1 >/dev/null
+
+msg_ok "Attached EFI and root disk"
+
+# Set VM description
+set_description
+
+# Cloud-Init configuration
+if [ "$USE_CLOUD_INIT" = "yes" ]; then
+  msg_info "Configuring Cloud-Init"
+  setup_cloud_init "$VMID" "$STORAGE" "$HN" "yes"
+  msg_ok "Cloud-Init configured"
+fi
+
+# Start VM
+if [ "$START_VM" == "yes" ]; then
+  msg_info "Starting Docker VM"
+  qm start $VMID >/dev/null 2>&1
+  msg_ok "Started Docker VM"
+fi
+
+# ==============================================================================
+# FINAL OUTPUT
+# ==============================================================================
+VM_IP=""
+if [ "$START_VM" == "yes" ]; then
+  set +e
+  for i in {1..10}; do
+    VM_IP=$(qm guest cmd "$VMID" network-get-interfaces 2>/dev/null |
+      jq -r '.[] | select(.name != "lo") | ."ip-addresses"[]? | select(."ip-address-type" == "ipv4") | ."ip-address"' 2>/dev/null |
+      grep -v "^127\." | head -1) || true
+    [ -n "$VM_IP" ] && break
+    sleep 3
+  done
+  set -e
+fi
+
+echo -e "\n${INFO}${BOLD}${GN}Docker VM Configuration Summary:${CL}"
+echo -e "${TAB}${DGN}VM ID: ${BGN}${VMID}${CL}"
+echo -e "${TAB}${DGN}Hostname: ${BGN}${HN}${CL}"
+echo -e "${TAB}${DGN}OS: ${BGN}${OS_DISPLAY}${CL}"
+[ -n "$VM_IP" ] && echo -e "${TAB}${DGN}IP Address: ${BGN}${VM_IP}${CL}"
+
+if [ "$DOCKER_PREINSTALLED" = "yes" ]; then
+  echo -e "${TAB}${DGN}Docker: ${BGN}Pre-installed (via get.docker.com)${CL}"
+else
+  echo -e "${TAB}${DGN}Docker: ${BGN}Installing on first boot${CL}"
+  echo -e "${TAB}${YW}⚠️  Wait 2-3 minutes for installation to complete${CL}"
+  echo -e "${TAB}${YW}⚠️  Check progress: ${BL}cat /var/log/install-docker.log${CL}"
+fi
+
+if [ "$USE_CLOUD_INIT" = "yes" ]; then
+  display_cloud_init_info "$VMID" "$HN" 2>/dev/null || true
+fi
+
+post_update_to_api "done" "none"
+msg_ok "Completed successfully!\n"

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -719,6 +719,7 @@ fi
 
 touch /root/.penpot-setup-done
 echo "[$(date)] Penpot setup completed"
+echo "[$(date)] Penpot is available at: http://${PENPOT_IP}:9001"
 SETUPEOF
   virt-customize -q -a "$WORK_FILE" \
     --upload "${penpot_setup_tmp}:/root/penpot-setup.sh" \
@@ -976,7 +977,9 @@ if [ -n "$VM_IP" ]; then
   echo -e "${INFO}${YW} Access it using the following URL (once first-boot setup completes):${CL}"
   echo -e "${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
 else
-  echo -e "${INFO}${YW} IP not detected yet - check the Summary tab in the Proxmox UI for this VM's IP once it boots.${CL}"
+  echo -e "${INFO}${YW} IP not detected yet. Once first-boot setup completes, the real URL is printed by:${CL}"
+  echo -e "${TAB}${BGN}journalctl -u penpot-setup | grep 'available at'${CL}"
+  echo -e "${TAB}${DGN}(or check the Summary tab in the Proxmox UI for this VM's IP)${CL}"
   echo -e "${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
 fi
 

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -144,7 +144,7 @@ function prompt_penpot_telemetry() {
   else
     PENPOT_TELEMETRY_INPUT="disable"
   fi
-  echo -e "${INFO}${BOLD}${DGN}Penpot Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d${CL}"
+  msg_custom "$INFO" "${BOLD}${DGN}" "Penpot Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d"
 }
 
 function prompt_penpot_registration() {
@@ -154,7 +154,7 @@ function prompt_penpot_registration() {
   else
     PENPOT_REGISTRATION_INPUT="disable"
   fi
-  echo -e "${INFO}${BOLD}${DGN}Penpot Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
+  msg_custom "$INFO" "${BOLD}${DGN}" "Penpot Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d"
 }
 
 function prompt_penpot_admin_account() {
@@ -163,7 +163,7 @@ function prompt_penpot_admin_account() {
   if PENPOT_ADMIN_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
     --inputbox "Registration is disabled, so this account will be the only way to log in.\n\nFull name for the first Penpot account:" 11 70 "Admin" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
     [ -z "$PENPOT_ADMIN_NAME" ] && PENPOT_ADMIN_NAME="Admin"
-    echo -e "${INFO}${BOLD}${DGN}First User Name: ${BGN}${PENPOT_ADMIN_NAME}${CL}"
+    msg_custom "$INFO" "${BOLD}${DGN}" "First User Name: ${BGN}${PENPOT_ADMIN_NAME}"
   else
     exit_script
   fi
@@ -172,7 +172,7 @@ function prompt_penpot_admin_account() {
     if PENPOT_ADMIN_EMAIL=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
       --inputbox "Email for the first account (this is the login username):" 10 70 "" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
       if [[ "$PENPOT_ADMIN_EMAIL" =~ ^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$ ]]; then
-        echo -e "${INFO}${BOLD}${DGN}First User Email: ${BGN}${PENPOT_ADMIN_EMAIL}${CL}"
+        msg_custom "$INFO" "${BOLD}${DGN}" "First User Email: ${BGN}${PENPOT_ADMIN_EMAIL}"
         break
       fi
       whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "Enter a valid email address (e.g. you@example.com)." 8 60
@@ -185,7 +185,7 @@ function prompt_penpot_admin_account() {
     if PENPOT_ADMIN_PASSWORD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
       --passwordbox "Password for the first account (min. 8 characters):" 10 70 --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
       if [ "${#PENPOT_ADMIN_PASSWORD}" -ge 8 ]; then
-        echo -e "${INFO}${BOLD}${DGN}First User Password: ${BGN}(hidden)${CL}"
+        msg_custom "$INFO" "${BOLD}${DGN}" "First User Password: ${BGN}(hidden)"
         break
       fi
       whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "Password must be at least 8 characters." 8 60
@@ -202,7 +202,7 @@ function prompt_vm_protection() {
   else
     PROTECT_VM="no"
   fi
-  echo -e "${INFO}${BOLD}${DGN}VM Protection: ${BGN}${PROTECT_VM}${CL}"
+  msg_custom "$INFO" "${BOLD}${DGN}" "VM Protection: ${BGN}${PROTECT_VM}"
 }
 
 # ==============================================================================
@@ -954,7 +954,8 @@ fi
 # ==============================================================================
 # FINAL OUTPUT
 # ==============================================================================
-echo -e "\n${INFO}${BOLD}${GN}Penpot VM Configuration Summary:${CL}"
+echo -e ""
+msg_custom "$INFO" "${BOLD}${GN}" "Penpot VM Configuration Summary:"
 echo -e "${TAB}${DGN}VM ID: ${BGN}${VMID}${CL}"
 echo -e "${TAB}${DGN}Hostname: ${BGN}${HN}${CL}"
 echo -e "${TAB}${DGN}OS: ${BGN}${OS_DISPLAY}${CL}"
@@ -968,21 +969,21 @@ else
 fi
 
 echo -e ""
-echo -e "${INFO}${BOLD}${GN}Penpot is being configured automatically on first boot!${CL}"
+msg_custom "$INFO" "${BOLD}${GN}" "Penpot is being configured automatically on first boot!"
 echo -e "${TAB}${YW}⚠️  First boot pulls several GB of Docker images — this can take several minutes.${CL}"
 echo -e "${TAB}${DGN}Setup log: ${BGN}journalctl -u penpot-setup -f${CL}"
 echo -e "${TAB}${DGN}Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d${CL}"
 echo -e "${TAB}${DGN}Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
 
 echo -e ""
-echo -e "${INFO}${YW} Once first-boot setup completes, open Penpot on this VM's IP at port 9001:${CL}"
+msg_custom "$INFO" "$YW" "Once first-boot setup completes, open Penpot on this VM's IP at port 9001:"
 echo -e "${GATEWAY}${BGN}http://<this-VM's-IP>:9001${CL}"
 echo -e "${TAB}${DGN}Find the IP in the Proxmox UI: select this VM -> Summary tab.${CL}"
 
 if [ "$PENPOT_REGISTRATION_INPUT" = "enable" ]; then
-  echo -e "${INFO}${YW} Log in: ${CL}open the URL above and use Create account to register the first user."
+  msg_custom "$INFO" "$YW" "Log in: ${CL}open the URL above and use Create account to register the first user."
 else
-  echo -e "${INFO}${YW} Log in: ${CL}registration is disabled — the account below is created automatically on first boot."
+  msg_custom "$INFO" "$YW" "Log in: ${CL}registration is disabled — the account below is created automatically on first boot."
   echo -e "${TAB}${DGN}Email: ${BGN}${PENPOT_ADMIN_EMAIL}${CL}"
   echo -e "${TAB}${DGN}Password: ${BGN}(the one you entered during setup)${CL}"
 fi

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -956,20 +956,23 @@ fi
 # ==============================================================================
 VM_IP=""
 if [ "$START_VM" == "yes" ]; then
-  msg_info "Waiting for VM IP address (up to 60s)"
-  set +e
-  for i in {1..20}; do
+  msg_info "Waiting for guest agent (first boot pulls Docker images, ~5-6 min)"
+  for i in {1..180}; do
     VM_IP=$(qm guest cmd "$VMID" network-get-interfaces 2>/dev/null |
       jq -r '.[] | select(.name != "lo") | ."ip-addresses"[]? | select(."ip-address-type" == "ipv4") | ."ip-address"' 2>/dev/null |
-      grep -v "^127\." | head -1) || true
-    [ -n "$VM_IP" ] && break
-    sleep 3
+      grep -v "^127\." | head -1 || echo "")
+    if [ -n "$VM_IP" ]; then
+      break
+    fi
+    # Show elapsed time so it doesn't look stuck
+    printf "\r${TAB}${YW}${HOLD}Waiting for guest agent (first boot pulls Docker images, ~5-6 min) [%ds]${HOLD}" "$((i * 2))"
+    sleep 2
   done
-  set -e
+
   if [ -n "$VM_IP" ]; then
-    msg_ok "VM IP address: ${VM_IP}"
+    msg_ok "Guest agent responding — VM IP: ${VM_IP}"
   else
-    msg_ok "VM IP address not detected yet (see notes below)"
+    msg_ok "VM started (could not detect IP — check VM console)"
   fi
 fi
 

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: thost96 (thost96) | michelroegl-brunner | MickLesk
+# Author: unreadablename
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://penpot.app
 
 # ==============================================================================
-# Docker VM - Creates a Docker-ready Virtual Machine
+# Penpot VM - Creates a Docker-based Penpot Virtual Machine
 # ==============================================================================
 
 source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxVE/raw/branch/main/misc/api.func) 2>/dev/null
@@ -16,16 +17,16 @@ load_functions
 # ==============================================================================
 # SCRIPT VARIABLES
 # ==============================================================================
-APP="Docker"
+APP="Penpot"
 APP_TYPE="vm"
-NSAPP="docker-vm"
+NSAPP="penpot-vm"
 var_os="debian"
 var_version="13"
 
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-DISK_SIZE="10G"
+DISK_SIZE="40G"
 USE_CLOUD_INIT="no"
 OS_TYPE=""
 OS_VERSION=""
@@ -56,7 +57,7 @@ function error_handler() {
 # ==============================================================================
 function select_os() {
   if OS_CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "SELECT OS" --radiolist \
-    "Choose Operating System for Docker VM" 14 68 4 \
+    "Choose Operating System for Penpot VM" 14 68 4 \
     "debian13" "Debian 13 (Trixie) - Latest" ON \
     "debian12" "Debian 12 (Bookworm) - Stable" OFF \
     "ubuntu2404" "Ubuntu 24.04 LTS (Noble)" OFF \
@@ -138,8 +139,8 @@ function default_settings() {
   FORMAT=""
   MACHINE=" -machine q35"
   DISK_CACHE=""
-  DISK_SIZE="10G"
-  HN="docker"
+  DISK_SIZE="40G"
+  HN="penpot"
   CPU_TYPE=" -cpu host"
   CORE_COUNT="2"
   RAM_SIZE="4096"
@@ -163,7 +164,7 @@ function default_settings() {
   echo -e "${VLANTAG}${BOLD}${DGN}VLAN: ${BGN}Default${CL}"
   echo -e "${DEFAULT}${BOLD}${DGN}Interface MTU Size: ${BGN}Default${CL}"
   echo -e "${GATEWAY}${BOLD}${DGN}Start VM when completed: ${BGN}yes${CL}"
-  echo -e "${CREATING}${BOLD}${DGN}Creating a Docker VM using the above settings${CL}"
+  echo -e "${CREATING}${BOLD}${DGN}Creating a Penpot VM using the above settings${CL}"
 }
 
 function advanced_settings() {
@@ -215,7 +216,7 @@ function advanced_settings() {
   fi
 
   # Disk Size
-  if DISK_SIZE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Disk Size in GiB (e.g., 10, 20)" 8 58 "$DISK_SIZE" --title "DISK SIZE" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+  if DISK_SIZE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Disk Size in GiB (e.g., 40, 60)" 8 58 "$DISK_SIZE" --title "DISK SIZE" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
     DISK_SIZE=$(echo "$DISK_SIZE" | tr -d ' ')
     if [[ "$DISK_SIZE" =~ ^[0-9]+$ ]]; then
       DISK_SIZE="${DISK_SIZE}G"
@@ -223,7 +224,7 @@ function advanced_settings() {
     elif [[ "$DISK_SIZE" =~ ^[0-9]+G$ ]]; then
       echo -e "${DISKSIZE}${BOLD}${DGN}Disk Size: ${BGN}$DISK_SIZE${CL}"
     else
-      echo -e "${DISKSIZE}${BOLD}${RD}Invalid Disk Size. Please use a number (e.g., 10 or 10G).${CL}"
+      echo -e "${DISKSIZE}${BOLD}${RD}Invalid Disk Size. Please use a number (e.g., 40 or 40G).${CL}"
       exit_script
     fi
   else
@@ -247,9 +248,9 @@ function advanced_settings() {
   fi
 
   # Hostname
-  if VM_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Hostname" 8 58 docker --title "HOSTNAME" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+  if VM_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Hostname" 8 58 penpot --title "HOSTNAME" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
     if [ -z $VM_NAME ]; then
-      HN="docker"
+      HN="penpot"
     else
       HN=$(echo "${VM_NAME,,}" | tr -cs 'a-z0-9-' '-' | sed 's/^-//;s/-$//')
       if [ "$HN" != "${VM_NAME,,}" ]; then
@@ -384,8 +385,8 @@ function advanced_settings() {
   fi
 
   # Confirm
-  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "ADVANCED SETTINGS COMPLETE" --yesno "Ready to create a Docker VM?" --no-button Do-Over 10 58); then
-    echo -e "${CREATING}${BOLD}${DGN}Creating a Docker VM using the above advanced settings${CL}"
+  if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "ADVANCED SETTINGS COMPLETE" --yesno "Ready to create a Penpot VM?" --no-button Do-Over 10 58); then
+    echo -e "${CREATING}${BOLD}${DGN}Creating a Penpot VM using the above advanced settings${CL}"
   else
     header_info
     echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
@@ -414,7 +415,7 @@ check_root
 arch_check
 pve_check
 
-if whiptail --backtitle "Proxmox VE Helper Scripts" --title "Docker VM" --yesno "This will create a New Docker VM. Proceed?" 10 58; then
+if whiptail --backtitle "Proxmox VE Helper Scripts" --title "Penpot VM" --yesno "This will create a New Penpot VM. Proceed?" 10 58; then
   :
 else
   header_info && echo -e "${CROSS}${RD}User exited script${CL}\n" && exit
@@ -646,7 +647,7 @@ msg_ok "Resized disk image"
 # ==============================================================================
 # VM CREATION
 # ==============================================================================
-msg_info "Creating Docker VM shell"
+msg_info "Creating Penpot VM shell"
 
 qm create $VMID -agent 1${MACHINE} -tablet 0 -localtime 1 -bios ovmf${CPU_TYPE} -cores $CORE_COUNT -memory $RAM_SIZE \
   -name $HN -tags community-script -net0 virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
@@ -705,9 +706,9 @@ fi
 
 # Start VM
 if [ "$START_VM" == "yes" ]; then
-  msg_info "Starting Docker VM"
+  msg_info "Starting Penpot VM"
   qm start $VMID >/dev/null 2>&1
-  msg_ok "Started Docker VM"
+  msg_ok "Started Penpot VM"
 fi
 
 # ==============================================================================
@@ -726,7 +727,7 @@ if [ "$START_VM" == "yes" ]; then
   set -e
 fi
 
-echo -e "\n${INFO}${BOLD}${GN}Docker VM Configuration Summary:${CL}"
+echo -e "\n${INFO}${BOLD}${GN}Penpot VM Configuration Summary:${CL}"
 echo -e "${TAB}${DGN}VM ID: ${BGN}${VMID}${CL}"
 echo -e "${TAB}${DGN}Hostname: ${BGN}${HN}${CL}"
 echo -e "${TAB}${DGN}OS: ${BGN}${OS_DISPLAY}${CL}"

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -954,33 +954,10 @@ fi
 # ==============================================================================
 # FINAL OUTPUT
 # ==============================================================================
-VM_IP=""
-if [ "$START_VM" == "yes" ]; then
-  msg_info "Waiting for guest agent (first boot pulls Docker images, ~5-6 min)"
-  for i in {1..180}; do
-    VM_IP=$(qm guest cmd "$VMID" network-get-interfaces 2>/dev/null |
-      jq -r '.[] | select(.name != "lo") | ."ip-addresses"[]? | select(."ip-address-type" == "ipv4") | ."ip-address"' 2>/dev/null |
-      grep -v "^127\." | head -1 || echo "")
-    if [ -n "$VM_IP" ]; then
-      break
-    fi
-    # Show elapsed time so it doesn't look stuck
-    printf "\r${TAB}${YW}${HOLD}Waiting for guest agent (first boot pulls Docker images, ~5-6 min) [%ds]${HOLD}" "$((i * 2))"
-    sleep 2
-  done
-
-  if [ -n "$VM_IP" ]; then
-    msg_ok "Guest agent responding — VM IP: ${VM_IP}"
-  else
-    msg_ok "VM started (could not detect IP — check VM console)"
-  fi
-fi
-
 echo -e "\n${INFO}${BOLD}${GN}Penpot VM Configuration Summary:${CL}"
 echo -e "${TAB}${DGN}VM ID: ${BGN}${VMID}${CL}"
 echo -e "${TAB}${DGN}Hostname: ${BGN}${HN}${CL}"
 echo -e "${TAB}${DGN}OS: ${BGN}${OS_DISPLAY}${CL}"
-[ -n "$VM_IP" ] && echo -e "${TAB}${DGN}IP Address: ${BGN}${VM_IP}${CL}"
 
 if [ "$DOCKER_PREINSTALLED" = "yes" ]; then
   echo -e "${TAB}${DGN}Docker: ${BGN}Pre-installed (via get.docker.com)${CL}"
@@ -998,15 +975,9 @@ echo -e "${TAB}${DGN}Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d${CL}"
 echo -e "${TAB}${DGN}Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
 
 echo -e ""
-if [ -n "$VM_IP" ]; then
-  echo -e "${INFO}${YW} Access it using the following URL (once first-boot setup completes):${CL}"
-  echo -e "${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
-else
-  echo -e "${INFO}${YW} IP not detected yet. Once first-boot setup completes, the real URL is printed by:${CL}"
-  echo -e "${TAB}${BGN}journalctl -u penpot-setup | grep 'available at'${CL}"
-  echo -e "${TAB}${DGN}(or check the Summary tab in the Proxmox UI for this VM's IP)${CL}"
-  echo -e "${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
-fi
+echo -e "${INFO}${YW} Once first-boot setup completes, open Penpot on this VM's IP at port 9001:${CL}"
+echo -e "${GATEWAY}${BGN}http://<this-VM's-IP>:9001${CL}"
+echo -e "${TAB}${DGN}Find the IP in the Proxmox UI: select this VM -> Summary tab.${CL}"
 
 if [ "$PENPOT_REGISTRATION_INPUT" = "enable" ]; then
   echo -e "${INFO}${YW} Log in: ${CL}open the URL above and use Create account to register the first user."

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -36,6 +36,7 @@ PENPOT_REGISTRATION_INPUT="disable"
 PENPOT_ADMIN_NAME=""
 PENPOT_ADMIN_EMAIL=""
 PENPOT_ADMIN_PASSWORD=""
+PROTECT_VM="no"
 
 # ==============================================================================
 # ERROR HANDLING & CLEANUP
@@ -194,6 +195,16 @@ function prompt_penpot_admin_account() {
   done
 }
 
+function prompt_vm_protection() {
+  if whiptail --backtitle "Proxmox VE Helper Scripts" --title "VM PROTECTION" --defaultno \
+    --yesno "Enable VM Protection?\n\nPrevents accidental deletion of this VM. You must disable protection before removing it." 11 65; then
+    PROTECT_VM="yes"
+  else
+    PROTECT_VM="no"
+  fi
+  echo -e "${INFO}${BOLD}${DGN}VM Protection: ${BGN}${PROTECT_VM}${CL}"
+}
+
 # ==============================================================================
 # SETTINGS FUNCTIONS
 # ==============================================================================
@@ -201,6 +212,7 @@ function default_settings() {
   prompt_penpot_telemetry
   prompt_penpot_registration
   prompt_penpot_admin_account
+  prompt_vm_protection
   select_os
   select_cloud_init
 
@@ -240,6 +252,7 @@ function advanced_settings() {
   prompt_penpot_telemetry
   prompt_penpot_registration
   prompt_penpot_admin_account
+  prompt_vm_protection
   select_os
   select_cloud_init
 
@@ -873,8 +886,11 @@ msg_ok "Resized disk image"
 # ==============================================================================
 msg_info "Creating Penpot VM shell"
 
+PROTECTION_FLAG=""
+[ "$PROTECT_VM" = "yes" ] && PROTECTION_FLAG=" -protection 1"
+
 qm create $VMID -agent 1${MACHINE} -tablet 0 -localtime 1 -bios ovmf${CPU_TYPE} -cores $CORE_COUNT -memory $RAM_SIZE \
-  -name $HN -tags community-script -net0 virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
+  -name $HN -tags community-script -net0 virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU -onboot 1 -ostype l26 -scsihw virtio-scsi-pci${PROTECTION_FLAG} >/dev/null
 
 msg_ok "Created VM shell"
 
@@ -940,6 +956,7 @@ fi
 # ==============================================================================
 VM_IP=""
 if [ "$START_VM" == "yes" ]; then
+  msg_info "Waiting for VM IP address (up to 60s)"
   set +e
   for i in {1..20}; do
     VM_IP=$(qm guest cmd "$VMID" network-get-interfaces 2>/dev/null |
@@ -949,6 +966,11 @@ if [ "$START_VM" == "yes" ]; then
     sleep 3
   done
   set -e
+  if [ -n "$VM_IP" ]; then
+    msg_ok "VM IP address: ${VM_IP}"
+  else
+    msg_ok "VM IP address not detected yet (see notes below)"
+  fi
 fi
 
 echo -e "\n${INFO}${BOLD}${GN}Penpot VM Configuration Summary:${CL}"

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -629,6 +629,74 @@ else
   msg_ok "Packages will be installed on first boot"
 fi
 
+# ==============================================================================
+# PENPOT FIRST-BOOT AUTOMATION
+# ==============================================================================
+function configure_penpot_setup() {
+  msg_info "Configuring Penpot first-boot automation"
+
+  # First-boot setup script (single-quoted heredoc — no host variable expansion)
+  local penpot_setup_tmp
+  penpot_setup_tmp=$(mktemp)
+  cat >"$penpot_setup_tmp" <<'SETUPEOF'
+#!/bin/bash
+exec > /var/log/penpot-setup.log 2>&1
+set -e
+
+echo "[$(date)] Starting Penpot automated setup"
+
+# Wait for Docker (up to 5 minutes)
+for i in {1..60}; do
+  docker info >/dev/null 2>&1 && break
+  sleep 5
+done
+docker info >/dev/null 2>&1 || { echo "[$(date)] ERROR: Docker not ready after 5 min"; exit 1; }
+
+mkdir -p /root/penpot
+cd /root/penpot
+
+curl -fsSL https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml -o docker-compose.yaml
+echo "[$(date)] Downloaded docker-compose.yaml"
+
+touch /root/.penpot-setup-done
+echo "[$(date)] Penpot setup completed"
+SETUPEOF
+  virt-customize -q -a "$WORK_FILE" \
+    --upload "${penpot_setup_tmp}:/root/penpot-setup.sh" \
+    --run-command "chmod +x /root/penpot-setup.sh" >/dev/null 2>&1
+  rm -f "$penpot_setup_tmp"
+
+  # First-boot oneshot unit that runs the setup script exactly once
+  local penpot_first_boot_svc_tmp
+  penpot_first_boot_svc_tmp=$(mktemp)
+  cat >"$penpot_first_boot_svc_tmp" <<'FBSVCEOF'
+[Unit]
+Description=Penpot Initial Setup
+After=network-online.target docker.service
+Wants=network-online.target
+ConditionPathExists=!/root/.penpot-setup-done
+
+[Service]
+Type=oneshot
+ExecStart=/root/penpot-setup.sh
+RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+TimeoutStartSec=1200
+
+[Install]
+WantedBy=multi-user.target
+FBSVCEOF
+  virt-customize -q -a "$WORK_FILE" \
+    --upload "${penpot_first_boot_svc_tmp}:/etc/systemd/system/penpot-setup.service" \
+    --run-command "systemctl enable penpot-setup.service" >/dev/null 2>&1
+  rm -f "$penpot_first_boot_svc_tmp"
+
+  msg_ok "Configured Penpot first-boot automation"
+}
+
+configure_penpot_setup
+
 msg_info "Finalizing image (hostname, SSH config)"
 # Set hostname and prepare for unique machine-id
 virt-customize -q -a "$WORK_FILE" --hostname "${HN}" >/dev/null 2>&1 || true
@@ -825,7 +893,7 @@ if [ -n "$VM_IP" ]; then
   echo -e "${INFO}${YW} Access it using the following URL (once first-boot setup completes):${CL}"
   echo -e "${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
 else
-  echo -e "${INFO}${YW} Access it once first-boot setup completes at:${CL}"
+  echo -e "${INFO}${YW} IP not detected yet - check the Summary tab in the Proxmox UI for this VM's IP once it boots.${CL}"
   echo -e "${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
 fi
 

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -635,6 +635,29 @@ fi
 function configure_penpot_setup() {
   msg_info "Configuring Penpot first-boot automation"
 
+  local penpot_telemetry_value="true"
+  [ "$PENPOT_TELEMETRY_INPUT" = "disable" ] && penpot_telemetry_value="false"
+
+  local penpot_flags_value="disable-secure-session-cookies disable-email-verification enable-login-with-password enable-prepl-server ${PENPOT_REGISTRATION_INPUT}-registration"
+
+  local penpot_secret_key
+  penpot_secret_key=$(openssl rand -base64 64 | tr -d '\n')
+
+  # Host-expanded env file consumed by the first-boot setup script
+  local penpot_env_tmp
+  penpot_env_tmp=$(mktemp)
+  cat >"$penpot_env_tmp" <<ENVEOF
+PENPOT_TELEMETRY_VALUE="${penpot_telemetry_value}"
+PENPOT_FLAGS_VALUE="${penpot_flags_value}"
+PENPOT_SECRET_KEY_VALUE="${penpot_secret_key}"
+PENPOT_REGISTRATION_VALUE="${PENPOT_REGISTRATION_INPUT}"
+PENPOT_ADMIN_NAME_VALUE="${PENPOT_ADMIN_NAME}"
+PENPOT_ADMIN_EMAIL_VALUE="${PENPOT_ADMIN_EMAIL}"
+PENPOT_ADMIN_PASSWORD_VALUE="${PENPOT_ADMIN_PASSWORD}"
+ENVEOF
+  virt-customize -q -a "$WORK_FILE" --upload "${penpot_env_tmp}:/root/penpot.env" >/dev/null 2>&1
+  rm -f "$penpot_env_tmp"
+
   # First-boot setup script (single-quoted heredoc — no host variable expansion)
   local penpot_setup_tmp
   penpot_setup_tmp=$(mktemp)
@@ -652,11 +675,47 @@ for i in {1..60}; do
 done
 docker info >/dev/null 2>&1 || { echo "[$(date)] ERROR: Docker not ready after 5 min"; exit 1; }
 
+set -a
+source /root/penpot.env
+set +a
+
 mkdir -p /root/penpot
 cd /root/penpot
 
 curl -fsSL https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml -o docker-compose.yaml
 echo "[$(date)] Downloaded docker-compose.yaml"
+
+PENPOT_IP=$(hostname -I | awk '{print $1}')
+
+sed -i \
+  -e "s|^  PENPOT_FLAGS:.*|  PENPOT_FLAGS: ${PENPOT_FLAGS_VALUE}|" \
+  -e "s|^  PENPOT_PUBLIC_URI:.*|  PENPOT_PUBLIC_URI: http://${PENPOT_IP}:9001|" \
+  -e "s|^  PENPOT_SECRET_KEY:.*|  PENPOT_SECRET_KEY: ${PENPOT_SECRET_KEY_VALUE}|" \
+  -e "s|^      PENPOT_TELEMETRY_ENABLED:.*|      PENPOT_TELEMETRY_ENABLED: \"${PENPOT_TELEMETRY_VALUE}\"|" \
+  docker-compose.yaml
+echo "[$(date)] Patched docker-compose.yaml (flags, public URI, secret key, telemetry)"
+
+echo "[$(date)] Running docker compose up"
+docker compose -p penpot -f docker-compose.yaml up -d
+
+if [ "$PENPOT_REGISTRATION_VALUE" = "disable" ]; then
+  echo "[$(date)] Creating first Penpot account (registration disabled)"
+  penpot_account_created="no"
+  for i in {1..30}; do
+    if docker exec penpot-penpot-backend-1 python3 manage.py create-profile \
+      -n "$PENPOT_ADMIN_NAME_VALUE" -e "$PENPOT_ADMIN_EMAIL_VALUE" -p "$PENPOT_ADMIN_PASSWORD_VALUE" \
+      --skip-tutorial --skip-walkthrough >/tmp/penpot-create-profile.log 2>&1; then
+      penpot_account_created="yes"
+      echo "[$(date)] Created account for ${PENPOT_ADMIN_EMAIL_VALUE}"
+      break
+    fi
+    sleep 10
+  done
+  if [ "$penpot_account_created" = "no" ]; then
+    echo "[$(date)] ERROR: failed to create first account after 5 minutes"
+    cat /tmp/penpot-create-profile.log 2>/dev/null || true
+  fi
+fi
 
 touch /root/.penpot-setup-done
 echo "[$(date)] Penpot setup completed"
@@ -691,6 +750,30 @@ FBSVCEOF
     --upload "${penpot_first_boot_svc_tmp}:/etc/systemd/system/penpot-setup.service" \
     --run-command "systemctl enable penpot-setup.service" >/dev/null 2>&1
   rm -f "$penpot_first_boot_svc_tmp"
+
+  # Persistent service: brings the compose stack back up on every boot
+  local penpot_svc_tmp
+  penpot_svc_tmp=$(mktemp)
+  cat >"$penpot_svc_tmp" <<'SVCEOF'
+[Unit]
+Description=Penpot (docker compose)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/root/penpot
+ExecStart=/usr/bin/docker compose -p penpot -f docker-compose.yaml up -d
+ExecStop=/usr/bin/docker compose -p penpot -f docker-compose.yaml down
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+  virt-customize -q -a "$WORK_FILE" \
+    --upload "${penpot_svc_tmp}:/etc/systemd/system/penpot.service" \
+    --run-command "systemctl enable penpot.service" >/dev/null 2>&1
+  rm -f "$penpot_svc_tmp"
 
   msg_ok "Configured Penpot first-boot automation"
 }

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -31,6 +31,11 @@ USE_CLOUD_INIT="no"
 OS_TYPE=""
 OS_VERSION=""
 THIN="discard=on,ssd=1,"
+PENPOT_TELEMETRY_INPUT="enable"
+PENPOT_REGISTRATION_INPUT="disable"
+PENPOT_ADMIN_NAME=""
+PENPOT_ADMIN_EMAIL=""
+PENPOT_ADMIN_PASSWORD=""
 
 # ==============================================================================
 # ERROR HANDLING & CLEANUP
@@ -129,9 +134,73 @@ function get_image_url() {
 }
 
 # ==============================================================================
+# PENPOT OPTIONS
+# ==============================================================================
+function prompt_penpot_telemetry() {
+  if whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT TELEMETRY" \
+    --yesno "Send anonymous usage telemetry to the Penpot team?\n\nOn (default, matches Penpot's own default): sends anonymous data about how this instance is used - no personal data or design content, just usage patterns.\n\nOff: sets PENPOT_TELEMETRY_ENABLED to false in docker-compose.yaml.\n\nYou can change this later: edit /root/penpot/docker-compose.yaml, then run:\n  docker compose -p penpot -f docker-compose.yaml up -d" 18 74; then
+    PENPOT_TELEMETRY_INPUT="enable"
+  else
+    PENPOT_TELEMETRY_INPUT="disable"
+  fi
+  echo -e "${INFO}${BOLD}${DGN}Penpot Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d${CL}"
+}
+
+function prompt_penpot_registration() {
+  if whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT USER REGISTRATION" --defaultno \
+    --yesno "Allow anyone who reaches this VM's URL to create their own Penpot account?\n\nOn: the public sign-up page is enabled. There is no email verification on this LAN-HTTP setup, so anyone who can reach the URL can self-register.\n\nOff (default, recommended): the sign-up page is disabled. You'll be asked to set up the first account next, and it will be created automatically on first boot." 16 76; then
+    PENPOT_REGISTRATION_INPUT="enable"
+  else
+    PENPOT_REGISTRATION_INPUT="disable"
+  fi
+  echo -e "${INFO}${BOLD}${DGN}Penpot Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
+}
+
+function prompt_penpot_admin_account() {
+  [ "$PENPOT_REGISTRATION_INPUT" = "enable" ] && return
+
+  if PENPOT_ADMIN_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
+    --inputbox "Registration is disabled, so this account will be the only way to log in.\n\nFull name for the first Penpot account:" 11 70 "Admin" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+    [ -z "$PENPOT_ADMIN_NAME" ] && PENPOT_ADMIN_NAME="Admin"
+    echo -e "${INFO}${BOLD}${DGN}First User Name: ${BGN}${PENPOT_ADMIN_NAME}${CL}"
+  else
+    exit_script
+  fi
+
+  while true; do
+    if PENPOT_ADMIN_EMAIL=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
+      --inputbox "Email for the first account (this is the login username):" 10 70 "" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [[ "$PENPOT_ADMIN_EMAIL" =~ ^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$ ]]; then
+        echo -e "${INFO}${BOLD}${DGN}First User Email: ${BGN}${PENPOT_ADMIN_EMAIL}${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "Enter a valid email address (e.g. you@example.com)." 8 60
+    else
+      exit_script
+    fi
+  done
+
+  while true; do
+    if PENPOT_ADMIN_PASSWORD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT FIRST USER" \
+      --passwordbox "Password for the first account (min. 8 characters):" 10 70 --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
+      if [ "${#PENPOT_ADMIN_PASSWORD}" -ge 8 ]; then
+        echo -e "${INFO}${BOLD}${DGN}First User Password: ${BGN}(hidden)${CL}"
+        break
+      fi
+      whiptail --backtitle "Proxmox VE Helper Scripts" --title "INVALID INPUT" --msgbox "Password must be at least 8 characters." 8 60
+    else
+      exit_script
+    fi
+  done
+}
+
+# ==============================================================================
 # SETTINGS FUNCTIONS
 # ==============================================================================
 function default_settings() {
+  prompt_penpot_telemetry
+  prompt_penpot_registration
+  prompt_penpot_admin_account
   select_os
   select_cloud_init
 
@@ -168,6 +237,9 @@ function default_settings() {
 }
 
 function advanced_settings() {
+  prompt_penpot_telemetry
+  prompt_penpot_registration
+  prompt_penpot_admin_account
   select_os
   select_cloud_init
 
@@ -739,6 +811,30 @@ else
   echo -e "${TAB}${DGN}Docker: ${BGN}Installing on first boot${CL}"
   echo -e "${TAB}${YW}⚠️  Wait 2-3 minutes for installation to complete${CL}"
   echo -e "${TAB}${YW}⚠️  Check progress: ${BL}cat /var/log/install-docker.log${CL}"
+fi
+
+echo -e ""
+echo -e "${INFO}${BOLD}${GN}Penpot is being configured automatically on first boot!${CL}"
+echo -e "${TAB}${YW}⚠️  First boot pulls several GB of Docker images — this can take several minutes.${CL}"
+echo -e "${TAB}${DGN}Setup log: ${BGN}journalctl -u penpot-setup -f${CL}"
+echo -e "${TAB}${DGN}Telemetry: ${BGN}${PENPOT_TELEMETRY_INPUT}d${CL}"
+echo -e "${TAB}${DGN}Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
+
+echo -e ""
+if [ -n "$VM_IP" ]; then
+  echo -e "${INFO}${YW} Access it using the following URL (once first-boot setup completes):${CL}"
+  echo -e "${TAB}${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
+else
+  echo -e "${INFO}${YW} Access it once first-boot setup completes at:${CL}"
+  echo -e "${TAB}${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
+fi
+
+if [ "$PENPOT_REGISTRATION_INPUT" = "enable" ]; then
+  echo -e "${INFO}${YW} Log in: ${CL}open the URL above and use Create account to register the first user."
+else
+  echo -e "${INFO}${YW} Log in: ${CL}registration is disabled — the account below is created automatically on first boot."
+  echo -e "${TAB}${DGN}Email: ${BGN}${PENPOT_ADMIN_EMAIL}${CL}"
+  echo -e "${TAB}${DGN}Password: ${BGN}(the one you entered during setup)${CL}"
 fi
 
 if [ "$USE_CLOUD_INIT" = "yes" ]; then

--- a/vm/penpot-vm.sh
+++ b/vm/penpot-vm.sh
@@ -138,7 +138,7 @@ function get_image_url() {
 # ==============================================================================
 function prompt_penpot_telemetry() {
   if whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT TELEMETRY" \
-    --yesno "Send anonymous usage telemetry to the Penpot team?\n\nOn (default, matches Penpot's own default): sends anonymous data about how this instance is used - no personal data or design content, just usage patterns.\n\nOff: sets PENPOT_TELEMETRY_ENABLED to false in docker-compose.yaml.\n\nYou can change this later: edit /root/penpot/docker-compose.yaml, then run:\n  docker compose -p penpot -f docker-compose.yaml up -d" 18 74; then
+    --yesno "Send anonymous usage telemetry to the Penpot team?\n\nOn by default. You can change this later." 9 60; then
     PENPOT_TELEMETRY_INPUT="enable"
   else
     PENPOT_TELEMETRY_INPUT="disable"
@@ -148,7 +148,7 @@ function prompt_penpot_telemetry() {
 
 function prompt_penpot_registration() {
   if whiptail --backtitle "Proxmox VE Helper Scripts" --title "PENPOT USER REGISTRATION" --defaultno \
-    --yesno "Allow anyone who reaches this VM's URL to create their own Penpot account?\n\nOn: the public sign-up page is enabled. There is no email verification on this LAN-HTTP setup, so anyone who can reach the URL can self-register.\n\nOff (default, recommended): the sign-up page is disabled. You'll be asked to set up the first account next, and it will be created automatically on first boot." 16 76; then
+    --yesno "Allow anyone who reaches this VM's URL to create their own Penpot account?\n\nOff by default. You'll set up the first account next." 9 65; then
     PENPOT_REGISTRATION_INPUT="enable"
   else
     PENPOT_REGISTRATION_INPUT="disable"
@@ -789,7 +789,7 @@ fi
 VM_IP=""
 if [ "$START_VM" == "yes" ]; then
   set +e
-  for i in {1..10}; do
+  for i in {1..20}; do
     VM_IP=$(qm guest cmd "$VMID" network-get-interfaces 2>/dev/null |
       jq -r '.[] | select(.name != "lo") | ."ip-addresses"[]? | select(."ip-address-type" == "ipv4") | ."ip-address"' 2>/dev/null |
       grep -v "^127\." | head -1) || true
@@ -823,10 +823,10 @@ echo -e "${TAB}${DGN}Registration: ${BGN}${PENPOT_REGISTRATION_INPUT}d${CL}"
 echo -e ""
 if [ -n "$VM_IP" ]; then
   echo -e "${INFO}${YW} Access it using the following URL (once first-boot setup completes):${CL}"
-  echo -e "${TAB}${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
+  echo -e "${GATEWAY}${BGN}http://${VM_IP}:9001${CL}"
 else
   echo -e "${INFO}${YW} Access it once first-boot setup completes at:${CL}"
-  echo -e "${TAB}${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
+  echo -e "${GATEWAY}${BGN}http://<VM-IP>:9001${CL}"
 fi
 
 if [ "$PENPOT_REGISTRATION_INPUT" = "enable" ]; then


### PR DESCRIPTION
## ✍️ Description
Adds a VM-based install script for [Penpot](https://penpot.app/), the open-source design/prototyping platform. Penpot ships as a 6-container Docker Compose stack (frontend, backend, exporter, MCP, PostgreSQL, Valkey), which can't be an LXC/CT install script under this repo's Docker-in-LXC prohibition — hence a VM script, following the `docker-vm.sh` base (minimal-diff port) with Penpot-specific first-boot automation layered in netbird-server.sh style.

What the script does on top of the Docker VM base:
- Whiptail toggles for telemetry (default on, matches Penpot's own default), public registration (default off), and VM protection (default off)
- When registration is off, collects name/email/password in the wizard and creates that account automatically on first boot via `manage.py create-profile` (requires keeping `enable-prepl-server` in `PENPOT_FLAGS`)
- Generates `PENPOT_SECRET_KEY` host-side, patches the official `docker-compose.yaml`'s flags/public-URI/secret-key/telemetry lines with the guest's own runtime-detected IP, then `docker compose up`
- Persistent systemd unit so the stack survives reboots, alongside the first-boot-only setup unit

## 🔗 Related PR / Issue
Related discussion: https://github.com/community-scripts/ProxmoxVE/discussions/1143 (Penpot was never packaged as LXC because Docker is disallowed in CT install scripts; this VM script is the intended path)



## ✅ Prerequisites
- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Verified end-to-end on my own Proxmox node (default settings path, Debian 13, no Cloud-Init): VM creation, Docker install, Penpot compose stack coming up, and automatic first-account creation with registration disabled. Advanced-settings edge cases and the Ubuntu/Cloud-Init path have not been separately re-tested after later changes.
- [x] **No breaking changes** – New files only; no existing scripts modified.
- [x] **No security risks** – No hardcoded credentials; `PENPOT_SECRET_KEY` is randomly generated per install. Note: the wizard-collected admin password is written in plaintext to `/root/penpot.env` on the guest (root-only, `/root` not world-readable) for the first-boot script to consume — same pattern this repo already uses for `netbird-server.sh`'s `netbird.env`.

---

## 🏗️ arm64 Support
- [ ] **arm64 supported**
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported**

---

## 🛠️ Type of Change
- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**

---

## 🔍 Code & Security Review
- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure** – VM-type script, so this is `vm/penpot-vm.sh` + `json/penpot-vm.json` (no companion `install/` script, since that's the CT/LXC convention).
- [x] **No hardcoded credentials**

---

## 🤖 AI Assistance
- [ ] **No AI used**
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)
- This script downloads and patches the **official** Penpot `docker-compose.yaml` (`https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml`) at first boot rather than vendoring a custom copy — only the flags/public-URI/secret-key/telemetry lines are sed-patched, everything else (service definitions, images, volumes) is untouched upstream content.
- `shellcheck` on `vm/penpot-vm.sh` reports the same warning/note count as the unmodified `vm/docker-vm.sh` baseline (34 notes, 14 warnings, 0 errors) — no new findings introduced by the Penpot-specific additions.
- Category `12` (Documents & Notes) was chosen for `json/penpot-vm.json` since there's no dedicated design/prototyping category yet; closest existing precedent is `AFFiNE`, also filed there.
- Testing was done on my own Proxmox node, not from the machine that authored this PR.

## 📦 Application Requirements (for new scripts)
- [x] The application is **at least 6 months old** (Penpot repo created 2015)
- [x] The application is **actively maintained** (commits as recently as this week)
- [x] The application has **600+ GitHub stars** (55k+ stars)
- [ ] Official **release tarballs** are published – Penpot distributes versioned Docker images (`penpotapp/frontend`, `penpotapp/backend`, etc. on Docker Hub) rather than GitHub release tarballs; that's the actual distribution mechanism this script consumes.
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- https://github.com/penpot/penpot
- https://help.penpot.app/

