### PR TITLE
Correct escape for $uri in nginx configuration

### DIFF
--- a/install/grav-install.sh
+++ b/install/grav-install.sh
@@ -49,7 +49,7 @@ server {
 
     ## Begin - API
     location ^~ /api/ {
-        try_files $uri $uri/ /index.php$is_args$args;
+        try_files \$uri \$uri/ /index.php\$is_args\$args;
     }
     ## End - API
 
@@ -57,7 +57,7 @@ server {
     location ~* /user/(accounts|config|env)/.*$ { return 403; }
     # allow public media uploads under user/data to be served directly;
     # this must come before the user/data deny so it wins the match
-    location ~* /user/data/.*\.(jpe?g|png|gif|webp|avif|bmp|ico|mp4|webm|ogg|ogv|mov|mp3|wav|m4a|flac|pdf)$ { try_files $uri =404; }
+    location ~* /user/data/.*\.(jpe?g|png|gif|webp|avif|bmp|ico|mp4|webm|ogg|ogv|mov|mp3|wav|m4a|flac|pdf)$ { try_files \$uri =404; }
     # deny everything else under user/data
     location ~* /user/data/.*$ { return 403; }
 


### PR DESCRIPTION


## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  
With the previous fix of the default Nginx configuration I forgot to escape $uri correctly. Because I pasted the code in my running LXC and it worked, I just copy and pasted the correct configuration, forgetting to escape.

## 🔗 Related PR / Issue  

Link: #1961 

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🏗️ arm64 Support (**X** in brackets)

- [X] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [X] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)  
Before I just tested the configuration in a running LXC. And I forgot the escaping. FIxed that and tested against my fork. All good. The application is also up and running and usable.
```
COMMUNITY_SCRIPTS_URL="https://raw.githubusercontent.com/rafspiny/ProxmoxVED/refs/heads/fix/grav2-nginx-escape-fix"     bash -c "$(curl -fsSL https://raw.githubusercontent.com/rafspiny/ProxmoxVED/refs/heads/fix/grav2-nginx-escape-fix/ct/grav.sh)"
```

```
   ______                
  / ____/________ __   __
 / / __/ ___/ __ `/ | / /
/ /_/ / /  / /_/ /| |/ / 
\____/_/   \__,_/ |___/  
                         
  ⚙️  Using Default Settings on node proxmox
  💡  PVE Version 9.1.11 (Kernel: 6.17.9-1-pve)
  🆔  Container ID: 112
  🖥️  Operating System: debian (13)
  📦  Container Type: Unprivileged
  💾  Disk Size: 8 GB
  🧠  CPU Cores: 1
  🛠️  RAM Size: 2048 MiB
  🚀  Creating a Grav LXC using the above default settings
  
  ✔️  Storage local (Free: 61.3GB  Used: 27.9GB) [Template]
  ✔️  Storage local-lvm (Free: 289.1GB  Used: 59.8GB) [Container]
  ✔️  Storage 'local-lvm' (lvmthin) validated
  ✔️  Template storage 'local' validated
  ✔️  Template search completed
  ✔️  Template debian-13-standard_13.1-2_amd64.tar.zst [local]
  ✔️  LXC Container 112 was successfully created.
  ✔️  Started LXC Container
  ✔️  Network in LXC is reachable (ping)
  ✔️  Customized LXC Container
  ✔️  Set up Container OS
  ✔️  Network Connected: 192.168.178.20
  ✔️  IPv4 Internet Connected
  ✔️  IPv6 Internet Connected
  ✔️  Git DNS: github.com:(✔️ ) raw.githubusercontent.com:(✔️ ) api.github.com:(✔️ ) git.community-scripts.org:(✔️ )
  ✔️  Updated Container OS
  ✔️  Installed Dependencies
  ✔️  Setup PHP 8.4
  ✔️  Deployed: grav (2.0.10)
  ✔️  Configured Nginx
  ✔️  Customized Container
  ✔️  Completed successfully!

  🚀  Grav setup has been successfully initialized!
  💡  Access it using the following URL:
  🌐  http://192.168.178.20:80
root@proxmox:~# 
```

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
<!-- Add any sources and github links. -->  
