### PR TITLE
New Script: proxmox-autosnap

### DIFF
--- a/ct/proxmox-autosnap.sh
+++ b/ct/proxmox-autosnap.sh
@@ -12,6 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -37,7 +38,6 @@ function update_script() {
     fetch_and_deploy_gh_release "proxmox-autosnap" "Kr1sCode/proxmox-autosnap" "tarball"
 
     msg_info "Starting Service"
-    systemctl daemon-reload
     systemctl start autosnap-web.service
     msg_ok "Started Service"
     msg_ok "Updated Successfully"

--- a/ct/proxmox-autosnap.sh
+++ b/ct/proxmox-autosnap.sh
@@ -12,7 +12,6 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -25,21 +24,24 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  if [[ ! -d /opt/autosnap ]]; then
+  if [[ ! -d /opt/proxmox-autosnap ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
 
-  msg_info "Updating ${APP}"
-  tmp_dir=$(mktemp -d)
-  curl -fsSL "https://github.com/Kr1sCode/proxmox-autosnap/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp_dir"
-  src=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)
-  cp -r "$src"/app/. /opt/autosnap/
-  cp "$src"/systemd/*.service "$src"/systemd/*.timer /etc/systemd/system/
-  rm -rf "$tmp_dir"
-  systemctl daemon-reload
-  systemctl restart autosnap-web.service
-  msg_ok "Updated ${APP}"
+  if check_for_gh_release "proxmox-autosnap" "Kr1sCode/proxmox-autosnap"; then
+    msg_info "Stopping Service"
+    systemctl stop autosnap-web.service
+    msg_ok "Stopped Service"
+
+    fetch_and_deploy_gh_release "proxmox-autosnap" "Kr1sCode/proxmox-autosnap" "tarball"
+
+    msg_info "Starting Service"
+    systemctl daemon-reload
+    systemctl start autosnap-web.service
+    msg_ok "Started Service"
+    msg_ok "Updated Successfully"
+  fi
   exit
 }
 

--- a/ct/proxmox-autosnap.sh
+++ b/ct/proxmox-autosnap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Kr1sCode
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Kr1sCode/proxmox-autosnap
+
+APP="proxmox-autosnap"
+var_tags="${var_tags:-proxmox;snapshot;backup}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-3}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/autosnap ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  tmp_dir=$(mktemp -d)
+  curl -fsSL "https://github.com/Kr1sCode/proxmox-autosnap/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp_dir"
+  src=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)
+  cp -r "$src"/app/. /opt/autosnap/
+  cp "$src"/systemd/*.service "$src"/systemd/*.timer /etc/systemd/system/
+  rm -rf "$tmp_dir"
+  systemctl daemon-reload
+  systemctl restart autosnap-web.service
+  msg_ok "Updated ${APP}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"
+echo -e "${INFO}${YW}On first access, complete the setup wizard (Proxmox host + API token).${CL}"

--- a/install/proxmox-autosnap-install.sh
+++ b/install/proxmox-autosnap-install.sh
@@ -14,8 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y \
-  python3 \
+$STD apt install -y \
   python3-flask \
   python3-requests \
   python3-gunicorn

--- a/install/proxmox-autosnap-install.sh
+++ b/install/proxmox-autosnap-install.sh
@@ -18,29 +18,63 @@ $STD apt-get install -y \
   python3 \
   python3-flask \
   python3-requests \
-  python3-gunicorn \
-  curl
+  python3-gunicorn
 msg_ok "Installed Dependencies"
 
-msg_info "Installing proxmox-autosnap"
-tmp_dir=$(mktemp -d)
-curl -fsSL "https://github.com/Kr1sCode/proxmox-autosnap/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp_dir"
-src=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)
-mkdir -p /opt/autosnap /etc/autosnap /var/lib/autosnap /var/log/autosnap
-cp -r "$src"/app/. /opt/autosnap/
-cp "$src"/systemd/*.service "$src"/systemd/*.timer /etc/systemd/system/
+fetch_and_deploy_gh_release "proxmox-autosnap" "Kr1sCode/proxmox-autosnap" "tarball"
+
+msg_info "Setting up proxmox-autosnap"
+mkdir -p /etc/autosnap /var/lib/autosnap /var/log/autosnap
 cat <<'JSON' >/etc/autosnap/config.json
 {"settings":{"pve_host":"CHANGE_ME","pve_port":8006,"verify_tls":false,"paused":false},"auth":{"allowlist":["root@pam"]},"guests":{}}
 JSON
 python3 -c "import secrets; open('/etc/autosnap/secret','w').write(secrets.token_hex(32))"
 chmod 600 /etc/autosnap/secret
-rm -rf "$tmp_dir"
-msg_ok "Installed proxmox-autosnap"
+msg_ok "Set up proxmox-autosnap"
 
-msg_info "Enabling Services"
+msg_info "Creating Services"
+cat <<EOF >/etc/systemd/system/autosnap-web.service
+[Unit]
+Description=proxmox-autosnap web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+WorkingDirectory=/opt/proxmox-autosnap/app
+ExecStart=/usr/bin/python3 -m gunicorn -w 2 -b 0.0.0.0:80 --timeout 120 web:app
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/autosnap-scheduler.service
+[Unit]
+Description=proxmox-autosnap scheduler tick
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/proxmox-autosnap/app
+ExecStart=/usr/bin/python3 /opt/proxmox-autosnap/app/autosnap.py tick
+EOF
+
+cat <<EOF >/etc/systemd/system/autosnap-scheduler.timer
+[Unit]
+Description=proxmox-autosnap scheduler timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
 systemctl enable -q --now autosnap-web.service
 systemctl enable -q --now autosnap-scheduler.timer
-msg_ok "Enabled Services"
+msg_ok "Created Services"
 
 motd_ssh
 customize

--- a/install/proxmox-autosnap-install.sh
+++ b/install/proxmox-autosnap-install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Kr1sCode
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Kr1sCode/proxmox-autosnap
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  python3 \
+  python3-flask \
+  python3-requests \
+  python3-gunicorn \
+  curl
+msg_ok "Installed Dependencies"
+
+msg_info "Installing proxmox-autosnap"
+tmp_dir=$(mktemp -d)
+curl -fsSL "https://github.com/Kr1sCode/proxmox-autosnap/archive/refs/heads/main.tar.gz" | tar -xz -C "$tmp_dir"
+src=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)
+mkdir -p /opt/autosnap /etc/autosnap /var/lib/autosnap /var/log/autosnap
+cp -r "$src"/app/. /opt/autosnap/
+cp "$src"/systemd/*.service "$src"/systemd/*.timer /etc/systemd/system/
+cat <<'JSON' >/etc/autosnap/config.json
+{"settings":{"pve_host":"CHANGE_ME","pve_port":8006,"verify_tls":false,"paused":false},"auth":{"allowlist":["root@pam"]},"guests":{}}
+JSON
+python3 -c "import secrets; open('/etc/autosnap/secret','w').write(secrets.token_hex(32))"
+chmod 600 /etc/autosnap/secret
+rm -rf "$tmp_dir"
+msg_ok "Installed proxmox-autosnap"
+
+msg_info "Enabling Services"
+systemctl enable -q --now autosnap-web.service
+systemctl enable -q --now autosnap-scheduler.timer
+msg_ok "Enabled Services"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/proxmox-autosnap.json
+++ b/json/proxmox-autosnap.json
@@ -1,0 +1,45 @@
+{
+  "name": "proxmox-autosnap",
+  "slug": "proxmox-autosnap",
+  "categories": [
+    1,
+    7
+  ],
+  "date_created": "2026-07-15",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 80,
+  "documentation": "https://github.com/Kr1sCode/proxmox-autosnap#readme",
+  "website": "https://github.com/Kr1sCode/proxmox-autosnap",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/proxmox.webp",
+  "description": "proxmox-autosnap adds scheduled snapshots with automatic retention to Proxmox VE through a clean web UI. It runs in its own unprivileged LXC and talks to the host only via a scoped API token (VM.Snapshot + VM.Audit), so the hypervisor itself is never modified and the tool survives PVE upgrades. Per-guest interval or calendar schedules, retention, dry-run, global pause and bulk enable/disable are all managed from the UI.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/proxmox-autosnap.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 3,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "On first access, complete the setup wizard: enter your Proxmox host/IP and an API token with the VM.Snapshot + VM.Audit privileges. The setup page shows the exact pveum commands to create it.",
+      "type": "info"
+    },
+    {
+      "text": "Log in with your Proxmox credentials (root@pam by default), validated live against the PVE API. Put the panel behind a reverse proxy / VPN before exposing it publicly.",
+      "type": "warning"
+    }
+  ]
+}

--- a/json/proxmox-autosnap.json
+++ b/json/proxmox-autosnap.json
@@ -5,15 +5,16 @@
     1,
     7
   ],
-  "date_created": "2026-07-15",
+  "date_created": "2026-07-16",
   "type": "ct",
   "updateable": true,
   "privileged": false,
-  "has_arm": true,
+  "has_arm": false,
   "interface_port": 80,
   "documentation": "https://github.com/Kr1sCode/proxmox-autosnap#readme",
   "website": "https://github.com/Kr1sCode/proxmox-autosnap",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/proxmox.webp",
+  "config_path": "/etc/autosnap/config.json",
   "description": "proxmox-autosnap adds scheduled snapshots with automatic retention to Proxmox VE through a clean web UI. It runs in its own unprivileged LXC and talks to the host only via a scoped API token (VM.Snapshot + VM.Audit), so the hypervisor itself is never modified and the tool survives PVE upgrades. Per-guest interval or calendar schedules, retention, dry-run, global pause and bulk enable/disable are all managed from the UI.",
   "install_methods": [
     {


### PR DESCRIPTION
## ✍️ Description

New script: **proxmox-autosnap** — scheduled snapshots + automatic retention for Proxmox VE, managed from a clean web UI.

Proxmox has scheduled *backups* and *replication*, but no built-in scheduled *snapshots* with retention. This app fills that gap. It runs in its own unprivileged Debian 13 LXC and talks to the host **only** through a scoped API token (`VM.Snapshot` + `VM.Audit`) — the hypervisor itself is never modified.

- Per-guest **interval** or **calendar** (time-of-day / weekdays) schedules
- **Retention** (keep newest N; prune only `auto_YYYYMMDD_HHMMSS`, never manual snapshots)
- Dry-run, global pause, bulk enable/disable
- **First-run web setup wizard**: on first access the user enters the Proxmox host + API token (the page shows the exact `pveum` commands). This is why the install script needs **no** host-side privileged actions.
- Login with Proxmox credentials (validated live via the PVE ticket API); light/dark theme; English/Polish UI

Upstream repo: https://github.com/Kr1sCode/proxmox-autosnap (release `v1.0.0`)

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**

---

## 🔍 Code & Security Review (**X** in brackets)

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [x] **No Docker / Docker Compose** – Installed bare-metal.
- [x] **No git pull** – Install & update use `fetch_and_deploy_gh_release` / `check_for_gh_release`.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used**
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

**Testing performed** on Proxmox VE 9.2 (Debian 13 template):
- Created an unprivileged LXC, deployed the app from the `v1.0.0` release tarball (same artifact `fetch_and_deploy_gh_release … tarball` pulls) into `/opt/proxmox-autosnap/app`.
- Verified the unconfigured state redirects to the first-run setup wizard, that an invalid token is rejected and a valid scoped token is accepted, then the dashboard/login flow works.
- Verified snapshot creation and retention end-to-end: only `auto_*` snapshots are pruned; manual snapshots are never touched.
- `shellcheck` clean; JSON validates.

Screenshots (light + dark) are in the upstream repo README.
