### PR TITLE
Fix Satisfactory SteamCMD install retries

### DIFF
--- a/ct/satisfactory.sh
+++ b/ct/satisfactory.sh
@@ -38,18 +38,26 @@ function update_script() {
   create_backup /root/.config/Epic/FactoryGame/Saved
 
   msg_info "Updating ${APP}"
-  if $STD /opt/steamcmd/steamcmd.sh \
-    +force_install_dir /opt/satisfactory/server \
-    +login anonymous \
-    +app_update 1690800 -beta public validate \
-    +quit; then
-    msg_ok "Updated ${APP}"
-  else
-    restore_backup
-    systemctl start satisfactory
-    msg_error "Failed to update ${APP}"
-    exit 1
-  fi
+  for attempt in {1..5}; do
+    if $STD /opt/steamcmd/steamcmd.sh \
+      +force_install_dir /opt/satisfactory/server \
+      +login anonymous \
+      +app_update 1690800 -beta public validate \
+      +quit; then
+      msg_ok "Updated ${APP}"
+      break
+    fi
+
+    if [[ "$attempt" -eq 5 ]]; then
+      restore_backup
+      systemctl start satisfactory
+      msg_error "Failed to update ${APP}"
+      exit 1
+    fi
+
+    msg_warn "SteamCMD failed, retrying (${attempt}/5)"
+    sleep 15
+  done
 
   restore_backup
 

--- a/install/satisfactory-install.sh
+++ b/install/satisfactory-install.sh
@@ -15,6 +15,8 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt install -y \
+  ca-certificates \
+  curl \
   lib32gcc-s1 \
   lib32stdc++6
 msg_ok "Installed Dependencies"
@@ -28,11 +30,23 @@ fetch_and_deploy_from_url \
   "/opt/steamcmd"
 
 msg_info "Installing Satisfactory Dedicated Server"
-$STD /opt/steamcmd/steamcmd.sh \
-  +force_install_dir /opt/satisfactory/server \
-  +login anonymous \
-  +app_update 1690800 -beta public validate \
-  +quit
+for attempt in {1..5}; do
+  if $STD /opt/steamcmd/steamcmd.sh \
+    +force_install_dir /opt/satisfactory/server \
+    +login anonymous \
+    +app_update 1690800 -beta public validate \
+    +quit; then
+    break
+  fi
+
+  if [[ "$attempt" -eq 5 ]]; then
+    msg_error "Failed to install Satisfactory Dedicated Server"
+    exit 1
+  fi
+
+  msg_warn "SteamCMD failed, retrying (${attempt}/5)"
+  sleep 15
+done
 msg_ok "Installed Satisfactory Dedicated Server"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## Description

Adds retry handling around the Satisfactory SteamCMD install and update calls.

SteamCMD can surface transient Steam CDN/server response failures as curl exit code 8 during `app_update`. Retrying the SteamCMD call avoids failing the whole install/update on a temporary CDN response issue. The install script also installs `ca-certificates` and `curl` explicitly for the minimal Debian container environment.

## Related PR / Issue

Link: #

## Prerequisites

- [x] Self-review completed - Code follows project standards.
- [x] Tested thoroughly - Shell syntax and whitespace checks pass.
- [x] No breaking changes - Existing Satisfactory install/update behavior is preserved.
- [x] No security risks - No credentials, privilege changes, or new network endpoints added.

---

## arm64 Support

- [ ] arm64 supported - Tested and supported on arm64.
- [x] arm64 not tested - Assumed to work on arm64, but testing has not been done.
- [ ] arm64 not supported - Confirmed upstream dependencies or binaries do not support arm64.

---

## Type of Change

- [x] Bug fix - Resolves an issue without breaking functionality.
- [ ] New feature - Adds new, non-breaking functionality.
- [ ] Breaking change - Alters existing functionality in a way that may require updates.
- [ ] New script - A fully functional and tested script or script set.
- [ ] Website update - Changes to website-related JSON files or metadata.
- [ ] Refactoring / Code Cleanup - Improves readability or maintainability without changing functionality.
- [ ] Documentation update - Changes to README, AppName.md, CONTRIBUTING.md, or other docs.

---

## Code & Security Review

- [x] Follows CODE-AUDIT.md & CONTRIBUTING.md guidelines
- [x] Uses correct script structure (AppName.sh, AppName-install.sh, AppName.json)
- [x] No hardcoded credentials

---

## AI Assistance

- [ ] No AI used - Scripts were written without AI assistance.
- [x] AI was used - I confirm the scripts were built using AGENTS.md and .github/agents/pve-script-creator.agent.md as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## Additional Information

Validation performed:

- `bash -n ct/satisfactory.sh`
- `bash -n install/satisfactory-install.sh`
- `git diff --check`

Reported failure:

- SteamCMD `app_update 1690800 -beta public validate` failed with curl exit code 8 during Satisfactory installation.

---

## Application Requirements (for new scripts)

> Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for New script submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is at least 6 months old
- [ ] The application is actively maintained
- [ ] The application has 600+ GitHub stars
- [ ] Official release tarballs are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## Source

https://www.satisfactorygame.com/
https://satisfactory.wiki.gg/wiki/Dedicated_servers
