### PR TITLE
New Script: AirTrail

### DIFF
--- a/ct/airtrail.sh
+++ b/ct/airtrail.sh
@@ -42,9 +42,22 @@ function update_script() {
 
   if check_for_gh_release "airtrail" "johanohly/AirTrail"; then
     msg_info "Backing Up Database"
-    mkdir -p /var/lib/airtrail/backups
+    install -d \
+      -o root \
+      -g root \
+      -m 0700 \
+      /var/lib/airtrail/backups
+
     backup_file="/var/lib/airtrail/backups/airtrail-$(date +%Y%m%d-%H%M%S).sql"
-    sudo -u postgres pg_dump airtrail | tee "$backup_file" >/dev/null
+
+    sudo -u postgres pg_dump airtrail |
+      install \
+        -o root \
+        -g root \
+        -m 0600 \
+        /dev/stdin \
+        "$backup_file"
+
     find /var/lib/airtrail/backups \
       -type f \
       -name 'airtrail-*.sql' \

--- a/ct/airtrail.sh
+++ b/ct/airtrail.sh
@@ -67,6 +67,71 @@ function update_script() {
     $STD bun install --frozen-lockfile --production
     msg_ok "Built AirTrail"
 
+    msg_info "Installing Airport Overlay"
+    if ! command -v skopeo >/dev/null 2>&1; then
+      $STD apt install -y skopeo
+    fi
+
+    overlay_tmp=$(mktemp -d)
+
+    overlay_image=$(
+      awk '
+        $1 == "FROM" &&
+        $2 ~ /^johly\/airtrail-airport-overlay(:|@)/ {
+          print $2
+          exit
+        }
+      ' /opt/airtrail/docker/Dockerfile
+    )
+
+    if [[ -z "$overlay_image" ]]; then
+      msg_error "Airport overlay image not found"
+      exit 1
+    fi
+
+    if [[ "$overlay_image" == *@sha256:* ]]; then
+      image_without_digest="${overlay_image%@*}"
+      image_digest="${overlay_image#*@}"
+      image_repository="${image_without_digest%:*}"
+      skopeo_image="${image_repository}@${image_digest}"
+    else
+      skopeo_image="$overlay_image"
+    fi
+
+    mkdir -p \
+      "$overlay_tmp/archive" \
+      "$overlay_tmp/rootfs"
+
+    $STD skopeo copy \
+      "docker://docker.io/${skopeo_image}" \
+      "docker-archive:${overlay_tmp}/overlay.tar:airtrail-overlay:latest"
+
+    tar -xf "$overlay_tmp/overlay.tar" \
+      -C "$overlay_tmp/archive"
+
+    overlay_layer=$(
+      jq -r '.[0].Layers[-1]' \
+        "$overlay_tmp/archive/manifest.json"
+    )
+
+    tar -xf "$overlay_tmp/archive/$overlay_layer" \
+      -C "$overlay_tmp/rootfs"
+
+    if [[ ! -s "$overlay_tmp/rootfs/airport-overlay.pmtiles" ]]; then
+      msg_error "Airport overlay file not found"
+      exit 1
+    fi
+
+    install \
+      -o root \
+      -g root \
+      -m 0644 \
+      "$overlay_tmp/rootfs/airport-overlay.pmtiles" \
+      /opt/airtrail/build/client/airport-overlay.pmtiles
+
+    rm -rf "$overlay_tmp"
+    msg_ok "Installed Airport Overlay"
+
     msg_info "Applying Database Migrations"
     set -a
     source /etc/airtrail/airtrail.env

--- a/ct/airtrail.sh
+++ b/ct/airtrail.sh
@@ -31,131 +31,51 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="22" setup_nodejs
-
-  msg_info "Updating Bun"
-  export BUN_INSTALL="/root/.bun"
-  curl -fsSL https://bun.com/install | $STD bash
-  ln -sf /root/.bun/bin/bun /usr/local/bin/bun
-  ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
-  msg_ok "Updated Bun"
-
   if check_for_gh_release "airtrail" "johanohly/AirTrail"; then
-    msg_info "Backing Up Database"
-    install -d \
-      -o root \
-      -g root \
-      -m 0700 \
-      /var/lib/airtrail/backups
-
-    backup_file="/var/lib/airtrail/backups/airtrail-$(date +%Y%m%d-%H%M%S).sql"
-
-    sudo -u postgres pg_dump airtrail |
-      install \
-        -o root \
-        -g root \
-        -m 0600 \
-        /dev/stdin \
-        "$backup_file"
-
-    find /var/lib/airtrail/backups \
-      -type f \
-      -name 'airtrail-*.sql' \
-      -mtime +14 \
-      -delete
-    msg_ok "Backed Up Database"
-
+    msg_info "Stopping Service"
     systemctl stop airtrail
+    msg_ok "Stopped Service"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release \
-      "airtrail" \
-      "johanohly/AirTrail" \
-      "tarball"
+    create_backup /opt/airtrail/.env /opt/airtrail/uploads
 
-    msg_info "Building AirTrail"
+    NODE_VERSION="22" setup_nodejs
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "airtrail" "johanohly/AirTrail" "tarball"
+
+    restore_backup
+
+    msg_info "Updating AirTrail"
     cd /opt/airtrail
     $STD bun install --frozen-lockfile
     $STD bun run build
-    rm -rf /opt/airtrail/node_modules
-    $STD bun install --frozen-lockfile --production
-    msg_ok "Built AirTrail"
+    $STD bun run db:migrate-deploy
+    msg_ok "Updated AirTrail"
 
-    msg_info "Installing Airport Overlay"
-    if ! command -v skopeo >/dev/null 2>&1; then
-      $STD apt install -y skopeo
-    fi
+    msg_info "Updating Service"
+    cat <<EOF >/etc/systemd/system/airtrail.service
+[Unit]
+Description=AirTrail Flight Tracker
+After=network.target postgresql.service
 
-    overlay_tmp=$(mktemp -d)
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/airtrail
+EnvironmentFile=/opt/airtrail/.env
+ExecStart=/usr/bin/node /opt/airtrail/build
+Restart=on-failure
+RestartSec=5
 
-    overlay_image=$(
-      awk '
-        $1 == "FROM" &&
-        $2 ~ /^johly\/airtrail-airport-overlay(:|@)/ {
-          print $2
-          exit
-        }
-      ' /opt/airtrail/docker/Dockerfile
-    )
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    msg_ok "Updated Service"
 
-    if [[ -z "$overlay_image" ]]; then
-      msg_error "Airport overlay image not found"
-      exit 1
-    fi
-
-    if [[ "$overlay_image" == *@sha256:* ]]; then
-      image_without_digest="${overlay_image%@*}"
-      image_digest="${overlay_image#*@}"
-      image_repository="${image_without_digest%:*}"
-      skopeo_image="${image_repository}@${image_digest}"
-    else
-      skopeo_image="$overlay_image"
-    fi
-
-    mkdir -p \
-      "$overlay_tmp/archive" \
-      "$overlay_tmp/rootfs"
-
-    $STD skopeo copy \
-      "docker://docker.io/${skopeo_image}" \
-      "docker-archive:${overlay_tmp}/overlay.tar:airtrail-overlay:latest"
-
-    tar -xf "$overlay_tmp/overlay.tar" \
-      -C "$overlay_tmp/archive"
-
-    overlay_layer=$(
-      jq -r '.[0].Layers[-1]' \
-        "$overlay_tmp/archive/manifest.json"
-    )
-
-    tar -xf "$overlay_tmp/archive/$overlay_layer" \
-      -C "$overlay_tmp/rootfs"
-
-    if [[ ! -s "$overlay_tmp/rootfs/airport-overlay.pmtiles" ]]; then
-      msg_error "Airport overlay file not found"
-      exit 1
-    fi
-
-    install \
-      -o root \
-      -g root \
-      -m 0644 \
-      "$overlay_tmp/rootfs/airport-overlay.pmtiles" \
-      /opt/airtrail/build/client/airport-overlay.pmtiles
-
-    rm -rf "$overlay_tmp"
-    msg_ok "Installed Airport Overlay"
-
-    msg_info "Applying Database Migrations"
-    set -a
-    source /etc/airtrail/airtrail.env
-    set +a
-    $STD node /opt/airtrail/docker/migrate.js
-    msg_ok "Applied Database Migrations"
-
+    msg_info "Starting Service"
     systemctl start airtrail
+    msg_ok "Started Service"
     msg_ok "Updated successfully!"
   fi
-
   exit
 }
 

--- a/ct/airtrail.sh
+++ b/ct/airtrail.sh
@@ -35,7 +35,7 @@ function update_script() {
 
   msg_info "Updating Bun"
   export BUN_INSTALL="/root/.bun"
-  curl -fsSL https://bun.sh/install | $STD bash
+  curl -fsSL https://bun.com/install | $STD bash
   ln -sf /root/.bun/bin/bun /usr/local/bin/bun
   ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
   msg_ok "Updated Bun"

--- a/ct/airtrail.sh
+++ b/ct/airtrail.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Majiiin
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/johanohly/AirTrail
+
+APP="AirTrail"
+var_tags="${var_tags:-travel;flight-tracker}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-10}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/airtrail ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  NODE_VERSION="22" setup_nodejs
+
+  msg_info "Updating Bun"
+  export BUN_INSTALL="/root/.bun"
+  curl -fsSL https://bun.sh/install | $STD bash
+  ln -sf /root/.bun/bin/bun /usr/local/bin/bun
+  ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
+  msg_ok "Updated Bun"
+
+  if check_for_gh_release "airtrail" "johanohly/AirTrail"; then
+    msg_info "Backing Up Database"
+    mkdir -p /var/lib/airtrail/backups
+    backup_file="/var/lib/airtrail/backups/airtrail-$(date +%Y%m%d-%H%M%S).sql"
+    sudo -u postgres pg_dump airtrail | tee "$backup_file" >/dev/null
+    find /var/lib/airtrail/backups \
+      -type f \
+      -name 'airtrail-*.sql' \
+      -mtime +14 \
+      -delete
+    msg_ok "Backed Up Database"
+
+    systemctl stop airtrail
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release \
+      "airtrail" \
+      "johanohly/AirTrail" \
+      "tarball"
+
+    msg_info "Building AirTrail"
+    cd /opt/airtrail
+    $STD bun install --frozen-lockfile
+    $STD bun run build
+    rm -rf /opt/airtrail/node_modules
+    $STD bun install --frozen-lockfile --production
+    msg_ok "Built AirTrail"
+
+    msg_info "Applying Database Migrations"
+    set -a
+    source /etc/airtrail/airtrail.env
+    set +a
+    $STD node /opt/airtrail/docker/migrate.js
+    msg_ok "Applied Database Migrations"
+
+    systemctl start airtrail
+    msg_ok "Updated successfully!"
+  fi
+
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:3000${CL}"

--- a/install/airtrail-install.sh
+++ b/install/airtrail-install.sh
@@ -23,12 +23,12 @@ NODE_VERSION="22" setup_nodejs
 
 msg_info "Installing Bun"
 export BUN_INSTALL="/root/.bun"
-curl -fsSL https://bun.sh/install | $STD bash
+curl -fsSL https://bun.com/install | $STD bash
 ln -sf /root/.bun/bin/bun /usr/local/bin/bun
 ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
 
-PG_VERSION="17" setup_postgresql
+PG_VERSION="16" setup_postgresql
 PG_DB_NAME="airtrail" PG_DB_USER="airtrail" setup_postgresql_db
 
 fetch_and_deploy_gh_release "airtrail" "johanohly/AirTrail" "tarball"

--- a/install/airtrail-install.sh
+++ b/install/airtrail-install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Majiiin
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/johanohly/AirTrail
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  curl \
+  unzip
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Installing Bun"
+export BUN_INSTALL="/root/.bun"
+curl -fsSL https://bun.sh/install | $STD bash
+ln -sf /root/.bun/bin/bun /usr/local/bin/bun
+ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
+msg_ok "Installed Bun"
+
+PG_VERSION="17" setup_postgresql
+PG_DB_NAME="airtrail" PG_DB_USER="airtrail" setup_postgresql_db
+
+fetch_and_deploy_gh_release "airtrail" "johanohly/AirTrail" "tarball"
+
+msg_info "Configuring AirTrail"
+useradd \
+  --system \
+  --home-dir /opt/airtrail \
+  --shell /usr/sbin/nologin \
+  airtrail
+
+mkdir -p \
+  /etc/airtrail \
+  /var/lib/airtrail/uploads
+
+cat <<EOF_ENV >/etc/airtrail/airtrail.env
+NODE_ENV=production
+HOST=0.0.0.0
+PORT=3000
+ORIGIN=http://${LOCAL_IP}:3000
+DB_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@127.0.0.1:5432/${PG_DB_NAME}
+UPLOAD_LOCATION=/var/lib/airtrail/uploads
+BODY_SIZE_LIMIT=20M
+EOF_ENV
+
+chown root:airtrail /etc/airtrail/airtrail.env
+chmod 640 /etc/airtrail/airtrail.env
+chown -R airtrail:airtrail /var/lib/airtrail
+msg_ok "Configured AirTrail"
+
+msg_info "Building AirTrail"
+cd /opt/airtrail
+$STD bun install --frozen-lockfile
+$STD bun run build
+
+rm -rf /opt/airtrail/node_modules
+$STD bun install --frozen-lockfile --production
+msg_ok "Built AirTrail"
+
+msg_info "Applying Database Migrations"
+set -a
+source /etc/airtrail/airtrail.env
+set +a
+$STD node /opt/airtrail/docker/migrate.js
+msg_ok "Applied Database Migrations"
+
+msg_info "Creating Service"
+cat <<'EOF_SERVICE' >/etc/systemd/system/airtrail.service
+[Unit]
+Description=AirTrail Flight Tracker
+After=network-online.target postgresql.service
+Wants=network-online.target
+Requires=postgresql.service
+
+[Service]
+Type=simple
+User=airtrail
+Group=airtrail
+WorkingDirectory=/opt/airtrail
+EnvironmentFile=/etc/airtrail/airtrail.env
+ExecStart=/usr/bin/node /opt/airtrail/build
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+EOF_SERVICE
+
+systemctl enable -q --now airtrail
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/airtrail-install.sh
+++ b/install/airtrail-install.sh
@@ -16,6 +16,7 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   curl \
+  skopeo \
   unzip
 msg_ok "Installed Dependencies"
 
@@ -67,6 +68,67 @@ $STD bun run build
 rm -rf /opt/airtrail/node_modules
 $STD bun install --frozen-lockfile --production
 msg_ok "Built AirTrail"
+
+msg_info "Installing Airport Overlay"
+overlay_tmp=$(mktemp -d)
+
+overlay_image=$(
+  awk '
+    $1 == "FROM" &&
+    $2 ~ /^johly\/airtrail-airport-overlay(:|@)/ {
+      print $2
+      exit
+    }
+  ' /opt/airtrail/docker/Dockerfile
+)
+
+if [[ -z "$overlay_image" ]]; then
+  msg_error "Airport overlay image not found"
+  exit 1
+fi
+
+if [[ "$overlay_image" == *@sha256:* ]]; then
+  image_without_digest="${overlay_image%@*}"
+  image_digest="${overlay_image#*@}"
+  image_repository="${image_without_digest%:*}"
+  skopeo_image="${image_repository}@${image_digest}"
+else
+  skopeo_image="$overlay_image"
+fi
+
+mkdir -p \
+  "$overlay_tmp/archive" \
+  "$overlay_tmp/rootfs"
+
+$STD skopeo copy \
+  "docker://docker.io/${skopeo_image}" \
+  "docker-archive:${overlay_tmp}/overlay.tar:airtrail-overlay:latest"
+
+tar -xf "$overlay_tmp/overlay.tar" \
+  -C "$overlay_tmp/archive"
+
+overlay_layer=$(
+  jq -r '.[0].Layers[-1]' \
+    "$overlay_tmp/archive/manifest.json"
+)
+
+tar -xf "$overlay_tmp/archive/$overlay_layer" \
+  -C "$overlay_tmp/rootfs"
+
+if [[ ! -s "$overlay_tmp/rootfs/airport-overlay.pmtiles" ]]; then
+  msg_error "Airport overlay file not found"
+  exit 1
+fi
+
+install \
+  -o root \
+  -g root \
+  -m 0644 \
+  "$overlay_tmp/rootfs/airport-overlay.pmtiles" \
+  /opt/airtrail/build/client/airport-overlay.pmtiles
+
+rm -rf "$overlay_tmp"
+msg_ok "Installed Airport Overlay"
 
 msg_info "Applying Database Migrations"
 set -a

--- a/install/airtrail-install.sh
+++ b/install/airtrail-install.sh
@@ -13,18 +13,11 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt install -y \
-  curl \
-  skopeo \
-  unzip
-msg_ok "Installed Dependencies"
-
 NODE_VERSION="22" setup_nodejs
 
 msg_info "Installing Bun"
 export BUN_INSTALL="/root/.bun"
-curl -fsSL https://bun.com/install | $STD bash
+curl -fsSL https://bun.sh/install | $STD bash
 ln -sf /root/.bun/bin/bun /usr/local/bin/bun
 ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
@@ -34,134 +27,41 @@ PG_DB_NAME="airtrail" PG_DB_USER="airtrail" setup_postgresql_db
 
 fetch_and_deploy_gh_release "airtrail" "johanohly/AirTrail" "tarball"
 
-msg_info "Configuring AirTrail"
-useradd \
-  --system \
-  --home-dir /opt/airtrail \
-  --shell /usr/sbin/nologin \
-  airtrail
-
-mkdir -p \
-  /etc/airtrail \
-  /var/lib/airtrail/uploads
-
-cat <<EOF_ENV >/etc/airtrail/airtrail.env
+msg_info "Setting up AirTrail"
+cd /opt/airtrail
+mkdir -p /opt/airtrail/uploads
+cat <<EOF >/opt/airtrail/.env
 NODE_ENV=production
 HOST=0.0.0.0
 PORT=3000
 ORIGIN=http://${LOCAL_IP}:3000
 DB_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@127.0.0.1:5432/${PG_DB_NAME}
-UPLOAD_LOCATION=/var/lib/airtrail/uploads
+UPLOAD_LOCATION=/opt/airtrail/uploads
 BODY_SIZE_LIMIT=20M
-EOF_ENV
-
-chown root:airtrail /etc/airtrail/airtrail.env
-chmod 640 /etc/airtrail/airtrail.env
-chown -R airtrail:airtrail /var/lib/airtrail
-msg_ok "Configured AirTrail"
-
-msg_info "Building AirTrail"
-cd /opt/airtrail
+EOF
 $STD bun install --frozen-lockfile
 $STD bun run build
-
-rm -rf /opt/airtrail/node_modules
-$STD bun install --frozen-lockfile --production
-msg_ok "Built AirTrail"
-
-msg_info "Installing Airport Overlay"
-overlay_tmp=$(mktemp -d)
-
-overlay_image=$(
-  awk '
-    $1 == "FROM" &&
-    $2 ~ /^johly\/airtrail-airport-overlay(:|@)/ {
-      print $2
-      exit
-    }
-  ' /opt/airtrail/docker/Dockerfile
-)
-
-if [[ -z "$overlay_image" ]]; then
-  msg_error "Airport overlay image not found"
-  exit 1
-fi
-
-if [[ "$overlay_image" == *@sha256:* ]]; then
-  image_without_digest="${overlay_image%@*}"
-  image_digest="${overlay_image#*@}"
-  image_repository="${image_without_digest%:*}"
-  skopeo_image="${image_repository}@${image_digest}"
-else
-  skopeo_image="$overlay_image"
-fi
-
-mkdir -p \
-  "$overlay_tmp/archive" \
-  "$overlay_tmp/rootfs"
-
-$STD skopeo copy \
-  "docker://docker.io/${skopeo_image}" \
-  "docker-archive:${overlay_tmp}/overlay.tar:airtrail-overlay:latest"
-
-tar -xf "$overlay_tmp/overlay.tar" \
-  -C "$overlay_tmp/archive"
-
-overlay_layer=$(
-  jq -r '.[0].Layers[-1]' \
-    "$overlay_tmp/archive/manifest.json"
-)
-
-tar -xf "$overlay_tmp/archive/$overlay_layer" \
-  -C "$overlay_tmp/rootfs"
-
-if [[ ! -s "$overlay_tmp/rootfs/airport-overlay.pmtiles" ]]; then
-  msg_error "Airport overlay file not found"
-  exit 1
-fi
-
-install \
-  -o root \
-  -g root \
-  -m 0644 \
-  "$overlay_tmp/rootfs/airport-overlay.pmtiles" \
-  /opt/airtrail/build/client/airport-overlay.pmtiles
-
-rm -rf "$overlay_tmp"
-msg_ok "Installed Airport Overlay"
-
-msg_info "Applying Database Migrations"
-set -a
-source /etc/airtrail/airtrail.env
-set +a
-$STD node /opt/airtrail/docker/migrate.js
-msg_ok "Applied Database Migrations"
+$STD bun run db:migrate-deploy
+msg_ok "Set up AirTrail"
 
 msg_info "Creating Service"
-cat <<'EOF_SERVICE' >/etc/systemd/system/airtrail.service
+cat <<EOF >/etc/systemd/system/airtrail.service
 [Unit]
 Description=AirTrail Flight Tracker
-After=network-online.target postgresql.service
-Wants=network-online.target
-Requires=postgresql.service
+After=network.target postgresql.service
 
 [Service]
 Type=simple
-User=airtrail
-Group=airtrail
+User=root
 WorkingDirectory=/opt/airtrail
-EnvironmentFile=/etc/airtrail/airtrail.env
+EnvironmentFile=/opt/airtrail/.env
 ExecStart=/usr/bin/node /opt/airtrail/build
 Restart=on-failure
 RestartSec=5
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target
-EOF_SERVICE
-
+EOF
 systemctl enable -q --now airtrail
 msg_ok "Created Service"
 

--- a/json/airtrail.json
+++ b/json/airtrail.json
@@ -1,0 +1,49 @@
+{
+  "name": "AirTrail",
+  "slug": "airtrail",
+  "categories": [
+    24
+  ],
+  "date_created": "2026-07-16",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 3000,
+  "documentation": "https://airtrail.johan.ohly.dk/docs/overview/introduction",
+  "website": "https://airtrail.johan.ohly.dk",
+  "logo": "https://cdn.jsdelivr.net/gh/johanohly/AirTrail@main/static/favicon.png",
+  "description": "AirTrail is a self-hosted web application for tracking flights, viewing flight history on an interactive map, importing flight data, and displaying travel statistics.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/airtrail.sh",
+      "config_path": "/etc/airtrail/airtrail.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 10,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The first user registered through the web interface becomes the AirTrail owner.",
+      "type": "info"
+    },
+    {
+      "text": "The AirTrail configuration is stored in /etc/airtrail/airtrail.env.",
+      "type": "info"
+    },
+    {
+      "text": "A PostgreSQL database backup is created in /var/lib/airtrail/backups before each application update.",
+      "type": "info"
+    }
+  ]
+}

--- a/json/airtrail.json
+++ b/json/airtrail.json
@@ -18,7 +18,7 @@
     {
       "type": "default",
       "script": "ct/airtrail.sh",
-      "config_path": "/etc/airtrail/airtrail.env",
+      "config_path": "/opt/airtrail/.env",
       "resources": {
         "cpu": 2,
         "ram": 2048,
@@ -38,11 +38,7 @@
       "type": "info"
     },
     {
-      "text": "The AirTrail configuration is stored in /etc/airtrail/airtrail.env.",
-      "type": "info"
-    },
-    {
-      "text": "A PostgreSQL database backup is created in /var/lib/airtrail/backups before each application update.",
+      "text": "The AirTrail configuration is stored in /opt/airtrail/.env.",
       "type": "info"
     }
   ]


### PR DESCRIPTION
## ✍️ Description

Adds a fully functional and tested native AirTrail LXC script.

AirTrail is a self-hosted application for tracking flights, viewing flight history on an interactive map, importing flight data, and displaying travel statistics.

Implementation details:

- Native installation in an unprivileged Debian 13 LXC
- Node.js 22
- Bun
- PostgreSQL 16
- Dedicated `airtrail` system user
- Native systemd service
- GitHub release-based installation and updates
- PostgreSQL backup before application updates
- Database migrations during installation and updates
- Airport overlay installed from the exact OCI data artifact pinned by the upstream AirTrail Dockerfile
- Skopeo is used only to extract the upstream data artifact; no Docker daemon or Docker Compose deployment is installed or used

Tested on Proxmox VE 9.2.4:

- Fresh installation completed successfully
- AirTrail and PostgreSQL services active
- Main application returns HTTP 200
- Airport overlay returns HTTP 200
- Airport overlay file installed correctly
- Container reboot tested
- User account and flight data persisted after reboot
- Complete update workflow tested by forcing the local version marker to `0.0.0`
- User account and flight data persisted after update
- Database backup created successfully
- Backup confirmed non-empty with `root:root` ownership and `0600` permissions

## 🔗 Related PR / Issue

This PR addresses the existing AirTrail script request:

- https://github.com/community-scripts/ProxmoxVE/discussions/7999

The request was opened in September 2025 and received follow-up interest from two additional community members.

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

ARM64 is currently disabled in the script metadata until it can be properly tested.

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`.

---

## 🤖 AI Assistance

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information

The upstream AirTrail source release does not include `airport-overlay.pmtiles`.

AirTrail's official Dockerfile obtains this required static data file from a separately published and digest-pinned OCI image. The LXC installer reproduces only that asset extraction using Skopeo while running the application itself directly with Node.js and systemd.

---

## 📦 Application Requirements (for new scripts)

- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- https://github.com/johanohly/AirTrail
- https://airtrail.johan.ohly.dk
- https://airtrail.johan.ohly.dk/docs/overview/introduction