### PR TITLE
Improve Incus CT parity (roadmap P1-P3)

### DIFF
--- a/.github/workflows/bash-syntax.yml
+++ b/.github/workflows/bash-syntax.yml
@@ -1,0 +1,48 @@
+name: Bash Syntax Check
+
+on:
+  pull_request:
+    paths:
+      - "misc/**/*.func"
+      - "ct/**/*.sh"
+      - "install/**/*.sh"
+      - ".github/workflows/bash-syntax.yml"
+  push:
+    branches: [main]
+    paths:
+      - "misc/**/*.func"
+      - "ct/**/*.sh"
+      - "install/**/*.sh"
+      - ".github/workflows/bash-syntax.yml"
+
+jobs:
+  bash-n:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Syntax-check misc functions
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' f; do
+            if ! bash -n "$f"; then
+              echo "::error file=$f::bash -n failed"
+              fail=1
+            fi
+          done < <(find misc -type f -name '*.func' -print0 | sort -z)
+          exit "$fail"
+
+      - name: Syntax-check sample CT scripts
+        run: |
+          set -euo pipefail
+          samples=(ct/debian.sh ct/alpine.sh ct/ubuntu.sh)
+          fail=0
+          for f in "${samples[@]}"; do
+            [[ -f "$f" ]] || continue
+            if ! bash -n "$f"; then
+              echo "::error file=$f::bash -n failed"
+              fail=1
+            fi
+          done
+          exit "$fail"

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ Topics include:
 * Storage and network configuration
 * Unattended deployments
 * Environment-variable-based provisioning
+* [Incus host setup](guides/incus.md) (unified `ct/` scripts on Incus)
 
 ➡️ [Open Configuration Guides](https://community-scripts.org/docs/guides/readme)
 

--- a/docs/guides/incus.md
+++ b/docs/guides/incus.md
@@ -1,0 +1,88 @@
+# Incus Host Setup (Community Scripts)
+
+Proxmox VE and Incus share the same `ct/` and `install/` scripts. On an Incus host, `misc/build.func` detects the platform and loads the Incus backend. There is no separate `Incus/` script tree.
+
+## Requirements
+
+- Incus installed and usable (`incus info` works for your user)
+- Network access to pull images (`images:` remote) and script sources
+- Enough free space on the **Incus storage pool** (not only the host disk)
+
+## Platform detection
+
+| Environment | Detection |
+| ----------- | --------- |
+| Proxmox VE host | `pveversion` present → PVE backend |
+| Incus host | `incus` CLI + daemon → Incus backend |
+| Inside Incus CT | `/dev/incus/sock` or Community Scripts MOTD → update mode |
+
+Override (debug): `export LXC_PLATFORM=incus|pve|incus-container`
+
+## Local development
+
+Point scripts at your checkout instead of GitHub:
+
+```bash
+export COMMUNITY_SCRIPTS_DIR=/path/to/ProxmoxVED/misc
+bash ct/debian.sh
+```
+
+## Non-root Incus users
+
+Defaults, diagnostics, and build logs go to a writable state directory:
+
+| User | Directory |
+| ---- | --------- |
+| root (or writable `/usr/local`) | `/usr/local/community-scripts` |
+| non-root | `~/.config/community-scripts` |
+
+Override: `export COMMUNITY_SCRIPTS_STATE_DIR=/custom/path`
+
+Logs: `<state-dir>/logs/incus-create-*.log`
+
+## Storage pools
+
+`incus storage info` reports **pool** free space. Default loop-backed pools are often small (~10 GiB). Grow or choose another pool:
+
+```bash
+incus storage list
+incus storage set default size=50GiB
+```
+
+## Networking
+
+- **bridge / ovn / macvlan**: IPv4/IPv6 device options (`ipv4.address`, …) are applied when set
+- **physical / sriov**: IP device keys are skipped (host NIC); rely on DHCP or host-side config
+- DHCP on physical/macvlan can take longer than 20 s — the installer waits up to ~90 s and continues with a warning if needed
+
+## GPU passthrough
+
+Uses current Incus `gpu` devices (`pci=`, `id=`, `vendorid=`), not obsolete `device=/dev/dri/...`.
+
+```bash
+incus info --resources
+# After create, devices look like: gpu0 type=gpu gputype=physical pci=0000:…
+```
+
+`gid=` / `mode=` are set after container groups exist.
+
+## Privileged / nesting / TUN / FUSE
+
+| Need | Setting |
+| ---- | ------- |
+| Docker-in-LXC | `security.nesting=true` (default on) |
+| TUN / FUSE / USB serial | often `security.privileged=true` (Advanced settings) |
+
+## Update path
+
+Inside an existing CT, run the same `ct/<app>.sh` script. Detection switches to update mode (`update_script`) without calling the Incus host CLI.
+
+## Architecture
+
+```
+ct/*.sh → misc/build.func
+            ├─ Incus  → misc/incus-build.func
+            │             ├─ misc/build-ui.func
+            │             └─ misc/incus-backend.func
+            └─ PVE    → misc/build-ui.func + misc/pve-backend.func
+```

--- a/misc/build-ui.func
+++ b/misc/build-ui.func
@@ -3119,7 +3119,7 @@ install_script() {
         msg_error "Failed to apply default.vars"
         exit 1
       }
-      defaults_target="/usr/local/community-scripts/default.vars"
+      defaults_target="$(declare -f community_scripts_dir >/dev/null 2>&1 && community_scripts_dir || echo /usr/local/community-scripts)/default.vars"
       break
       ;;
     "$APPDEFAULTS_OPTION" | appdefaults | APPDEFAULTS)
@@ -3169,12 +3169,13 @@ install_script() {
 }
 
 edit_default_storage() {
-  local vf="/usr/local/community-scripts/default.vars"
+  local vf
+  vf="$(declare -f community_scripts_dir >/dev/null 2>&1 && community_scripts_dir || echo /usr/local/community-scripts)/default.vars"
 
   # Ensure file exists
   if [[ ! -f "$vf" ]]; then
-    mkdir -p "$(dirname "$vf")"
-    touch "$vf"
+    mkdir -p "$(dirname "$vf")" 2>/dev/null || true
+    touch "$vf" 2>/dev/null || true
   fi
 
   # Let ensure_storage_selection_for_vars_file handle everything
@@ -3205,7 +3206,7 @@ settings_menu() {
 
     case "$choice" in
     1) diagnostics_menu ;;
-    2) nano /usr/local/community-scripts/default.vars ;;
+    2) nano "$(declare -f community_scripts_dir >/dev/null 2>&1 && community_scripts_dir || echo /usr/local/community-scripts)/default.vars" ;;
     3) dev_mode_menu ;;
     4)
       if [ -f "$(get_app_defaults_path)" ]; then

--- a/misc/incus-backend.func
+++ b/misc/incus-backend.func
@@ -148,7 +148,7 @@ incus_validate_storage_space() {
     # Match PVE behavior: warn, do not hard-abort (pool/dir drivers can still grow).
     msg_warn "Pool '${pool}' reports ~${free_gb}GB free, container wants ${need_gb}GB"
     msg_custom "ℹ️" "${YW}" "Source: incus storage info '${pool}' (pool free space, not full host disk)"
-    msg_custom "ℹ️" "${YW}" "Check with: incus storage info ${pool}   /   incus storage list"
+    msg_custom "ℹ️" "${YW}" "Grow: incus storage set ${pool} size=50GiB   |   Or pick another pool"
     return 0
   fi
   msg_ok "Storage space validated (${pool}: ~${free_gb}GB free)"
@@ -400,7 +400,9 @@ incus_create_lxc_container() {
 
   if [[ "$net_reconfigure" -eq 1 ]]; then
     msg_info "Reconfiguring network settings"
-    _incus_soft incus restart "${CT_NAME}" >>"$LOGFILE" 2>&1 || msg_warn "Restart after network reconfiguration failed"
+    if ! incus restart "${CT_NAME}" >>"$LOGFILE" 2>&1; then
+      msg_warn "Restart after network reconfiguration failed"
+    fi
     msg_ok "Network settings applied"
   fi
 }
@@ -725,7 +727,7 @@ fix_gpu_gids() {
   local dev_name
   while IFS= read -r dev_name; do
     [[ -z "$dev_name" || "$dev_name" != gpu* ]] && continue
-    incus config device set "${CT_NAME}" "$dev_name" "gid=${video_gid}" >>"${LOGFILE:-$INCUS_BUILD_LOG}" 2>&1 || true
+    _incus_soft incus config device set "${CT_NAME}" "$dev_name" "gid=${video_gid}" "mode=0660" >>"${LOGFILE:-$INCUS_BUILD_LOG}" 2>&1
   done < <(incus config device list "${CT_NAME}" 2>/dev/null || true)
 
   # Best-effort permissions inside the CT when /dev/dri is visible
@@ -763,10 +765,12 @@ incus_customize_container() {
 
   if [[ "${var_os:-debian}" == "alpine" ]]; then
     sleep 2
-    incus_ct_exec /bin/sh -c 'cat <<EOF >/etc/apk/repositories
-http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
-http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
-EOF'
+    local alpine_rel="v${IMAGE_VERSION:-${var_version:-3.21}}"
+    [[ "$alpine_rel" != v3.* ]] && alpine_rel="latest-stable"
+    incus_ct_exec /bin/sh -c "cat <<EOF >/etc/apk/repositories
+http://dl-cdn.alpinelinux.org/alpine/${alpine_rel}/main
+http://dl-cdn.alpinelinux.org/alpine/${alpine_rel}/community
+EOF"
     incus_ct_exec ash -c "apk add bash newt curl openssh nano mc ncurses jq >/dev/null" || msg_warn "Alpine base package install had issues"
   elif [[ "${var_os:-debian}" =~ ^(debian|ubuntu|devuan)$ ]]; then
     sleep 2

--- a/misc/incus-build.func
+++ b/misc/incus-build.func
@@ -66,11 +66,21 @@ incus_variables() {
   RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
   SESSION_ID="${RANDOM_UUID:0:8}"
   EXECUTION_ID="${EXECUTION_ID:-$RANDOM_UUID}"
-  INCUS_BUILD_LOG="/tmp/incus-create-${SESSION_ID}.log"
-  INCUS_INSTALL_LOG="/tmp/incus-install-${SESSION_ID}.log"
+  local _log_dir
+  _log_dir="$(community_scripts_dir)/logs"
+  mkdir -p "$_log_dir" 2>/dev/null || _log_dir="/tmp"
+  INCUS_BUILD_LOG="${_log_dir}/incus-create-${SESSION_ID}.log"
+  INCUS_INSTALL_LOG="${_log_dir}/incus-install-${SESSION_ID}.log"
   BUILD_LOG="$INCUS_BUILD_LOG"
-  combined_log="/tmp/incus-install-${SESSION_ID}-combined.log"
+  combined_log="${_log_dir}/incus-install-${SESSION_ID}-combined.log"
   _INCUS_HOST_LOGFILE="$INCUS_BUILD_LOG"
+  touch "$INCUS_BUILD_LOG" 2>/dev/null || {
+    INCUS_BUILD_LOG="/tmp/incus-create-${SESSION_ID}.log"
+    INCUS_INSTALL_LOG="/tmp/incus-install-${SESSION_ID}.log"
+    BUILD_LOG="$INCUS_BUILD_LOG"
+    combined_log="/tmp/incus-install-${SESSION_ID}-combined.log"
+    _INCUS_HOST_LOGFILE="$INCUS_BUILD_LOG"
+  }
   CTTYPE="${CTTYPE:-${CT_TYPE:-1}}"
   if command -v incus &>/dev/null; then
     PVEVERSION="Incus $(incus version 2>/dev/null | awk 'NR==1 {for (i=3;i<=NF;i++) printf "%s%s", (i>3?" ":""), $i; print ""}' | sed 's/^[[:space:]]*//')"
@@ -165,7 +175,23 @@ _incus_sync_from_pve_settings() {
   CTID="$CT_NAME"
   UNPRIVILEGED="${CT_TYPE:-1}"
   IMAGE_OS="${var_os:-debian}"
+  IMAGE_OS="${IMAGE_OS,,}"
   IMAGE_VERSION="${var_version:-13}"
+  # Normalize common UI shortcuts for image aliases
+  case "$IMAGE_OS" in
+  ubuntu)
+    case "$IMAGE_VERSION" in
+    22) IMAGE_VERSION="22.04" ;;
+    24) IMAGE_VERSION="24.04" ;;
+    26) IMAGE_VERSION="26.04" ;;
+    esac
+    ;;
+  alpine)
+    case "$IMAGE_VERSION" in
+    latest | edge) IMAGE_VERSION="3.21" ;;
+    esac
+    ;;
+  esac
   PROFILE="${var_profile:-default}"
   STORAGE_POOL="${CONTAINER_STORAGE:-${STORAGE_POOL:-}}"
   if [[ -z "$STORAGE_POOL" ]]; then
@@ -191,13 +217,17 @@ _incus_sync_from_pve_settings() {
 
   case "${IPV6_METHOD:-auto}" in
   auto | dhcp) IPV6_ADDR="auto" ;;
-  static) IPV6_ADDR="${IPV6_ADDR:-auto}" ;;
-  none) IPV6_ADDR="none" ;;
+  static) IPV6_ADDR="${IPV6_ADDR:-}" ;;
+  none | disable) IPV6_ADDR="none"; IPV6_METHOD="none" ;;
   esac
 }
 
 # Shared Proxmox UI (menus / wizard / validators / install_script / start)
 _incus_source "misc/build-ui.func"
+
+# Keep UI update checks under stable names before any later tools.func reload.
+eval "$(declare -f check_container_storage | sed '1s/check_container_storage/_shared_check_container_storage/')"
+eval "$(declare -f check_container_resources | sed '1s/check_container_resources/_shared_check_container_resources/')"
 
 eval "$(declare -f base_settings | sed '1s/base_settings/_pve_base_settings/')"
 base_settings() {
@@ -212,10 +242,21 @@ _incus_source "misc/incus-backend.func"
 # SECTION 4: PLATFORM OVERRIDES
 # ==============================================================================
 
-pve_check() { incus_check; }
+pve_check() {
+  # Host install needs a working Incus daemon; guest update mode does not.
+  if [[ -n "${_INCUS_INSIDE_CONTAINER:-}" ]]; then
+    return 0
+  fi
+  incus_check
+}
 arch_check() { :; }
 arm64_notice() { :; }
 ssh_check() { :; }
+
+# Guest update: allow non-root root_check without requiring host `incus` CLI.
+if [[ -n "${_INCUS_INSIDE_CONTAINER:-}" ]]; then
+  root_check() { return 0; }
+fi
 
 validate_container_id() {
   local id="${1:-}"
@@ -318,8 +359,9 @@ choose_and_set_storage_for_file() {
 }
 
 ensure_storage_selection_for_vars_file() {
-  local vf="${1:-/usr/local/community-scripts/default.vars}"
-  [[ -f "$vf" ]] || { mkdir -p "$(dirname "$vf")"; touch "$vf"; }
+  local vf="${1:-}"
+  [[ -z "$vf" ]] && vf="$(community_scripts_dir)/default.vars"
+  [[ -f "$vf" ]] || { mkdir -p "$(dirname "$vf")" 2>/dev/null || true; touch "$vf" 2>/dev/null || true; }
 
   local tpl ct
   tpl=$(grep -E '^var_template_storage=' "$vf" 2>/dev/null | cut -d= -f2-)
@@ -344,20 +386,21 @@ select_storage() {
   while IFS= read -r pool; do
     [[ -z "$pool" ]] && continue
     free_gb=$(incus_storage_pool_free_gb "$pool" 2>/dev/null || echo "?")
-    info="Free: ~${free_gb}GB"
-    options+=("$pool" "Incus storage pool (${info})")
+    info="pool free ~${free_gb}GB (not full host disk)"
+    options+=("$pool" "${info}")
   done < <(incus storage list -f csv,noheader 2>/dev/null | cut -d, -f1)
   [[ ${#options[@]} -eq 0 ]] && return 1
 
   if [[ ${#options[@]} -eq 2 ]]; then
     STORAGE_RESULT="${options[0]}"
   else
-    STORAGE_RESULT=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "STORAGE POOL" --menu "Select storage for ${purpose}" 16 72 8 \
+    STORAGE_RESULT=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "INCUS STORAGE POOL" \
+      --menu "Select Incus pool for ${purpose}\n(Shows pool free space, not host disk)" 18 76 8 \
       "${options[@]}" 3>&1 1>&2 2>&3) || return 1
   fi
 
   free_gb=$(incus_storage_pool_free_gb "$STORAGE_RESULT" 2>/dev/null || echo "?")
-  STORAGE_INFO="Free: ~${free_gb}GB"
+  STORAGE_INFO="Pool free: ~${free_gb}GB"
   if [[ "$purpose" == "template" ]]; then
     TEMPLATE_STORAGE="$STORAGE_RESULT"
     TEMPLATE_STORAGE_INFO="$STORAGE_INFO"
@@ -430,9 +473,9 @@ api_exit_script() {
   local exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
     post_update_to_api "failed" "$exit_code" 2>/dev/null || true
-    ensure_log_on_host 2>/dev/null || true
-    if [[ "${CONTAINER_INSTALLING:-}" == "true" && -n "${CT_NAME:-}" ]]; then
-      incus stop "$CT_NAME" --force 2>/dev/null || true
+    [[ -z "${_INCUS_INSIDE_CONTAINER:-}" ]] && ensure_log_on_host 2>/dev/null || true
+    if [[ -z "${_INCUS_INSIDE_CONTAINER:-}" && "${CONTAINER_INSTALLING:-}" == "true" && -n "${CT_NAME:-}" ]]; then
+      command -v incus &>/dev/null && incus stop "$CT_NAME" --force 2>/dev/null || true
     fi
   elif [[ "${POST_TO_API_DONE:-}" == "true" && "${POST_UPDATE_DONE:-}" != "true" ]]; then
     post_update_to_api "done" "0" 2>/dev/null || true
@@ -466,6 +509,12 @@ start() {
       $STD apt -y autoclean 2>/dev/null || true
     }
   fi
+  # Re-bind build-ui update checks (80% disk / var_ram) after tools.func load.
+  if declare -f _shared_check_container_storage >/dev/null 2>&1; then
+    check_container_storage() { _shared_check_container_storage "$@"; }
+    check_container_resources() { _shared_check_container_resources "$@"; }
+  fi
+
   if [[ -z "${_INCUS_INSIDE_CONTAINER:-}" ]] && command -v incus &>/dev/null; then
     install_script || return 0
     return 0
@@ -499,13 +548,16 @@ _incus_on_err() {
   local _ec=$?
   [[ $_ec -eq 0 ]] && return 0
   post_update_to_api "failed" "$_ec" 2>/dev/null || true
-  ensure_log_on_host 2>/dev/null || true
+  [[ -z "${_INCUS_INSIDE_CONTAINER:-}" ]] && ensure_log_on_host 2>/dev/null || true
 }
 
 _incus_on_signal() {
   local sig="$1" code="$2"
   post_update_to_api "failed" "$code" 2>/dev/null || true
-  [[ -n "${CT_NAME:-}" ]] && incus stop "$CT_NAME" --force 2>/dev/null || true
+  # Only stop instances from the Incus host — never inside a guest update run.
+  if [[ -z "${_INCUS_INSIDE_CONTAINER:-}" ]] && command -v incus &>/dev/null && [[ -n "${CT_NAME:-}" ]]; then
+    incus stop "$CT_NAME" --force 2>/dev/null || true
+  fi
   exit "$code"
 }
 

--- a/misc/incus-core.func
+++ b/misc/incus-core.func
@@ -816,27 +816,27 @@ incus_get_image_alias() {
   case "$os" in
   debian)
     case "$version" in
-    12) echo "bookworm" ;;
-    13) echo "trixie" ;;
+    12 | bookworm) echo "bookworm" ;;
+    13 | trixie) echo "trixie" ;;
     *) echo "trixie" ;;
     esac
     ;;
   ubuntu)
     case "$version" in
-    22.04 | 22) echo "jammy" ;;
-    24.04 | 24) echo "noble" ;;
-    26.04 | 26) echo "plucky" ;;
+    22.04 | 22 | jammy) echo "jammy" ;;
+    24.04 | 24 | noble) echo "noble" ;;
+    26.04 | 26 | plucky | resolute) echo "plucky" ;;
     *) echo "noble" ;;
     esac
     ;;
   alpine)
     case "$version" in
-    3.20 | 3.21 | 3.22 | 3.23) echo "${version}" ;;
+    3.19 | 3.20 | 3.21 | 3.22 | 3.23) echo "${version}" ;;
     *) echo "3.21" ;;
     esac
     ;;
   *)
-    echo "trixie"
+    echo "${version}"
     ;;
   esac
 }

--- a/misc/incus-tools.func
+++ b/misc/incus-tools.func
@@ -112,8 +112,17 @@ update_motd_ip() {
 }
 
 setup_hwaccel() {
-  incus_msg_warn "Hardware acceleration setup is limited in Incus containers"
-  incus_msg_warn "Use host/device passthrough where applicable (Incus devices)"
+  # GPU/device passthrough is applied at create time (incus config device add gpu …).
+  # Inside the CT we only verify visibility and permissions.
+  if [[ -d /dev/dri ]] && compgen -G '/dev/dri/*' &>/dev/null; then
+    msg_ok "Hardware acceleration devices present under /dev/dri"
+    return 0
+  fi
+  if [[ "${ENABLE_GPU:-no}" == "yes" || "${var_gpu:-no}" == "yes" ]]; then
+    msg_warn "GPU was requested but /dev/dri is empty — recreate CT with GPU passthrough on the Incus host"
+  else
+    msg_custom "ℹ️" "${YW}" "No /dev/dri in this CT (passthrough is configured on the host at create time)"
+  fi
 }
 
 verb_ip6() {
@@ -283,20 +292,9 @@ cleanup_lxc() {
   rm -f /tmp/incus-funcs.sh 2>/dev/null || true
 }
 
-check_container_storage() {
-  local required_mb="${1:-500}" available_mb
-  available_mb=$(df -m / | awk 'NR==2 {print $4}')
-  [[ "$available_mb" -lt "$required_mb" ]] && {
-    msg_error "Insufficient storage: ${available_mb}MB < ${required_mb}MB"
-    exit 1
-  }
-}
-
-check_container_resources() {
-  local available_ram
-  available_ram=$(free -m | awk 'NR==2 {print $7}')
-  [[ "$available_ram" -lt 256 ]] && msg_warn "Low memory: ${available_ram}MB"
-}
+# check_container_storage / check_container_resources:
+# Intentionally NOT overridden here — build-ui.func provides the interactive
+# update-path checks (80% disk / var_ram). See incus-build.func start().
 
 header_info() {
   local app_name
@@ -308,7 +306,7 @@ header_info() {
     header_content=$(get_header "$app_name" 2>/dev/null || true)
   fi
 
-  clear
+  clear 2>/dev/null || true
   if [[ -n "$header_content" ]]; then
     echo "$header_content"
   else


### PR DESCRIPTION
## Summary
- Harden Incus create/update path: soft network wait, real hostname, image fallback/retry, non-root state/logs, safer traps inside CTs
- Feature parity: macvlan IP options, USB/extra-disk/TUN/FUSE messaging, hwaccel check, Alpine/Ubuntu image normalization, storage-pool UX
- Ship: Incus host guide, `bash -n` CI workflow, `community_scripts_dir` for shared UI defaults paths

## Test plan
- [ ] Incus host (non-root): `COMMUNITY_SCRIPTS_DIR=…/misc bash ct/debian.sh` default install
- [ ] Confirm hostname inside CT matches instance name; logs under `~/.config/community-scripts/logs`
- [ ] Physical/macvlan: DHCP delay does not abort install
- [ ] Missing image alias falls back / shows copy hint
- [ ] Inside CT: re-run `ct/debian.sh` update menu (no `incus` CLI required)
- [ ] Advanced: GPU/TUN/FUSE options warn clearly when attach fails
- [ ] CI `Bash Syntax Check` passes on the PR
