### PR TITLE
New script: OpenLMNP (French LMNP rental accounting)

### DIFF
--- a/ct/openlmnp.sh
+++ b/ct/openlmnp.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: manganate006
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/manganate006/openlmnp
+
+APP="OpenLMNP"
+var_tags="${var_tags:-accounting;finance}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/openlmnp ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "openlmnp" "manganate006/openlmnp"; then
+    msg_info "Stopping Services"
+    systemctl stop nginx php8.4-fpm
+    msg_ok "Stopped Services"
+
+    create_backup /opt/openlmnp/.env /opt/openlmnp/database /opt/openlmnp/storage/app /opt/openlmnp/storage/logs
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "openlmnp" "manganate006/openlmnp" "tarball"
+
+    restore_backup
+
+    msg_info "Updating Application"
+    cd /opt/openlmnp || exit
+    export COMPOSER_ALLOW_SUPERUSER=1
+    $STD /usr/local/bin/composer install --no-dev --optimize-autoloader --no-interaction
+    $STD npm install --no-audit --no-fund
+    $STD npm run build
+    $STD php artisan migrate --force
+    $STD php artisan optimize:clear
+    chown -R www-data:www-data /opt/openlmnp
+    chmod -R 775 /opt/openlmnp/storage /opt/openlmnp/database /opt/openlmnp/bootstrap/cache
+    msg_ok "Updated Application"
+
+    msg_info "Starting Services"
+    systemctl start php8.4-fpm nginx
+    msg_ok "Started Services"
+
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}${CL}"
+echo -e "${INFO}${YW} Admin credentials (generated at install) are stored in the container at:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}/opt/openlmnp/admin_credentials.txt${CL}"

--- a/install/openlmnp-install.sh
+++ b/install/openlmnp-install.sh
@@ -94,6 +94,7 @@ chmod 640 /opt/openlmnp/.env
 chmod 600 /opt/openlmnp/admin_credentials.txt
 
 msg_info "Configuring Nginx"
+$STD apt install -y nginx
 cat <<'EOF' >/etc/nginx/sites-available/openlmnp
 server {
     listen 80;
@@ -135,7 +136,6 @@ server {
 }
 EOF
 
-$STD apt install -y nginx
 ln -sf /etc/nginx/sites-available/openlmnp /etc/nginx/sites-enabled/
 rm -f /etc/nginx/sites-enabled/default
 $STD systemctl reload nginx

--- a/install/openlmnp-install.sh
+++ b/install/openlmnp-install.sh
@@ -75,7 +75,7 @@ $STD php artisan optimize
 msg_ok "Configured OpenLMNP"
 
 msg_info "Securing Admin Account"
-ADMIN_PASS="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)"
+ADMIN_PASS="$(openssl rand -hex 12)"
 # Replace the seeded demo password with a random one (password is cast as 'hashed')
 $STD php artisan tinker --execute="\$u = \App\Models\User::query()->orderBy('id')->first(); if (\$u) { \$u->password = '${ADMIN_PASS}'; \$u->save(); }"
 {

--- a/install/openlmnp-install.sh
+++ b/install/openlmnp-install.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: manganate006
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/manganate006/openlmnp
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  git \
+  sqlite3 \
+  unzip \
+  rsync
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="bcmath,intl,gd,zip,sqlite3" setup_php
+setup_composer
+
+fetch_and_deploy_gh_release "openlmnp" "manganate006/openlmnp" "tarball"
+
+msg_info "Configuring OpenLMNP"
+cd /opt/openlmnp || exit
+
+# Generate a valid Laravel APP_KEY without artisan (vendor/ is installed by composer below)
+APP_KEY="base64:$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
+cat <<EOF >/opt/openlmnp/.env
+APP_NAME=OpenLMNP
+APP_ENV=production
+APP_KEY=${APP_KEY}
+APP_DEBUG=false
+APP_URL=http://${LOCAL_IP}
+
+LOG_CHANNEL=stack
+LOG_LEVEL=warning
+
+DB_CONNECTION=sqlite
+DB_DATABASE=/opt/openlmnp/database/database.sqlite
+
+SESSION_DRIVER=file
+SESSION_LIFETIME=120
+CACHE_STORE=file
+QUEUE_CONNECTION=sync
+
+APP_LOCALE=fr
+APP_FALLBACK_LOCALE=en
+
+MAIL_MAILER=log
+
+MCP_ENABLED=false
+EOF
+
+export COMPOSER_ALLOW_SUPERUSER=1
+$STD /usr/local/bin/composer install --no-dev --optimize-autoloader --no-interaction
+$STD npm install --no-audit --no-fund
+$STD npm run build
+
+mkdir -p database storage/app/{public,data} storage/{logs,framework/{sessions,views,cache}}
+touch database/database.sqlite
+chmod 775 database/database.sqlite
+
+$STD php artisan storage:link
+$STD php artisan migrate --force
+$STD php artisan db:seed --force
+$STD php artisan optimize
+msg_ok "Configured OpenLMNP"
+
+msg_info "Securing Admin Account"
+ADMIN_PASS="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)"
+# Replace the seeded demo password with a random one (password is cast as 'hashed')
+$STD php artisan tinker --execute="\$u = \App\Models\User::query()->orderBy('id')->first(); if (\$u) { \$u->password = '${ADMIN_PASS}'; \$u->save(); }"
+{
+  echo "OpenLMNP — identifiants administrateur"
+  echo "Email    : demo@openlmnp.fr"
+  echo "Password : ${ADMIN_PASS}"
+  echo ""
+  echo "Changez-les après la première connexion."
+} >/opt/openlmnp/admin_credentials.txt
+chmod 600 /opt/openlmnp/admin_credentials.txt
+msg_ok "Secured Admin Account (credentials in /opt/openlmnp/admin_credentials.txt)"
+
+chown -R www-data:www-data /opt/openlmnp
+chmod -R 775 /opt/openlmnp/storage /opt/openlmnp/database /opt/openlmnp/bootstrap/cache
+chmod 640 /opt/openlmnp/.env
+chmod 600 /opt/openlmnp/admin_credentials.txt
+
+msg_info "Configuring Nginx"
+cat <<'EOF' >/etc/nginx/sites-available/openlmnp
+server {
+    listen 80;
+    server_name _;
+    root /opt/openlmnp/public;
+    index index.php;
+
+    client_max_body_size 20M;
+    charset utf-8;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+
+    gzip on;
+    gzip_types application/javascript application/x-javascript text/javascript text/plain text/css application/json application/xml image/svg+xml;
+    gzip_min_length 1000;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /index.php {
+        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ \.php$ {
+        return 403;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    error_log /var/log/nginx/openlmnp_error.log;
+    access_log /var/log/nginx/openlmnp_access.log;
+}
+EOF
+
+$STD apt install -y nginx
+ln -sf /etc/nginx/sites-available/openlmnp /etc/nginx/sites-enabled/
+rm -f /etc/nginx/sites-enabled/default
+$STD systemctl reload nginx
+msg_ok "Configured Nginx"
+
+msg_info "Setting up Cron"
+cat <<'EOF' >/etc/cron.d/openlmnp
+* * * * * www-data cd /opt/openlmnp && php artisan schedule:run >> /dev/null 2>&1
+EOF
+msg_ok "Set up Cron"
+
+msg_info "Enabling Services"
+systemctl enable -q --now php8.4-fpm nginx
+msg_ok "Enabled Services"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/openlmnp.json
+++ b/json/openlmnp.json
@@ -1,0 +1,43 @@
+{
+  "name": "OpenLMNP",
+  "slug": "openlmnp",
+  "categories": [23],
+  "date_created": "2026-07-20",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 80,
+  "documentation": "https://github.com/manganate006/openlmnp#readme",
+  "website": "https://github.com/manganate006/openlmnp",
+  "logo": "https://raw.githubusercontent.com/manganate006/openlmnp/main/public/favicon.ico",
+  "description": "Open-source French rental accounting software (LMNP) for Airbnb hosts. Manage properties, incomes, expenses, depreciation, and generate tax returns (liasse fiscale).",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/openlmnp.sh",
+      "config_path": "/opt/openlmnp/.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Admin account and a random password are generated during installation and saved to /opt/openlmnp/admin_credentials.txt inside the container. Change the password after first login.",
+      "type": "warning"
+    },
+    {
+      "text": "Data is stored in SQLite at /opt/openlmnp/database/database.sqlite. Back up this file regularly.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds a new script for **OpenLMNP**, an open-source French rental accounting application (AGPLv3, Laravel/PHP) for landlords under the "LMNP" (Location Meublée Non Professionnelle) real-expense tax regime. It manages properties, income/expenses, depreciation schedules, loans, and generates the French tax return (liasse fiscale 2031/2033) and DGFiP-compliant FEC exports.

- Repo: https://github.com/manganate006/openlmnp
- Latest release: v1.1.0

I tested this end-to-end on a fresh Debian 13 LXC on real Proxmox hardware, pointing the framework at this branch (`COMMUNITY_SCRIPTS_URL` override). Two real bugs surfaced during that testing and are already fixed in this branch:
- The admin-password generator (`tr -dc ... </dev/urandom | head -c 20`) triggered SIGPIPE under `pipefail` — replaced with `openssl rand -hex 12` (the pattern used elsewhere in this repo).
- The Nginx site config was written before the `nginx` package was installed (`/etc/nginx/sites-available/` didn't exist yet) — reordered.

After these fixes, the container installs cleanly, migrations/seeders run, and the login page returns HTTP 200 with a working generated admin password.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [x] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)  

OpenLMNP is a young project (repo created 2025-09, first stable release 2026-07-02) and does not yet meet the "Application Requirements" checklist below (in particular the 600+ GitHub stars threshold) — I'm aware this PR is very likely to be auto-closed by the requirements-check bot given its current traction, and I'm submitting it anyway, transparently, so the branch/testing work is ready to resubmit (or be manually reconsidered) once those criteria are met.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

https://github.com/manganate006/openlmnp
