### PR TITLE
New Script: Seanime

### DIFF
--- a/ct/seanime.sh
+++ b/ct/seanime.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: hasan-ismail
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://seanime.app/
+
+APP="Seanime"
+var_tags="${var_tags:-media;anime;manga}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+var_gpu="${var_gpu:-yes}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/seanime ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "seanime" "5rahim/seanime"; then
+    msg_info "Stopping Service"
+    systemctl stop seanime
+    msg_ok "Stopped Service"
+
+    create_backup /opt/seanime/data/config.toml
+
+    # CLEAN_INSTALL is intentionally omitted: the release archive holds only the
+    # seanime binary, so wiping /opt/seanime would take the data directory with it.
+    fetch_and_deploy_gh_release "seanime" "5rahim/seanime" "prebuild" "latest" "/opt/seanime" "seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz"
+    chmod +x /opt/seanime/seanime
+
+    restore_backup
+
+    msg_info "Starting Service"
+    systemctl start seanime
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:43211${CL}"

--- a/ct/seanime.sh
+++ b/ct/seanime.sh
@@ -36,11 +36,9 @@ function update_script() {
     systemctl stop seanime
     msg_ok "Stopped Service"
 
-    create_backup /opt/seanime/data/config.toml
+    create_backup /opt/seanime-data/config.toml
 
-    # CLEAN_INSTALL is intentionally omitted: the release archive holds only the
-    # seanime binary, so wiping /opt/seanime would take the data directory with it.
-    fetch_and_deploy_gh_release "seanime" "5rahim/seanime" "prebuild" "latest" "/opt/seanime" "seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "seanime" "5rahim/seanime" "prebuild" "latest" "/opt/seanime" "seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz"
     chmod +x /opt/seanime/seanime
 
     restore_backup
@@ -61,3 +59,5 @@ msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
 echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:43211${CL}"
+echo -e "${INFO}${YW} Credentials saved in:${CL}"
+echo -e "${TAB}/root/seanime.creds"

--- a/install/seanime-install.sh
+++ b/install/seanime-install.sh
@@ -15,9 +15,6 @@ update_os
 
 setup_hwaccel
 
-# Seanime shells out to ffmpeg/ffprobe for media streaming and transcoding.
-# jellyfin-ffmpeg7 ships the Intel QSV/VAAPI, AMD and NVIDIA encoders that the
-# Debian ffmpeg build does not fully cover.
 msg_info "Installing FFmpeg"
 setup_deb822_repo \
   "jellyfin" \
@@ -32,9 +29,20 @@ msg_ok "Installed FFmpeg"
 fetch_and_deploy_gh_release "seanime" "5rahim/seanime" "prebuild" "latest" "/opt/seanime" "seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz"
 chmod +x /opt/seanime/seanime
 
+msg_info "Configuring Seanime"
+SEANIME_PASSWORD=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)
+mkdir -p /opt/seanime-data
+cat <<EOF >/opt/seanime-data/config.toml
+[server]
+password = "${SEANIME_PASSWORD}"
+EOF
+cat <<EOF >/root/seanime.creds
+Seanime URL: http://${LOCAL_IP}:43211
+Password: ${SEANIME_PASSWORD}
+EOF
+msg_ok "Configured Seanime"
+
 msg_info "Creating Service"
-# Seanime binds 127.0.0.1 by default, which is unreachable from outside the
-# container, so the listen address is set explicitly.
 cat <<EOF >/etc/systemd/system/seanime.service
 [Unit]
 Description=Seanime
@@ -44,7 +52,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/opt/seanime
-ExecStart=/opt/seanime/seanime --datadir /opt/seanime/data --host 0.0.0.0
+ExecStart=/opt/seanime/seanime --datadir /opt/seanime-data --host 0.0.0.0
 Restart=on-failure
 RestartSec=5
 

--- a/install/seanime-install.sh
+++ b/install/seanime-install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: hasan-ismail
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://seanime.app/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+setup_hwaccel
+
+# Seanime shells out to ffmpeg/ffprobe for media streaming and transcoding.
+# jellyfin-ffmpeg7 ships the Intel QSV/VAAPI, AMD and NVIDIA encoders that the
+# Debian ffmpeg build does not fully cover.
+msg_info "Installing FFmpeg"
+setup_deb822_repo \
+  "jellyfin" \
+  "https://repo.jellyfin.org/jellyfin_team.gpg.key" \
+  "https://repo.jellyfin.org/debian" \
+  "$(get_os_info codename)"
+$STD apt install -y jellyfin-ffmpeg7
+ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
+ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
+msg_ok "Installed FFmpeg"
+
+fetch_and_deploy_gh_release "seanime" "5rahim/seanime" "prebuild" "latest" "/opt/seanime" "seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz"
+chmod +x /opt/seanime/seanime
+
+msg_info "Creating Service"
+# Seanime binds 127.0.0.1 by default, which is unreachable from outside the
+# container, so the listen address is set explicitly.
+cat <<EOF >/etc/systemd/system/seanime.service
+[Unit]
+Description=Seanime
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/seanime
+ExecStart=/opt/seanime/seanime --datadir /opt/seanime/data --host 0.0.0.0
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now seanime
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/seanime.json
+++ b/json/seanime.json
@@ -18,7 +18,7 @@
     {
       "type": "default",
       "script": "ct/seanime.sh",
-      "config_path": "/opt/seanime/data/config.toml",
+      "config_path": "/opt/seanime-data/config.toml",
       "resources": {
         "cpu": 2,
         "ram": 2048,
@@ -30,12 +30,12 @@
   ],
   "default_credentials": {
     "username": null,
-    "password": null
+    "password": "auto-generated"
   },
   "notes": [
     {
-      "text": "The instance is unauthenticated by default. Set `password` under `[server]` in /opt/seanime/data/config.toml and restart seanime.service before exposing it beyond your LAN.",
-      "type": "warning"
+      "text": "A random server password is generated at install and saved to `/root/seanime.creds`. Seanime authenticates with that password alone — there is no username. Change it under `[server]` in /opt/seanime-data/config.toml and restart seanime.service.",
+      "type": "info"
     },
     {
       "text": "Seanime is built around a single AniList account per instance and has no multi-user accounts or role-based access. Trakt and SIMKL are not supported, and MyAnimeList is limited to optional progress sync.",
@@ -50,7 +50,7 @@
       "type": "info"
     },
     {
-      "text": "The data directory /opt/seanime/data lives on the container disk and holds config.toml, the database, logs, the transcode cache, downloaded manga and — when the built-in torrent client is used — downloads. Increase the disk size or bind-mount storage before building a large library.",
+      "text": "The data directory /opt/seanime-data lives on the container disk and holds config.toml, the database, logs, the transcode cache, downloaded manga and — when the built-in torrent client is used — downloads. It is kept outside /opt/seanime so updates can replace the binary cleanly. Increase the disk size or bind-mount storage before building a large library.",
       "type": "info"
     }
   ]

--- a/json/seanime.json
+++ b/json/seanime.json
@@ -1,0 +1,57 @@
+{
+  "name": "Seanime",
+  "slug": "seanime",
+  "categories": [
+    13
+  ],
+  "date_created": "2026-07-25",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 43211,
+  "documentation": "https://seanime.app/docs",
+  "website": "https://seanime.app/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/seanime.webp",
+  "description": "Seanime is a self-hosted server for an anime and manga library, built around AniList. It scans local media, tracks progress back to AniList, searches torrents through extension-based providers, downloads through qBittorrent, Transmission, Torbox, Real-Debrid, AllDebrid or Premiumize, streams torrent and debrid content straight to a player, auto-downloads airing episodes, and includes a manga reader and online streaming via extensions.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/seanime.sh",
+      "config_path": "/opt/seanime/data/config.toml",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The instance is unauthenticated by default. Set `password` under `[server]` in /opt/seanime/data/config.toml and restart seanime.service before exposing it beyond your LAN.",
+      "type": "warning"
+    },
+    {
+      "text": "Seanime is built around a single AniList account per instance and has no multi-user accounts or role-based access. Trakt and SIMKL are not supported, and MyAnimeList is limited to optional progress sync.",
+      "type": "warning"
+    },
+    {
+      "text": "Attach your existing library to the container, then point Seanime at it under Settings: pct set <CTID> -mp0 /path/on/host,mp=/mnt/anime",
+      "type": "info"
+    },
+    {
+      "text": "GPU passthrough is enabled by default during installation and can be turned off in the Advanced install options. The matching Intel/AMD/NVIDIA drivers and jellyfin-ffmpeg7 are installed for it. Transcoding itself is off by default: enable it under Settings > Transcoding / Direct Play, then set Hardware acceleration to Intel (QSV), Intel (QSV Low-Power), VAAPI or NVIDIA (NVENC). That choice is stored in Seanime's database, so the installer cannot preset it.",
+      "type": "info"
+    },
+    {
+      "text": "The data directory /opt/seanime/data lives on the container disk and holds config.toml, the database, logs, the transcode cache, downloaded manga and — when the built-in torrent client is used — downloads. Increase the disk size or bind-mount storage before building a large library.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description

Adds a CT script, install script and JSON metadata for **Seanime** - a self-hosted anime/manga media server built around AniList.

**How it installs**
- Deploys the official prebuilt Linux release binary via `fetch_and_deploy_gh_release ... "prebuild"` - no Docker, no build from source. The asset glob is `seanime-[0-9]*_Linux_$(arch_resolve x86_64 arm64).tar.gz`; the `[0-9]` guard stops it from ever matching the `seanime-denshi-*` desktop assets shipped in the same release.
- Debian 13, unprivileged. The upstream binary is a statically linked Go ELF, so there is no glibc floor.
- `--host 0.0.0.0` is set in the unit **because Seanime binds `127.0.0.1:43211` by default** (`internal/core/config.go`: `defaultHost := "127.0.0.1"`). Without it the web UI is unreachable from outside the container.
- `--datadir /opt/seanime/data` pins the data directory instead of letting it land in `/root/.config/Seanime`, which also gives the JSON a stable `config_path`.
- `chmod +x` is explicit because `prebuild` mode does not set the exec bit itself.

**Hardware transcoding (Intel QSV)**
- `var_gpu="${var_gpu:-yes}"` opts into the framework's GPU passthrough, the same way `ct/immich.sh` does. On the Advanced path the Step-21 prompt is pre-selected to **Yes**; on the Default path passthrough is applied automatically.
- `setup_hwaccel` installs the matching Intel/AMD/NVIDIA userland, and `jellyfin-ffmpeg7` provides the QSV/VAAPI encoders (Seanime shells out to `ffmpeg`/`ffprobe` from `PATH`, defaulting to the bare names). Both degrade gracefully on a host with no GPU.
- Transcoding itself is off by default in Seanime, and the hwaccel backend is stored in Seanime's database rather than `config.toml`, so the installer cannot preset it - the JSON notes give the exact UI path instead.

**Updates**
`check_for_gh_release` + `fetch_and_deploy_gh_release`, with `config.toml` preserved through `create_backup`/`restore_backup`. `CLEAN_INSTALL` is deliberately **not** used: the archive contains only the binary, so wiping `/opt/seanime` would destroy the data directory.

**Testing**
Installed on a real Proxmox VE host (amd64): the container builds, `seanime.service` comes up, and the Seanime web UI is reachable on port 43211.

Also verified statically: `bash -n` and `shellcheck` on both scripts (only the usual SC1090/SC1091 source-following notices, byte-identical to the baseline from existing scripts in this repo); the v3.10.2 release asset downloads and contains a single root-level `./seanime` binary at mode 0755; the asset glob matches that asset and nothing else in the release; `prebuild` mode's extraction lands it at `/opt/seanime/seanime`; `jellyfin-ffmpeg7` exists for trixie on both amd64 and arm64; and every factual claim in the JSON was checked against upstream source.

**arm64:** marked *not tested* - upstream publishes an official `_Linux_arm64.tar.gz` which the script selects via `arch_resolve`, but the host it was tested on is amd64, so arm64 remains unconfirmed.


## 🔗 Related PR / Issue  

Link: https://github.com/community-scripts/ProxmoxVE/discussions/12559 (open community request for a Seanime script)

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [x] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- Upstream: https://github.com/5rahim/seanime - GPL-3.0, ~3.9k stars, created 2023-10-23, latest release v3.10.2 (2026-07-23), 30 releases with official tarballs
- Website: https://seanime.app/
- Docs: https://seanime.app/docs
- Community request: https://github.com/community-scripts/ProxmoxVE/discussions/12559
