### PR TITLE
New Script: Kaneo

### DIFF
--- a/ct/kaneo.sh
+++ b/ct/kaneo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: onionrings29
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/usekaneo/kaneo
+
+APP="Kaneo"
+var_tags="${var_tags:-project-management;productivity}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-6144}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/kaneo ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "kaneo" "usekaneo/kaneo"; then
+    msg_info "Stopping Service"
+    systemctl stop kaneo
+    msg_ok "Stopped Service"
+
+    create_backup /opt/kaneo/.env
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "kaneo" "usekaneo/kaneo" "tarball"
+
+    restore_backup
+
+    msg_info "Configuring Kaneo"
+    cat <<EOF >/opt/kaneo/apps/web/.env.production
+VITE_API_URL=$(grep '^KANEO_API_URL=' /opt/kaneo/.env | cut -d= -f2-)
+VITE_CLIENT_URL=$(grep '^KANEO_CLIENT_URL=' /opt/kaneo/.env | cut -d= -f2-)
+EOF
+    msg_ok "Configured Kaneo"
+
+    msg_info "Building Kaneo"
+    cd /opt/kaneo
+    export NODE_OPTIONS="--max-old-space-size=4096"
+    HUSKY=0 $STD pnpm install --frozen-lockfile
+    $STD pnpm exec turbo build --filter=@kaneo/api --filter=@kaneo/web
+    unset NODE_OPTIONS
+    msg_ok "Built Kaneo"
+
+    msg_info "Starting Service"
+    systemctl start kaneo
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:5173${CL}"

--- a/ct/kaneo.sh
+++ b/ct/kaneo.sh
@@ -39,6 +39,9 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "kaneo" "usekaneo/kaneo" "tarball"
 
+    PNPM_VERSION=$(sed -n 's/.*"packageManager": "pnpm@\([^"+]*\).*/\1/p' /opt/kaneo/package.json)
+    NODE_VERSION="22" NODE_MODULE="pnpm@${PNPM_VERSION:-10.32.1}" setup_nodejs
+
     restore_backup
 
     msg_info "Configuring Kaneo"

--- a/install/kaneo-install.sh
+++ b/install/kaneo-install.sh
@@ -19,8 +19,10 @@ msg_ok "Installed Dependencies"
 
 PG_VERSION="17" setup_postgresql
 PG_DB_NAME="kaneo" PG_DB_USER="kaneo" setup_postgresql_db
-NODE_VERSION="22" NODE_MODULE="pnpm@10.32.1" setup_nodejs
 fetch_and_deploy_gh_release "kaneo" "usekaneo/kaneo" "tarball"
+
+PNPM_VERSION=$(sed -n 's/.*"packageManager": "pnpm@\([^"+]*\).*/\1/p' /opt/kaneo/package.json)
+NODE_VERSION="22" NODE_MODULE="pnpm@${PNPM_VERSION:-10.32.1}" setup_nodejs
 
 msg_info "Configuring Kaneo"
 cat <<EOF >/opt/kaneo/.env

--- a/install/kaneo-install.sh
+++ b/install/kaneo-install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: onionrings29
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/usekaneo/kaneo
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y nginx
+msg_ok "Installed Dependencies"
+
+PG_VERSION="17" setup_postgresql
+PG_DB_NAME="kaneo" PG_DB_USER="kaneo" setup_postgresql_db
+NODE_VERSION="22" NODE_MODULE="pnpm@10.32.1" setup_nodejs
+fetch_and_deploy_gh_release "kaneo" "usekaneo/kaneo" "tarball"
+
+msg_info "Configuring Kaneo"
+cat <<EOF >/opt/kaneo/.env
+DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}
+AUTH_SECRET=$(openssl rand -hex 32)
+KANEO_CLIENT_URL=http://${LOCAL_IP}:5173
+KANEO_API_URL=http://${LOCAL_IP}:5173/api
+EOF
+cat <<EOF >/opt/kaneo/apps/web/.env.production
+VITE_API_URL=http://${LOCAL_IP}:5173/api
+VITE_CLIENT_URL=http://${LOCAL_IP}:5173
+EOF
+msg_ok "Configured Kaneo"
+
+msg_info "Building Kaneo"
+cd /opt/kaneo
+export NODE_OPTIONS="--max-old-space-size=4096"
+HUSKY=0 $STD pnpm install --frozen-lockfile
+$STD pnpm exec turbo build --filter=@kaneo/api --filter=@kaneo/web
+unset NODE_OPTIONS
+msg_ok "Built Kaneo"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/kaneo.service
+[Unit]
+Description=Kaneo API
+After=network.target postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/kaneo
+Environment=NODE_ENV=production
+EnvironmentFile=/opt/kaneo/.env
+ExecStart=/usr/bin/node /opt/kaneo/apps/api/dist/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now kaneo
+msg_ok "Created Service"
+
+msg_info "Configuring Nginx"
+cat <<EOF >/etc/nginx/sites-available/kaneo
+server {
+  listen 5173;
+  server_name _;
+
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  client_max_body_size 25M;
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1000;
+  gzip_proxied any;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_comp_level 6;
+
+  location = /.well-known/oauth-protected-resource/api/mcp {
+    proxy_pass http://127.0.0.1:1337/.well-known/oauth-protected-resource/api/mcp;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+  location = /.well-known/oauth-authorization-server/api {
+    proxy_pass http://127.0.0.1:1337/.well-known/oauth-authorization-server/api;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+  location /.well-known/ {
+    return 404;
+  }
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:1337/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+  location / {
+    root /opt/kaneo/apps/web/dist;
+    index index.html;
+    try_files \$uri \$uri/ /index.html;
+  }
+}
+EOF
+ln -sf /etc/nginx/sites-available/kaneo /etc/nginx/sites-enabled/kaneo
+rm -f /etc/nginx/sites-enabled/default
+$STD nginx -t
+systemctl reload nginx
+msg_ok "Configured Nginx"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/kaneo.json
+++ b/json/kaneo.json
@@ -1,0 +1,54 @@
+{
+  "name": "Kaneo",
+  "slug": "kaneo",
+  "categories": [
+    25
+  ],
+  "date_created": "2026-07-26",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 5173,
+  "documentation": "https://kaneo.app/docs",
+  "website": "https://kaneo.app/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/kaneo.webp",
+  "config_path": "/opt/kaneo/.env",
+  "description": "Kaneo is an open source project management platform with kanban boards, task tracking, time tracking and team workspaces.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/kaneo.sh",
+      "config_path": "/opt/kaneo/.env",
+      "resources": {
+        "cpu": 4,
+        "ram": 6144,
+        "hdd": 20,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The first registered account becomes the instance admin.",
+      "type": "info"
+    },
+    {
+      "text": "Registration and guest sign-in both stay open after that. Set DISABLE_REGISTRATION=true and DISABLE_GUEST_ACCESS=true in /opt/kaneo/.env and restart the service to close the instance; DISABLE_REGISTRATION alone still leaves the guest login available.",
+      "type": "warning"
+    },
+    {
+      "text": "The API URL is baked into the frontend at build time. To move Kaneo to another IP or a custom domain, set KANEO_CLIENT_URL and KANEO_API_URL in /opt/kaneo/.env and the matching VITE_API_URL and VITE_CLIENT_URL in /opt/kaneo/apps/web/.env.production, then rebuild with 'cd /opt/kaneo && pnpm exec turbo build --filter=@kaneo/web'.",
+      "type": "warning"
+    },
+    {
+      "text": "Image and file attachments require object storage. Add S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY to /opt/kaneo/.env and restart the service.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds a Kaneo LXC helper script. Kaneo is an open source project management platform (kanban boards, tasks, time tracking, workspaces).

Installed bare metal on Debian 13: PostgreSQL 17, Node.js 22 + pnpm, the Hono API on port 1337 as a systemd service, and nginx on 5173 serving the built Vite frontend and proxying `/api` (including the WebSocket upgrade) to the API. Only `@kaneo/api` and `@kaneo/web` are built — the repo also contains a Next.js marketing site that is deliberately skipped.

Two Kaneo-specific details worth noting for review:

- `apps/web/.env.production` is rewritten before the build. Upstream ships it containing literal placeholder strings (e.g. `VITE_TURNSTILE_SITE_KEY="KANEO_TURNSTILE_SITE_KEY"`) that their Docker entrypoint substitutes at container start. Left as-is the placeholder is truthy in the bundle and breaks signup (usekaneo/kaneo#1304).
- `HUSKY=0` on `pnpm install` — the root `package.json` has `"prepare": "husky"`, which fails on a release tarball since it has no `.git`.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

Tested on Proxmox VE 9.2.4, Debian 13 unprivileged CT, 4 cores / 6 GB / 20 GB:

- Fresh install completes and both `kaneo` and `nginx` come up active.
- Drizzle migrations run at API startup — 29 tables created.
- Full workflow exercised in a browser: sign up, create workspace, create project, create task, open task detail, change status via the dropdown — all persisted.
- WebSocket upgrade through nginx works; a second client receives `TASK_CREATED` broadcasts, so live board updates function.
- MCP OAuth discovery (`/.well-known/oauth-authorization-server/api` and `/.well-known/oauth-protected-resource/api/mcp`) is proxied to the API rather than falling through to the SPA; other `.well-known` probes return 404. These stanzas and the gzip/header settings follow upstream's own `apps/web/nginx.kaneo.conf`.
- Update path (`create_backup` → `CLEAN_INSTALL=1 fetch_and_deploy_gh_release` → `restore_backup` → rebuild) completes with `/opt/kaneo/.env`, active sessions and existing database rows preserved.
- Container reboot tested — `kaneo`, `nginx` and `postgresql` all come back up and the UI is reachable.
- Disk usage after install plus one update cycle: 3.1 GB of the 20 GB default. Idle RAM 194 MB — the 6 GB default is sized for the Vite build, not for runtime.

Two behaviours worth knowing about, both documented in the JSON notes:

- The frontend is a static bundle with the API URL baked in at build time, so moving the container to another IP or fronting it with a reverse proxy on a custom domain requires updating `/opt/kaneo/.env` plus `apps/web/.env.production` and rebuilding.
- Closing an instance needs **both** `DISABLE_REGISTRATION=true` and `DISABLE_GUEST_ACCESS=true`. Verified on a live instance: with only `DISABLE_REGISTRATION` set, `/api/config` still reports `hasGuestAccess: true` and `POST /api/auth/sign-in/anonymous` still issues a working session.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- Website: https://kaneo.app/
- GitHub: https://github.com/usekaneo/kaneo
- Docs: https://kaneo.app/docs
