### PR TITLE
Add Orb internet quality sensor

### DIFF
--- a/ct/orb.sh
+++ b/ct/orb.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: angusmaul
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://orb.net/
+
+APP="Orb"
+var_tags="${var_tags:-network;monitoring}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if ! command -v orb >/dev/null 2>&1; then
+    msg_error "No ${APP} Installation Found!"
+    exit 233
+  fi
+
+  if [[ ! -f /etc/apt/sources.list.d/orb.sources ]]; then
+    setup_deb822_repo \
+      "orb" \
+      "https://pkgs.orb.net/stable/debian/orbforge.noarmor.gpg" \
+      "https://pkgs.orb.net/stable/debian" \
+      "orb" \
+      "main"
+  fi
+
+  # The sensor identity (private.key + certificate.crt) lives in /home/orb/.config/orb.
+  # Upgrading the package replaces only /usr/bin/orb, so that directory is never touched
+  # and the sensor keeps its Orb ID and its history. Do not clear it to "start clean".
+  msg_info "Updating $APP LXC"
+  $STD apt update
+  $STD apt install -y --only-upgrade orb
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}The sensor is running but is not linked to an Orb account yet.${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}pct exec ${CTID} -- runuser -u orb -- orb link${CL}"
+echo -e "${INFO}${YW}Then scan the QR code, or open the printed URL and sign in.${CL}"
+echo -e "${INFO}${YW}Measurements are viewed in the Orb app or at:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://app.orb.net${CL}"

--- a/ct/orb.sh
+++ b/ct/orb.sh
@@ -39,9 +39,6 @@ function update_script() {
       "main"
   fi
 
-  # The sensor identity (private.key + certificate.crt) lives in /home/orb/.config/orb.
-  # Upgrading the package replaces only /usr/bin/orb, so that directory is never touched
-  # and the sensor keeps its Orb ID and its history. Do not clear it to "start clean".
   msg_info "Updating $APP LXC"
   $STD apt update
   $STD apt install -y --only-upgrade orb
@@ -55,8 +52,5 @@ description
 
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW}The sensor is running but is not linked to an Orb account yet.${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}To link the sensor to your orb account run:${CL}"
 echo -e "${TAB}${GATEWAY}${BGN}pct exec ${CTID} -- runuser -u orb -- orb link${CL}"
-echo -e "${INFO}${YW}Then scan the QR code, or open the printed URL and sign in.${CL}"
-echo -e "${INFO}${YW}Measurements are viewed in the Orb app or at:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}https://app.orb.net${CL}"

--- a/ct/orb.sh
+++ b/ct/orb.sh
@@ -25,18 +25,9 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  if ! command -v orb >/dev/null 2>&1; then
+  if ! dpkg -s orb >/dev/null 2>&1; then
     msg_error "No ${APP} Installation Found!"
     exit 233
-  fi
-
-  if [[ ! -f /etc/apt/sources.list.d/orb.sources ]]; then
-    setup_deb822_repo \
-      "orb" \
-      "https://pkgs.orb.net/stable/debian/orbforge.noarmor.gpg" \
-      "https://pkgs.orb.net/stable/debian" \
-      "orb" \
-      "main"
   fi
 
   msg_info "Updating $APP LXC"

--- a/install/orb-install.sh
+++ b/install/orb-install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: angusmaul
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://orb.net/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# Orb publishes an official apt repository. The suite is literally "orb" rather than a
+# Debian codename, so one suite serves every release and there is no codename to keep in
+# sync. Architectures is deliberately omitted: amd64 and arm64 both live in "main", so apt
+# resolves whichever the container is.
+setup_deb822_repo \
+  "orb" \
+  "https://pkgs.orb.net/stable/debian/orbforge.noarmor.gpg" \
+  "https://pkgs.orb.net/stable/debian" \
+  "orb" \
+  "main"
+
+msg_info "Installing Orb"
+$STD apt install -y orb
+msg_ok "Installed Orb"
+
+# The package ships orb.service and its postinst enables and starts it, creating the
+# system user "orb" with a home of /home/orb. The unit runs /usr/bin/orb sensor as that
+# user with AmbientCapabilities=CAP_NET_RAW, which works in an unprivileged container.
+msg_info "Enabling Service"
+$STD systemctl enable --now orb
+msg_ok "Enabled Service"
+
+# orb-update.timer ships with the package but is deliberately left disabled. Updates go
+# through the CT script's update option instead: /usr/bin/orb-update passes
+# Dir::Etc::sourcelist=sources.list.d/orb.list, the legacy one-line source, so it would
+# refresh nothing against the deb822 orb.sources written above.
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/orb-install.sh
+++ b/install/orb-install.sh
@@ -13,10 +13,6 @@ setting_up_container
 network_check
 update_os
 
-# Orb publishes an official apt repository. The suite is literally "orb" rather than a
-# Debian codename, so one suite serves every release and there is no codename to keep in
-# sync. Architectures is deliberately omitted: amd64 and arm64 both live in "main", so apt
-# resolves whichever the container is.
 setup_deb822_repo \
   "orb" \
   "https://pkgs.orb.net/stable/debian/orbforge.noarmor.gpg" \
@@ -28,17 +24,9 @@ msg_info "Installing Orb"
 $STD apt install -y orb
 msg_ok "Installed Orb"
 
-# The package ships orb.service and its postinst enables and starts it, creating the
-# system user "orb" with a home of /home/orb. The unit runs /usr/bin/orb sensor as that
-# user with AmbientCapabilities=CAP_NET_RAW, which works in an unprivileged container.
 msg_info "Enabling Service"
 $STD systemctl enable --now orb
 msg_ok "Enabled Service"
-
-# orb-update.timer ships with the package but is deliberately left disabled. Updates go
-# through the CT script's update option instead: /usr/bin/orb-update passes
-# Dir::Etc::sourcelist=sources.list.d/orb.list, the legacy one-line source, so it would
-# refresh nothing against the deb822 orb.sources written above.
 
 motd_ssh
 customize

--- a/json/orb.json
+++ b/json/orb.json
@@ -35,27 +35,11 @@
   },
   "notes": [
     {
-      "text": "The sensor starts unlinked and must be claimed before it appears in your account. Run `runuser -u orb -- orb link` inside the container, then scan the QR code it prints or open the URL it shows and sign in to Orb.",
+      "text": "The sensor starts unlinked and must be claimed before it appears in your account. Run `runuser -u orb -- orb link` inside the container to sign into Orb.",
       "type": "info"
     },
     {
-      "text": "Running `orb sensor --help` STARTS A SECOND SENSOR. The sensor subcommand does not implement --help, so any such invocation launches another sensor process that shares this sensor's identity and writes the same filestore, which can register a duplicate device in the Orb cloud that you then have to delete by hand. Never use `orb sensor` to probe the CLI. Use `orb help` for usage and `orb version` for the version - both are safe.",
-      "type": "warning"
-    },
-    {
-      "text": "The sensor's identity is the private.key and certificate.crt in /home/orb/.config/orb (mode 700, owned by orb). Deleting or resetting that directory registers a brand new sensor and orphans all previous history, so preserve it across rebuilds, restores and migrations. Package upgrades replace only /usr/bin/orb and never touch it.",
-      "type": "warning"
-    },
-    {
-      "text": "There is no web interface. The sensor listens on port 7443 for Orb's own API and returns 404 for anything else, so there is nothing to browse to. View measurements in the Orb app or at https://app.orb.net, or run `runuser -u orb -- orb summary` in the container for the latest scores as JSON.",
-      "type": "info"
-    },
-    {
-      "text": "The sensor's display name is a cloud-side property and there is no rename command. Rename it in the Orb app or dashboard; the container hostname is unrelated to it.",
-      "type": "info"
-    },
-    {
-      "text": "Update through the script's own update option. The package also ships orb-update.timer for Orb's daily self-upgrade and it is left disabled, which is deliberate: /usr/bin/orb-update refreshes only /etc/apt/sources.list.d/orb.list, the legacy one-line source, while this script installs the repository in deb822 format as orb.sources. Enabling that timer would therefore refresh nothing of Orb's own package list.",
+      "text": "View measurements in the Orb app or at https://app.orb.net, or run `runuser -u orb -- orb summary` in the container for the latest scores as JSON.",
       "type": "info"
     }
   ]

--- a/json/orb.json
+++ b/json/orb.json
@@ -1,0 +1,62 @@
+{
+  "name": "Orb",
+  "slug": "orb",
+  "categories": [
+    9,
+    4
+  ],
+  "date_created": "2026-07-28",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": null,
+  "documentation": "https://orb.net/docs",
+  "website": "https://orb.net/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/orb.webp",
+  "description": "Orb continuously measures internet quality rather than just speed, scoring responsiveness, reliability and bandwidth into a single Orb Score. The sensor is a headless agent that runs 24/7, uploads its measurements to your Orb account, and is viewed from the Orb mobile or desktop app. Orb is free for up to five sensors.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/orb.sh",
+      "config_path": "/etc/default/orb",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The sensor starts unlinked and must be claimed before it appears in your account. Run `runuser -u orb -- orb link` inside the container, then scan the QR code it prints or open the URL it shows and sign in to Orb.",
+      "type": "info"
+    },
+    {
+      "text": "Running `orb sensor --help` STARTS A SECOND SENSOR. The sensor subcommand does not implement --help, so any such invocation launches another sensor process that shares this sensor's identity and writes the same filestore, which can register a duplicate device in the Orb cloud that you then have to delete by hand. Never use `orb sensor` to probe the CLI. Use `orb help` for usage and `orb version` for the version - both are safe.",
+      "type": "warning"
+    },
+    {
+      "text": "The sensor's identity is the private.key and certificate.crt in /home/orb/.config/orb (mode 700, owned by orb). Deleting or resetting that directory registers a brand new sensor and orphans all previous history, so preserve it across rebuilds, restores and migrations. Package upgrades replace only /usr/bin/orb and never touch it.",
+      "type": "warning"
+    },
+    {
+      "text": "There is no web interface. The sensor listens on port 7443 for Orb's own API and returns 404 for anything else, so there is nothing to browse to. View measurements in the Orb app or at https://app.orb.net, or run `runuser -u orb -- orb summary` in the container for the latest scores as JSON.",
+      "type": "info"
+    },
+    {
+      "text": "The sensor's display name is a cloud-side property and there is no rename command. Rename it in the Orb app or dashboard; the container hostname is unrelated to it.",
+      "type": "info"
+    },
+    {
+      "text": "Update through the script's own update option. The package also ships orb-update.timer for Orb's daily self-upgrade and it is left disabled, which is deliberate: /usr/bin/orb-update refreshes only /etc/apt/sources.list.d/orb.list, the legacy one-line source, while this script installs the repository in deb822 format as orb.sources. Enabling that timer would therefore refresh nothing of Orb's own package list.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description

Adds a helper script for **Orb** (https://orb.net), a headless internet-quality sensor. It scores responsiveness, reliability and bandwidth into a single Orb Score, runs 24/7, and is free for up to five sensors.

Orb's own docs point self-hosters at Docker for this, but a container runtime is unnecessary. Orb publishes an **official apt repository** and the package is a single statically linked Go binary plus a systemd unit — so this installs bare-metal from the vendor's own repo via `setup_deb822_repo`, with nothing pulled out of an image and nothing redistributed by this repo.

Two behaviours specific to Orb shaped the script, both documented in `orb.json` notes:

1. **`orb sensor --help` starts a second sensor.** The `sensor` subcommand does not implement `--help`; invoking it launches another sensor process that shares the identity and writes the same filestore, which can register a duplicate device cloud-side. So no install or update path ever invokes `orb sensor` to probe anything. `orb version` and `orb help` are safe and were verified as such.
2. **The sensor has identity state.** `private.key` + `certificate.crt` in `/home/orb/.config/orb` (mode 700) *are* the identity — wiping that directory registers a new sensor and orphans all history. `update_script()` only upgrades the package, which owns just `/usr/bin/orb`, so that directory is never touched.

A first run leaves the sensor unlinked; the completion message tells the user to run `runuser -u orb -- orb link` and scan the QR code it prints.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

`var_arm64="yes"` is set. Orb ships an `arm64` build in the same `main` component as `amd64` (`orb_1.5.3_arm64.deb`), and `Architectures:` is deliberately omitted from the deb822 source so apt resolves whichever the container is. I only had amd64 hardware to test on.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

Update is `apt install --only-upgrade orb` against the vendor repo, the same shape as `ct/evcc.sh` and `ct/grafana.sh` in ProxmoxVE. There is no GitHub release to fetch.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

**Testing** — built from this branch on PVE 9.2.4 into a fresh Debian 13 unprivileged LXC (1 core / 512 MB / 4 GB) and verified:

- `orb.service` active and enabled; runs `/usr/bin/orb sensor` as the `orb` user with `AmbientCapabilities=CAP_NET_RAW`, which works **unprivileged** — no privileged container and no feature flags needed.
- Sensor completed real measurements from inside the container (649 Mbps down / 87 Mbps up, Orb Score 93).
- deb822 source and keyring written correctly; `orb version` reports `v1.5.3`.
- Identity created at `/home/orb/.config/orb` (700, `orb:orb`).
- **Update path proven with a real version change**, not just a no-op: downgraded to `1.5.2`, then ran the `update_script()` commands to upgrade back to `1.5.3`. The service restarted cleanly and `private.key`/`certificate.crt` were byte-identical (sha256 unchanged) across the upgrade.
- Disk use after install: 806 MB of 4 GB.

**Two deliberate choices a reviewer may want to check:**

- *A system user is created* — normally flagged by AGENTS.md rule 9. It is not created by this script: Orb's own `postinst` creates it, and the shipped unit hardcodes `User=orb`. Overriding that would fight the package.
- *`orb-update.timer` is left disabled.* The package ships it for Orb's daily self-upgrade, but `/usr/bin/orb-update` runs `apt-get update -o Dir::Etc::sourcelist="sources.list.d/orb.list"` — the legacy one-line source. Against the deb822 `orb.sources` this repo writes, that refreshes nothing (verified: `W: Unable to read /etc/apt/sources.list.d/orb.list`). Updating through the script is therefore the correct path, and the JSON note says so rather than recommending the timer.

**Licensing** — Orb is proprietary freeware. Nothing is redistributed here: the script configures Orb's own package repository and installs from Orb's own servers, which is exactly what Orb's documented installer (`curl -fsSL https://pkgs.orb.net/install.sh | sh`) does. Each user installs under their own grant.

**On the new-script criteria below** — Orb is closed-source, so it has no GitHub repository, no stars and no release tarballs; those three boxes cannot honestly be ticked. The remaining criteria are met, and there is established precedent for closed-source, vendor-packaged apps in ProxmoxVE (`plex`, `emby`, `cloudflared`, `netbird`, `zerotier-one`, `unifi-os-server`). Happy to drop this if the org would rather not carry it.

---

## 📦 Application Requirements (for new scripts)

- [X] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- Website: https://orb.net/
- Docs: https://orb.net/docs
- Linux install docs: https://orb.net/docs/setup-sensor/linux
- Package repository: https://pkgs.orb.net/stable/debian (suite `orb`, component `main`)
