### PR TITLE
New script: Whisparr-Eros (Whisparr V3)

### DIFF
--- a/ct/whisparr-eros.sh
+++ b/ct/whisparr-eros.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: angusmaul
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Whisparr/Whisparr-Eros
+
+APP="Whisparr-Eros"
+var_tags="${var_tags:-arr}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /var/lib/whisparr-eros ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "whisparr-eros" "Whisparr/Whisparr-Eros"; then
+    msg_info "Stopping Service"
+    systemctl stop whisparr-eros
+    msg_ok "Stopped Service"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "whisparr-eros" "Whisparr/Whisparr-Eros" "prebuild" "latest" "/opt/Whisparr-Eros" "Whisparr.eros.*.linux-$(arch_resolve "x64" "arm64").tar.gz"
+    rm -rf /opt/Whisparr-Eros/Whisparr.Update
+    chmod +x /opt/Whisparr-Eros/Whisparr
+
+    msg_info "Starting Service"
+    systemctl start whisparr-eros
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:6969${CL}"

--- a/install/whisparr-eros-install.sh
+++ b/install/whisparr-eros-install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: angusmaul
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/Whisparr/Whisparr-Eros
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y sqlite3 libicu-dev
+msg_ok "Installed Dependencies"
+
+fetch_and_deploy_gh_release "whisparr-eros" "Whisparr/Whisparr-Eros" "prebuild" "latest" "/opt/Whisparr-Eros" "Whisparr.eros.*.linux-$(arch_resolve "x64" "arm64").tar.gz"
+
+msg_info "Configuring Whisparr-Eros"
+rm -rf /opt/Whisparr-Eros/Whisparr.Update
+chmod +x /opt/Whisparr-Eros/Whisparr
+mkdir -p /var/lib/whisparr-eros/
+chmod 775 /var/lib/whisparr-eros/ /opt/Whisparr-Eros/
+msg_ok "Configured Whisparr-Eros"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/whisparr-eros.service
+[Unit]
+Description=Whisparr-Eros Daemon
+After=syslog.target network.target
+
+[Service]
+UMask=0002
+Type=simple
+ExecStart=/opt/Whisparr-Eros/Whisparr -nobrowser -data=/var/lib/whisparr-eros/
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now whisparr-eros
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/whisparr-eros.json
+++ b/json/whisparr-eros.json
@@ -1,0 +1,50 @@
+{
+  "name": "Whisparr-Eros",
+  "slug": "whisparr-eros",
+  "categories": [
+    14
+  ],
+  "date_created": "2026-07-28",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 6969,
+  "documentation": "https://wiki.servarr.com/whisparr",
+  "website": "https://github.com/Whisparr/Whisparr-Eros",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/whisparr.webp",
+  "config_path": "/var/lib/whisparr-eros/config.xml",
+  "description": "Whisparr V3 (\"eros\") is an adult movie and scene collection manager for Usenet and BitTorrent users. It monitors RSS feeds for new items, interfaces with download clients and indexers to grab, sort and rename them, and can automatically upgrade existing files when a better quality release appears. V3 is the Radarr-based train and is developed in its own repository, separate from the Sonarr-based Whisparr V2.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/whisparr-eros.sh",
+      "config_path": "/var/lib/whisparr-eros/config.xml",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Whisparr V3 (\"eros\") is not an upgrade of Whisparr V2 — they are two different applications developed in parallel. V2 is based on Sonarr and uses whisparr.db, V3 is based on Radarr and uses whisparr3.db, and neither can read the other's database. Use the `whisparr` script for V2 and this one for V3; do not point one at the other's data directory.",
+      "type": "warning"
+    },
+    {
+      "text": "The in-app updater cannot update this install. The Servarr `eros` update channel has not advanced past 3.1.0.2116 (2026-01-14) and reports no update available for current releases, so Whisparr will log \"Update mechanism ... changing to BuiltIn\" and then find nothing. Update with this script's update option instead, which pulls the latest stable release from Whisparr/Whisparr-Eros.",
+      "type": "info"
+    },
+    {
+      "text": "Configuration and the database live in /var/lib/whisparr-eros and survive updates — the update replaces /opt/Whisparr-Eros only. Attach your media and download directories before use: pct set <CTID> -mp0 /path/on/host,mp=/media",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review.**

## ✍️ Description  

Adds a helper script for **Whisparr V3 ("eros")**, which currently has none.

`ct/whisparr.sh` deploys `Whisparr/Whisparr` `latest` = **v2.2.0-release.108**, i.e. Whisparr **V2**
(Sonarr-based, `whisparr.db`). Whisparr V3 is a *different application* in a *different repository*,
`Whisparr/Whisparr-Eros` (Radarr-based, `whisparr3.db`), split out on 2026-01-15. V2 cannot read a
V3 database, so a V3 user who runs the existing script gets either an empty install or a
destructive migration attempt, with no warning.

**A separate script, not a version option on `ct/whisparr.sh`** — that was already settled here:

- community-scripts/ProxmoxVE#11042 — @tremor021: *"Ah, so it should be separate scripts then. …
  probably be making a separate script for v3."*
- community-scripts/ProxmoxVE#2895 — the selector-inside-the-existing-script approach was closed
  unmerged after CI failed on its interactive `read -p`.

Notable points:

- **`update_script()` does not defer to the built-in updater.** The Servarr **eros** channel
  (`https://whisparr.servarr.com/v1/update/eros?version=…&os=linux&runtime=netcore&arch=x64`) tops
  out at **3.1.0.2116, dated 2026-01-14** — older than current releases — and returns
  `available:false` for anything current, so the in-app updater never finds anything on this branch.
  The script uses `check_for_gh_release` + `CLEAN_INSTALL=1 fetch_and_deploy_gh_release` instead.
- `/releases/latest` on `Whisparr/Whisparr-Eros` correctly resolves to the stable tag
  (`v3.3.7-release.979`) and skips the `-develop` prereleases, so no custom version logic is needed.
- **The asset pattern must not match `linux-musl-x64`.** Every release ships both, and the musl
  build fails on Debian with `cannot execute: required file not found`
  (`libc.musl-x86_64.so.1 => not found`). I verified the glob cannot match the musl variants rather
  than assuming it.
- Paths derive from the slug — `/opt/Whisparr-Eros`, `/var/lib/whisparr-eros`, unit
  `whisparr-eros`. This is deliberate: if V3 reused V2's `/var/lib/whisparr`, `update_script()`
  could be pointed at a V2 container and overwrite it with the eros build, which is the exact
  failure this script exists to prevent. Data lives outside `/opt`, so the update needs no
  backup/restore step.

**Testing** — installed and updated on a real Debian 13 unprivileged LXC via `build.func`:

- Install → `/api/v3/system/status` reports version `3.3.7.979`, **branch `eros`**; `whisparr3.db`
  created; binary confirmed glibc-linked; health clean.
- Update → seeded an older version file, got
  `Update available: whisparr-eros 3.3.6-release.934 → 3.3.7-release.979`, service restarted,
  `config.xml` and `whisparr3.db` byte-identical afterwards.
- Both guard branches exercised: "No update available" and "No Whisparr-Eros Installation Found!".

## 🔗 Related PR / Issue  

Link: #2072

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

> Per @asylumexp in #2072, `var_arm64="yes"` and `"has_arm": true` are set to **supported** in the
> script and JSON. The box above reflects only that I personally tested amd64 — the `linux-arm64`
> asset ships upstream and `arch_resolve` already selects it.

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [X] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**  
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [X] **No hardcoded credentials**  
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)  

`ct/headers/whisparr-eros` is not included, since `auto-update-app-headers.yml` generates it on merge.

One deliberate deviation from the sibling \*arr scripts: this one removes
`/opt/Whisparr-Eros/Whisparr.Update` after deploying, matching Servarr's own instructions for
installs that are not self-updating. Since the eros update channel is stale (above), the in-app
updater cannot reach anything anyway, and removing it keeps `~/.whisparr-eros` authoritative for
`check_for_gh_release`. Happy to drop that line if you would rather stay byte-for-byte consistent
with `radarr`/`sonarr`.

---

## 📦 Application Requirements

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [X] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [X] The application has **600+ GitHub stars**
- [X] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

> **Being explicit about the star box, so the tick cannot mislead anyone.** These checkboxes ask
> about the *application*: **Whisparr** has **~1,042 stars** and dates from 2022, and this is its V3
> train. The **`Whisparr-Eros` repo itself has ~44 stars**, because it was split out of the main
> repo on 2026-01-15 — that is six months of releases (232 of them), not six months of project
> history. @asylumexp agreed to an exception to the star rule for this in #2072; the automated check
> has no exception path, so I have ticked it and am stating the split here rather than leaving it
> silent. Please untick and close if that is not the call you intended.

## 🌐 Source

- V3 (this script): https://github.com/Whisparr/Whisparr-Eros — GPL-3.0, `eros` branch, 232 releases since 2026-01-15
- Application / V2: https://github.com/Whisparr/Whisparr
- Docs: https://wiki.servarr.com/whisparr
