### PR TITLE
Add Rommarr

### DIFF
--- a/ct/rommarr.sh
+++ b/ct/rommarr.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: BlizzHacker
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/BlizzHacker/rommarr
+
+APP="Rommarr"
+var_tags="${var_tags:-arr;emulation}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/rommarr ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "rommarr" "BlizzHacker/rommarr"; then
+    msg_info "Stopping Service"
+    systemctl stop rommarr
+    msg_ok "Stopped Service"
+
+    # The settings file holds the request history and the release profile, so
+    # it must survive an update -- it is the only state Rommarr keeps.
+    create_backup /opt/rommarr/.env
+    BACKUP_DIR=/opt/rommarr-data.backup create_backup /opt/rommarr/rommarr.json
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rommarr" "BlizzHacker/rommarr" "tarball" "latest" "/opt/rommarr"
+
+    msg_info "Updating ${APP}"
+    cd /opt/rommarr
+    $STD /opt/rommarr/.venv/bin/pip install --upgrade -r requirements.txt
+    msg_ok "Updated ${APP}"
+
+    msg_info "Starting Service"
+    systemctl start rommarr
+    msg_ok "Started Service"
+    msg_ok "Updated Successfully"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:7878${CL}"

--- a/install/rommarr-install.sh
+++ b/install/rommarr-install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: BlizzHacker
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/BlizzHacker/rommarr
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y python3-venv
+msg_ok "Installed Dependencies"
+
+fetch_and_deploy_gh_release "rommarr" "BlizzHacker/rommarr" "tarball" "latest" "/opt/rommarr"
+
+msg_info "Setting up Rommarr"
+cd /opt/rommarr
+$STD python3 -m venv .venv
+$STD /opt/rommarr/.venv/bin/pip install --upgrade pip
+$STD /opt/rommarr/.venv/bin/pip install -r requirements.txt
+
+# Rommarr talks to three services and stores nothing else. Every value here is
+# a placeholder on purpose: it starts and serves its UI with none of them
+# reachable, and the Settings pages say which are missing, so a first run is
+# never a blank failure.
+cat <<EOF >/opt/rommarr/.env
+PROWLARR_URL=http://192.168.1.100:9696
+PROWLARR_API_KEY=
+
+QBITTORRENT_URL=http://192.168.1.100:8080
+QBITTORRENT_USER=admin
+QBITTORRENT_PASS=
+
+ROMM_URL=http://192.168.1.100:8080
+ROMM_USERNAME=
+ROMM_PASSWORD=
+
+# Where imported ROMs are filed. This must be a path RomM also scans, or the
+# import succeeds and the game never appears.
+ROMM_LIBRARY=/mnt/roms
+ROMMARR_DATA=/opt/rommarr/rommarr.json
+ROMMARR_PORT=7878
+LOG_LEVEL=INFO
+EOF
+chmod 600 /opt/rommarr/.env
+mkdir -p /mnt/roms
+msg_ok "Set up Rommarr"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/rommarr.service
+[Unit]
+Description=Rommarr - the *arr for games
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/rommarr
+EnvironmentFile=/opt/rommarr/.env
+ExecStart=/opt/rommarr/.venv/bin/python -m rommarr
+Restart=on-failure
+RestartSec=10
+
+# It reads indexers and writes ROMs into one directory; nothing else on the
+# filesystem is any of its business.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/rommarr /mnt/roms
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now rommarr
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"

--- a/json/rommarr.json
+++ b/json/rommarr.json
@@ -1,0 +1,53 @@
+{
+  "name": "Rommarr",
+  "slug": "rommarr",
+  "categories": [
+    14
+  ],
+  "date_created": "2026-07-28",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 7878,
+  "documentation": "https://github.com/BlizzHacker/rommarr#readme",
+  "website": "https://github.com/BlizzHacker/rommarr",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/romm.webp",
+  "description": "Rommarr is the *arr for games. It watches for game requests, searches your indexers through Prowlarr, hands the winner to qBittorrent, SABnzbd or NZBGet depending on the release's protocol, picks the ROM out of the finished download and files it into RomM where it can be played. Release ranking is built for cartridges rather than video: it scores region and revision instead of bitrate, treats a large result as a warning rather than a preference, and rejects prototypes, hacks and cross-console mismatches.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/rommarr.sh",
+      "config_path": "/opt/rommarr/.env",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Edit /opt/rommarr/.env after install. Rommarr needs a Prowlarr URL and API key, at least one download client, and the path to RomM's library root. It starts and serves its UI with none of them reachable, and the Settings pages say which are missing.",
+      "type": "info"
+    },
+    {
+      "text": "A release is routed by its protocol, so an indexer type with no matching client cannot be grabbed at all. Configure qBittorrent for torrents, SABnzbd or NZBGet for usenet, or both. The Download Clients page names any protocol left uncovered.",
+      "type": "info"
+    },
+    {
+      "text": "ROMM_LIBRARY must be a path RomM also scans, and the download client's completed directory must be reachable from this container. If the client runs elsewhere, set a remote path mapping under Settings, otherwise imports fail with 'download path does not exist' while the file is sitting right there.",
+      "type": "warning"
+    },
+    {
+      "text": "Use a dedicated RomM account rather than your admin one. Rommarr only reads the library and triggers a rescan.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Rommarr — the *arr for games. It watches for game requests, searches indexers through Prowlarr, routes each release to a download client that speaks its protocol, picks the ROM out of the finished download, and files it into [RomM](https://github.com/rommapp/romm).

Repo: https://github.com/BlizzHacker/rommarr (MIT, 57 tests)

## Files

- `ct/rommarr.sh`
- `install/rommarr-install.sh`
- `json/rommarr.json`

## Resources

1 CPU / 512 MB / 4 GB, Debian 13, unprivileged, ARM64 supported. Web UI on port 7878.

It's stdlib-only Python — no web framework and no database. The only runtime dependency is `requests`, and state is a single JSON file, so it sits comfortably next to a download client on a small container.

## Notes

- Starts and serves its UI with nothing configured; the Settings pages report which dependencies are missing rather than failing blank.
- A release is routed by protocol, so an indexer type with no matching client can't be grabbed. The Download Clients page names any protocol left uncovered instead of silently refusing results.
- `create_backup` covers `.env` and the settings/history file on update, since that file is the only state it keeps.

## Testing

Installed and running on Debian 13 unprivileged. Verified end to end against a real Prowlarr, qBittorrent and RomM: search → grab → download → import → the ROM landed in the library with a verified file header, and the event recorded in history.

`bash -n` clean on both scripts; `json/rommarr.json` validates and follows the existing schema (category 14, *Arr Suite).

Happy to adjust anything that doesn't match house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)