### PR TITLE
feat: Valheim dedicated server + admin panel

### DIFF
--- a/ct/valheim.sh
+++ b/ct/valheim.sh
@@ -66,7 +66,7 @@ function update_script() {
     fetch_and_deploy_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox" "prebuild" "latest" "/opt/valheim/panel" "panel.tar.gz"
 
     msg_info "Updating Panel Dependencies"
-    $STD /opt/valheim/panel/.venv/bin/pip install --upgrade fastapi "uvicorn[standard]" pyyaml
+    $STD uv pip install --python /opt/valheim/panel/.venv/bin/python --upgrade fastapi "uvicorn[standard]" pyyaml
     msg_ok "Updated Panel Dependencies"
 
     msg_info "Starting Panel"

--- a/ct/valheim.sh
+++ b/ct/valheim.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: PawelSzymanski89
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/PawelSzymanski89/valheim-proxmox
+
+APP="Valheim"
+var_tags="${var_tags:-game;valheim}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-8192}"
+var_disk="${var_disk:-30}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/valheim ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  # Two things update independently: the game comes from Steam, the panel from GitHub.
+  msg_info "Checking Steam for a new game build"
+  APPID=896660
+  INSTALLED=$(awk -F'"' '/"buildid"/{print $4; exit}' /opt/valheim/server/steamapps/appmanifest_${APPID}.acf 2>/dev/null)
+  LATEST=$(runuser -u valheim -- env HOME=/opt/valheim /opt/valheim/steamcmd/steamcmd.sh \
+    +login anonymous +app_info_update 1 +app_info_print ${APPID} +quit 2>/dev/null |
+    sed -n '/"branches"/,/^}/p' | sed -n '/"public"/,/}/p' | grep -m1 '"buildid"' | grep -oE '[0-9]+')
+  if [[ -n "$LATEST" && "$INSTALLED" != "$LATEST" ]]; then
+    msg_ok "New build ${LATEST} available"
+    msg_info "Stopping ${APP}"
+    systemctl stop valheim
+    msg_ok "Stopped ${APP}"
+
+    msg_info "Updating game files (this pulls ~1.5 GB)"
+    $STD runuser -u valheim -- env HOME=/opt/valheim /opt/valheim/steamcmd/steamcmd.sh \
+      +force_install_dir /opt/valheim/server +login anonymous +app_update ${APPID} validate +quit
+    msg_ok "Updated game files"
+
+    msg_info "Starting ${APP}"
+    systemctl start valheim
+    msg_ok "Started ${APP}"
+  else
+    msg_ok "Game is up to date (build ${INSTALLED:-unknown})"
+  fi
+
+  if check_for_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox"; then
+    msg_info "Stopping Panel"
+    systemctl stop valheim-panel
+    msg_ok "Stopped Panel"
+
+    # panel.env holds the login and port, server.env the game settings - neither is shipped
+    create_backup /opt/valheim/panel.env /opt/valheim/server.env
+
+    fetch_and_deploy_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox" "prebuild" "latest" "/opt/valheim/panel" "panel.tar.gz"
+
+    msg_info "Updating Panel Dependencies"
+    $STD /opt/valheim/panel/.venv/bin/pip install --upgrade fastapi "uvicorn[standard]" pyyaml
+    msg_ok "Updated Panel Dependencies"
+
+    msg_info "Starting Panel"
+    systemctl start valheim-panel
+    msg_ok "Started Panel"
+    msg_ok "Updated Successfully"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access the panel using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:2460${CL}"
+echo -e "${INFO}${YW}Log in with admin / valheim123 and change it in Settings.${CL}"
+echo -e "${INFO}${YW}Players join at ${IP}:2456 - forward UDP 2456-2458 for internet access.${CL}"

--- a/install/valheim-install.sh
+++ b/install/valheim-install.sh
@@ -125,6 +125,8 @@ chown -R valheim:valheim /opt/valheim
 msg_ok "Configured Server"
 
 msg_info "Setting up Admin Panel"
+# "latest" on purpose: check_for_gh_release in ct/valheim.sh compares against the same
+# pointer, so an install and an update never disagree. Verified against v1.0.2.
 fetch_and_deploy_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox" "prebuild" "latest" "/opt/valheim/panel" "panel.tar.gz"
 $STD uv venv /opt/valheim/panel/.venv
 # a uv-created venv ships without pip, and ensurepip is not in it either - install through uv

--- a/install/valheim-install.sh
+++ b/install/valheim-install.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: PawelSzymanski89
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/PawelSzymanski89/valheim-proxmox
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD dpkg --add-architecture i386
+$STD apt update
+# libpulse-mainloop-glib0 is not optional: PlayFab Party (crossplay) fails to initialise
+# without it, the server loops on "begin PlayFab create and join network" and hands out an
+# empty join code.
+$STD apt install -y \
+  lib32gcc-s1 \
+  libsdl2-2.0-0:i386 \
+  libatomic1 \
+  libpulse0 \
+  libpulse-mainloop-glib0
+msg_ok "Installed Dependencies"
+
+setup_uv
+
+msg_info "Creating valheim User"
+$STD useradd -m -d /opt/valheim -s /bin/bash valheim
+mkdir -p /opt/valheim/{steamcmd,server,data/worlds_local,backups,panel}
+chown -R valheim:valheim /opt/valheim
+msg_ok "Created valheim User"
+
+msg_info "Setting up SteamCMD"
+$STD runuser -u valheim -- env HOME=/opt/valheim bash -c \
+  "cd /opt/valheim/steamcmd && curl -fsSL https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz | tar zxf -"
+# The first steamcmd run updates steamcmd itself and re-executes, dropping the rest of the
+# command line - the app_update then dies with "Missing configuration". So: warm it up first.
+$STD runuser -u valheim -- env HOME=/opt/valheim /opt/valheim/steamcmd/steamcmd.sh +login anonymous +quit || true
+msg_ok "Set up SteamCMD"
+
+msg_info "Downloading Valheim Server (~1.5 GB, this takes a while)"
+$STD runuser -u valheim -- env HOME=/opt/valheim /opt/valheim/steamcmd/steamcmd.sh \
+  +force_install_dir /opt/valheim/server +login anonymous +app_update 896660 validate +quit
+[[ -x /opt/valheim/server/valheim_server.x86_64 ]] || {
+  msg_error "Steam download failed"
+  exit 1
+}
+msg_ok "Downloaded Valheim Server"
+
+msg_info "Configuring Server"
+# Launch settings live here so the panel has something to edit; start.sh only assembles args.
+cat <<'EOF' >/opt/valheim/server.env
+NAME='Valheim'
+WORLD='Dedicated'
+PASSWORD='valheim123'
+PORT='2456'
+PUBLIC='0'
+CROSSPLAY='0'
+PRESET=''
+MODIFIERS=''
+SETKEYS=''
+EOF
+
+cat <<'EOF' >/opt/valheim/start.sh
+#!/bin/bash
+export LD_LIBRARY_PATH="/opt/valheim/server/linux64:$LD_LIBRARY_PATH"
+export SteamAppId=892970
+NAME=Valheim; WORLD=Dedicated; PASSWORD=; PORT=2456; PUBLIC=0; CROSSPLAY=0; PRESET=; MODIFIERS=; SETKEYS=
+[ -r /opt/valheim/server.env ] && . /opt/valheim/server.env
+cd /opt/valheim/server
+
+# BepInEx (installed by the panel on the first mod) is loaded by doorstop. These are the
+# Doorstop 4 names from the pack's own start_server_bepinex.sh; the older DOORSTOP_ENABLE
+# spelling is silently ignored and looks exactly like "mods do nothing".
+if [ -d /opt/valheim/server/BepInEx ]; then
+  export DOORSTOP_ENABLED=1
+  export DOORSTOP_TARGET_ASSEMBLY=./BepInEx/core/BepInEx.Preloader.dll
+  export LD_LIBRARY_PATH="./doorstop_libs:$LD_LIBRARY_PATH"
+  export LD_PRELOAD="libdoorstop_x64.so:$LD_PRELOAD"
+fi
+
+ARGS=(-nographics -batchmode -name "$NAME" -port "$PORT" -world "$WORLD" -savedir /opt/valheim/data -public "$PUBLIC")
+[ -n "$PASSWORD" ] && ARGS+=(-password "$PASSWORD")
+[ "$CROSSPLAY" = "1" ] && ARGS+=(-crossplay)
+[ -n "$PRESET" ] && ARGS+=(-preset "$PRESET")
+for m in $MODIFIERS; do ARGS+=(-modifier "${m%%:*}" "${m#*:}"); done
+for k in $SETKEYS; do ARGS+=(-setkey "$k"); done
+
+exec ./valheim_server.x86_64 "${ARGS[@]}"
+EOF
+
+cat <<'EOF' >/opt/valheim/backup.sh
+#!/bin/bash
+SRC=/opt/valheim/data/worlds_local; DST=/opt/valheim/backups
+[ -d "$SRC" ] || exit 0
+ts=$(date +%Y%m%d-%H%M%S)
+tar czf "$DST/world-$ts.tar.gz" -C "$SRC" . 2>/dev/null && echo "backup world-$ts.tar.gz"
+ls -1t "$DST"/world-*.tar.gz 2>/dev/null | tail -n +31 | xargs -r rm -f
+EOF
+
+cat <<'EOF' >/opt/valheim/panel-passwd.sh
+#!/bin/bash
+# Reset the panel login without the panel: /opt/valheim/panel-passwd.sh [user] <password>
+set -eu
+ENV=/opt/valheim/panel.env
+[ $# -ge 1 ] || { echo "usage: $0 [user] <password>"; exit 1; }
+if [ $# -ge 2 ]; then USER_=$1; PASS=$2; else USER_=$(grep -oP "PANEL_USER='\K[^']*" $ENV || echo admin); PASS=$1; fi
+[ ${#PASS} -ge 8 ] || { echo "password must be at least 8 characters"; exit 1; }
+PORT=$(grep -oP "PANEL_PORT='\K[^']*" $ENV 2>/dev/null || echo 2460)
+printf "PANEL_USER='%s'\nPANEL_PASS='%s'\nPANEL_PORT='%s'\n" "$USER_" "$PASS" "$PORT" >$ENV
+chmod 600 $ENV
+echo "panel login is now $USER_ / $PASS (no restart needed)"
+EOF
+
+for f in adminlist bannedlist permittedlist; do
+  echo "// one player id per line" >/opt/valheim/data/${f}.txt
+done
+chmod +x /opt/valheim/{start.sh,backup.sh,panel-passwd.sh}
+chown -R valheim:valheim /opt/valheim
+msg_ok "Configured Server"
+
+msg_info "Setting up Admin Panel"
+fetch_and_deploy_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox" "prebuild" "latest" "/opt/valheim/panel" "panel.tar.gz"
+$STD uv venv /opt/valheim/panel/.venv
+$STD /opt/valheim/panel/.venv/bin/python -m ensurepip
+$STD /opt/valheim/panel/.venv/bin/pip install fastapi "uvicorn[standard]" pyyaml
+# The starting password is the same on every install on purpose - the panel shows a red
+# banner until it is changed and refuses to have the default set back.
+cat <<'EOF' >/opt/valheim/panel.env
+PANEL_USER='admin'
+PANEL_PASS='valheim123'
+PANEL_PORT='2460'
+EOF
+chmod 600 /opt/valheim/panel.env
+msg_ok "Set up Admin Panel"
+
+msg_info "Creating Services"
+cat <<'EOF' >/etc/systemd/system/valheim.service
+[Unit]
+Description=Valheim dedicated server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=valheim
+ExecStart=/opt/valheim/start.sh
+Restart=on-failure
+RestartSec=8
+# SIGINT is what makes the server save the world before dying; SIGTERM loses it
+KillSignal=SIGINT
+TimeoutStopSec=90
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<'EOF' >/etc/systemd/system/valheim-panel.service
+[Unit]
+Description=Valheim admin panel
+After=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/opt/valheim/panel.env
+WorkingDirectory=/opt/valheim/panel
+ExecStart=/bin/sh -c '/opt/valheim/panel/.venv/bin/uvicorn app:app --host 0.0.0.0 --port ${PANEL_PORT}'
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<'EOF' >/etc/systemd/system/valheim-backup.service
+[Unit]
+Description=Valheim world backup
+
+[Service]
+Type=oneshot
+User=valheim
+ExecStart=/opt/valheim/backup.sh
+EOF
+
+cat <<'EOF' >/etc/systemd/system/valheim-backup.timer
+[Unit]
+Description=Valheim world backup every 2h
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=2h
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl enable -q --now valheim valheim-panel valheim-backup.timer
+msg_ok "Created Services"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/valheim-install.sh
+++ b/install/valheim-install.sh
@@ -127,8 +127,8 @@ msg_ok "Configured Server"
 msg_info "Setting up Admin Panel"
 fetch_and_deploy_gh_release "valheim-panel" "PawelSzymanski89/valheim-proxmox" "prebuild" "latest" "/opt/valheim/panel" "panel.tar.gz"
 $STD uv venv /opt/valheim/panel/.venv
-$STD /opt/valheim/panel/.venv/bin/python -m ensurepip
-$STD /opt/valheim/panel/.venv/bin/pip install fastapi "uvicorn[standard]" pyyaml
+# a uv-created venv ships without pip, and ensurepip is not in it either - install through uv
+$STD uv pip install --python /opt/valheim/panel/.venv/bin/python fastapi "uvicorn[standard]" pyyaml
 # The starting password is the same on every install on purpose - the panel shows a red
 # banner until it is changed and refuses to have the default set back.
 cat <<'EOF' >/opt/valheim/panel.env

--- a/json/valheim.json
+++ b/json/valheim.json
@@ -1,0 +1,53 @@
+{
+  "name": "Valheim",
+  "slug": "valheim",
+  "categories": [
+    24
+  ],
+  "date_created": "2026-07-31",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 2460,
+  "documentation": "https://github.com/PawelSzymanski89/valheim-proxmox#readme",
+  "website": "https://www.valheimgame.com/",
+  "logo": "https://cdn.cloudflare.steamstatic.com/steam/apps/892970/capsule_231x87.jpg",
+  "description": "Valheim dedicated server with a web admin panel. The panel shows who is online with a live session timer and keeps a login history that survives journal rotation, manages the admin/ban/allow lists, switches, uploads and downloads worlds, restores backups, and edits the launch settings (name, world, ports, crossplay, world preset and modifiers). Mods install from a Thunderstore Mod Manager share code, which pins every player to the same versions. World backups run every two hours, keeping 30.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/valheim.sh",
+      "config_path": "/opt/valheim/server.env",
+      "resources": {
+        "cpu": 4,
+        "ram": 8192,
+        "hdd": 30,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": "valheim123"
+  },
+  "notes": [
+    {
+      "text": "The panel password is the same on every install. It shows a red banner until you change it in Settings, and refuses to have the default set back. Locked out: `pct exec <CTID> -- /opt/valheim/panel-passwd.sh 'new-password'`.",
+      "type": "warning"
+    },
+    {
+      "text": "Keep the panel on the LAN or behind a VPN - it can delete worlds and hand out world downloads. Only the game needs to face the internet: forward UDP 2456-2458 to the container.",
+      "type": "warning"
+    },
+    {
+      "text": "Crossplay is off by default. With crossplay on the server never binds the game port at all and players join with a code instead, which makes a router forward meaningless - turn it on in Settings only if you want that mode.",
+      "type": "info"
+    },
+    {
+      "text": "The game download is ~1.5 GB from Steam, so the install takes a few minutes. Valheim caps at 10 players; 8 GB covers that comfortably and leaves room for mods.",
+      "type": "info"
+    }
+  ]
+}

--- a/json/valheim.json
+++ b/json/valheim.json
@@ -12,7 +12,7 @@
   "interface_port": 2460,
   "documentation": "https://github.com/PawelSzymanski89/valheim-proxmox#readme",
   "website": "https://www.valheimgame.com/",
-  "logo": "https://cdn.cloudflare.steamstatic.com/steam/apps/892970/capsule_231x87.jpg",
+  "logo": "https://cdn.jsdelivr.net/gh/PawelSzymanski89/valheim-proxmox@main/docs/icon.svg",
   "description": "Valheim dedicated server with a web admin panel. The panel shows who is online with a live session timer and keeps a login history that survives journal rotation, manages the admin/ban/allow lists, switches, uploads and downloads worlds, restores backups, and edits the launch settings (name, world, ports, crossplay, world preset and modifiers). Mods install from a Thunderstore Mod Manager share code, which pins every player to the same versions. World backups run every two hours, keeping 30.",
   "install_methods": [
     {


### PR DESCRIPTION
## ✍️ Description

Valheim dedicated server in an LXC, with a web admin panel for the things a server admin actually has to do. There is no Valheim script — and no game-server script at all — in the repo today.

Valheim has no RCON, so everything the panel does is server-side: the systemd unit, the launch arguments, the player lists, the worlds and the backups. In-game commands stay where they live, in the F5 console — the panel manages `adminlist.txt` so you can get there.

**Panel:** players online with a live session timer and a login history that survives journal rotation · admin/ban/allow lists · world switch, upload, download, delete · backup restore · launch settings (name, world, ports, crossplay, world preset and modifiers) · mods installed from a Thunderstore Mod Manager share code · log. Own login screen with a session cookie, HTTP Basic kept for scripts, English and Polish.

**Things found while building this that the script encodes:**

- **`libpulse-mainloop-glib0` is a hard dependency, not a nicety.** Without it PlayFab Party never initialises, the server loops on `begin PlayFab create and join network` every 30 s and hands out an empty join code — a server nobody can reach by any route. Diagnosed with `ldd libparty.so`; `libpulse0` alone is not enough.
- **steamcmd needs a warm-up run.** Its first launch updates itself and re-executes, dropping the rest of the command line; `app_update` then dies with `Missing configuration`. Hence the `+login anonymous +quit` before the real download.
- **`HOME` must be set for the `valheim` user.** `runuser -u` keeps root's `HOME` and steamcmd fails the same way.
- **Crossplay defaults to off.** With crossplay on the server never binds the game port at all — players join with a code and a router forward does nothing. Measured with `ss -uln` in both modes.
- Game update and panel update are separate: the game comes from Steam (build id comparison), the panel from a GitHub release. `update_script()` does both.

Tested on Proxmox VE 8.4 into a fresh `debian-13-standard` container through `install.func`. Clean run end to end: dependencies, uv, steamcmd, the ~1.5 GB game download, config, panel release deploy, services. The panel answered on `:2460`, the world generated, the game bound `:2456`, the backup timer was enabled. Mods were exercised against a real Thunderstore share code — BepInEx installed itself and the chainloader reported `Loading [Jotunn 2.24.3]`. One bug found and fixed during testing: a `uv`-created venv has neither `pip` nor `ensurepip`, so panel dependencies go in through `uv pip install --python`.

## 🔗 Related PR / Issue

Link: #2102 (closed by the bot — opened without this template, my mistake)

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [X] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [ ] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

> **On "No hardcoded credentials" — left unchecked deliberately.** The panel ships a fixed
> starting login (`admin` / `valheim123`), declared in `default_credentials` in the JSON. A
> generated password means digging through install output later; a fixed one is the same on
> every install. The panel shows a red banner until it is changed, refuses to have the
> default set back, and `panel-passwd.sh` resets it from the host. If the ORG prefers a
> generated password instead, say so and I will change it — I did not want to tick a box
> that is arguably false.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

**Agent disclosure, as the template asks:** these scripts were written by **Claude Opus 5 (1M context)**, running at **high reasoning effort**, in Claude Code, working from `AGENTS.md` in this repo. Everything here was installed and exercised on real hardware before submission, not just generated — the `libpulse-mainloop-glib0`, steamcmd warm-up, `HOME`, crossplay port and `uv`/`pip` findings above all came out of failed runs that were then fixed. The human author (@PawelSzymanski89) owns the upstream project and reviewed the submission.

---

## 📋 Additional Information (optional)

The upstream repo also carries the standalone installer this was ported from, the panel source, and screenshots: https://github.com/PawelSzymanski89/valheim-proxmox

---

## 📦 Application Requirements (for new scripts)

- [ ] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [X] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

**Two boxes left unchecked on purpose, because ticking them would be false.**

The packaged *game server* is Valheim (Iron Gate, released 2021, ~500k Steam reviews) — old and popular by any measure. But the repo this script installs from is **mine and it is new**: created this week, no stars yet. Read strictly against my repo, the 6-month and 600-star thresholds are not met, so I expect this to be closed automatically.

I am opening it anyway rather than waiting, for two reasons: the bot's own message says closed submissions are periodically reviewed and may be reopened if considered valuable, and there is currently no game-server script in the repo at all. If the thresholds are meant strictly, close it and I will resubmit when the repo has the age and the stars — no need to reply, and I will not ping about it.

## 🌐 Source

- Script + panel source: https://github.com/PawelSzymanski89/valheim-proxmox (MIT)
- Release the panel is deployed from: https://github.com/PawelSzymanski89/valheim-proxmox/releases/tag/v1.0.2
- Game: https://www.valheimgame.com/ · dedicated server appid 896660
