### PR TITLE
New script: PrismCast

### DIFF
--- a/ct/prismcast.sh
+++ b/ct/prismcast.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: subsistence
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/hjdhjd/prismcast
+
+APP="PrismCast"
+var_tags="${var_tags:-media;streaming;plex;hdhomerun}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-10}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+var_unprivileged="${var_unprivileged:-1}"
+var_gpu="${var_gpu:-yes}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/prismcast ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "prismcast" "hjdhjd/prismcast"; then
+    msg_info "Stopping Service"
+    systemctl stop prismcast
+    msg_ok "Stopped Service"
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "prismcast" "hjdhjd/prismcast" "tarball"
+
+    msg_info "Building PrismCast"
+    cd /opt/prismcast
+    export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    $STD npm ci
+    $STD npm run build
+    msg_ok "Built PrismCast"
+
+    msg_info "Starting Service"
+    systemctl start prismcast
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}PrismCast tuner (add manually in Plex as ${IP}:5004):${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:5004/discover.json${CL}"
+echo -e "${INFO}${YW}PrismCast web interface:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:5589${CL}"
+echo -e "${INFO}${YW}Chrome direct VNC:${CL}"
+echo -e "${GATEWAY}${BGN}vnc://${IP}:5900${CL}"
+echo -e "${INFO}${YW}Chrome noVNC (recommended):${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:6080/vnc.html${CL}"

--- a/install/prismcast-install.sh
+++ b/install/prismcast-install.sh
@@ -75,18 +75,29 @@ $STD apt install -y \
   xdg-utils
 msg_ok "Installed Chrome Dependencies"
 
+msg_info "Adding Google Chrome APT Repository"
+setup_deb822_repo "google-chrome" "https://dl.google.com/linux/linux_signing_key.pub" "http://dl.google.com/linux/chrome/deb/" "stable" "main" "amd64"
+msg_ok "Added Google Chrome APT Repository"
+
 msg_info "Installing Google Chrome"
-curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-$STD apt install -y /tmp/google-chrome.deb
-rm -f /tmp/google-chrome.deb
+$STD apt install -y google-chrome-stable
 msg_ok "Installed Google Chrome"
 
 msg_info "Creating Chrome Sandbox Wrapper"
-cat <<'EOF' >/usr/local/bin/chrome-no-sandbox
+# --use-gl=angle --use-angle=gl-egl gets Chrome real GPU-backed rendering via direct EGL/GBM access to
+# the DRM device, bypassing the fact that stock Debian's Xvfb has no DRI3 device backing of its own.
+# The spoofed --user-agent is load-bearing, not cosmetic: Xfinity Stream's guide page checks the client
+# OS and hard-blocks Linux ("Update your browser to start streaming"/"unsupported operating system"),
+# which otherwise makes every channel fail with "guide page did not load within timeout" regardless of
+# login state. Since every Docker/LXC deployment of this app runs on Linux, without this override the
+# Xfinity integration - the app's primary use case - does not work at all.
+CHROME_VERSION=$(google-chrome-stable --version | grep -oP '[\d.]+' | head -1)
+cat <<EOF >/usr/local/bin/chrome-no-sandbox
 #!/bin/bash
-exec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-gpu-sandbox \
-  --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks \
-  --ignore-gpu-blocklist "$@"
+exec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-gpu-sandbox \\
+  --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks \\
+  --ignore-gpu-blocklist --use-gl=angle --use-angle=gl-egl \\
+  --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${CHROME_VERSION} Safari/537.36" "\$@"
 EOF
 chmod +x /usr/local/bin/chrome-no-sandbox
 msg_ok "Created Chrome Sandbox Wrapper"

--- a/install/prismcast-install.sh
+++ b/install/prismcast-install.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: subsistence
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/hjdhjd/prismcast
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+setup_hwaccel
+
+# Installed before the apt packages below: Debian's "novnc" package depends on
+# Debian's own nodejs, and installing nodesource's Node.js afterward replaces
+# that package, which apt then removes as an orphaned dependency - taking novnc
+# down with it. Installing Node.js first means novnc's dependency is already
+# satisfied by the nodesource package and nothing gets removed later.
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Installing Xvfb/VNC Dependencies"
+$STD apt install -y \
+  xvfb \
+  x11vnc \
+  x11-xkb-utils \
+  xfonts-100dpi \
+  xfonts-75dpi \
+  xfonts-scalable \
+  x11-apps \
+  xauth \
+  novnc \
+  websockify \
+  fonts-liberation
+msg_ok "Installed Xvfb/VNC Dependencies"
+
+msg_info "Installing Chrome Dependencies"
+$STD apt install -y \
+  libasound2t64 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libcairo2 \
+  libcups2 \
+  libdbus-1-3 \
+  libdrm2 \
+  libexpat1 \
+  libfontconfig1 \
+  libgbm1 \
+  libgdk-pixbuf-2.0-0 \
+  libglib2.0-0 \
+  libgtk-3-0 \
+  libnspr4 \
+  libnss3 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libstdc++6 \
+  libx11-6 \
+  libx11-xcb1 \
+  libxcb1 \
+  libxcomposite1 \
+  libxcursor1 \
+  libxdamage1 \
+  libxext6 \
+  libxfixes3 \
+  libxi6 \
+  libxkbcommon0 \
+  libxrandr2 \
+  libxrender1 \
+  libxss1 \
+  libxtst6 \
+  lsb-release \
+  xdg-utils
+msg_ok "Installed Chrome Dependencies"
+
+msg_info "Installing Google Chrome"
+curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+$STD apt install -y /tmp/google-chrome.deb
+rm -f /tmp/google-chrome.deb
+msg_ok "Installed Google Chrome"
+
+msg_info "Creating Chrome Sandbox Wrapper"
+cat <<'EOF' >/usr/local/bin/chrome-no-sandbox
+#!/bin/bash
+exec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-gpu-sandbox \
+  --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoEncoder,VaapiIgnoreDriverChecks \
+  --ignore-gpu-blocklist "$@"
+EOF
+chmod +x /usr/local/bin/chrome-no-sandbox
+msg_ok "Created Chrome Sandbox Wrapper"
+
+fetch_and_deploy_gh_release "prismcast" "hjdhjd/prismcast" "tarball"
+
+msg_info "Building PrismCast"
+cd /opt/prismcast
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+$STD npm ci
+$STD npm run build
+mkdir -p /opt/prismcast_data
+msg_ok "Built PrismCast"
+
+msg_info "Creating Services"
+cat <<EOF >/etc/systemd/system/xvfb.service
+[Unit]
+Description=Virtual Framebuffer X Server for PrismCast
+After=network.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sh -c 'rm -f /tmp/.X99-lock'
+ExecStart=/usr/bin/Xvfb :99 -screen 0 1920x1080x24 -dpi 96 +extension COMPOSITE +extension DAMAGE +extension GLX +extension RANDR +extension RENDER +extension MIT-SHM +extension XFIXES +extension XTEST -nolisten tcp -ac -noreset
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/x11vnc.service
+[Unit]
+Description=x11vnc Server for PrismCast
+After=xvfb.service
+Requires=xvfb.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -nopw -rfbport 5900 -quiet
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/novnc.service
+[Unit]
+Description=noVNC WebSocket Proxy for PrismCast
+After=x11vnc.service
+Requires=x11vnc.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/websockify --web=/usr/share/novnc 6080 localhost:5900
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/prismcast.service
+[Unit]
+Description=PrismCast
+After=network-online.target xvfb.service
+Wants=network-online.target
+Requires=xvfb.service
+
+[Service]
+Type=simple
+User=root
+Environment=DISPLAY=:99
+Environment=CHROME_BIN=/usr/local/bin/chrome-no-sandbox
+Environment=PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+Environment=PRISMCAST_DATA_DIR=/opt/prismcast_data
+WorkingDirectory=/opt/prismcast
+ExecStart=/usr/bin/node /opt/prismcast/dist/index.js
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+msg_ok "Created Services"
+
+msg_info "Starting Services"
+systemctl enable -q --now xvfb
+sleep 2
+systemctl enable -q --now x11vnc
+sleep 1
+systemctl enable -q --now novnc
+sleep 1
+systemctl enable -q --now prismcast
+msg_ok "Started Services"
+
+motd_ssh
+cat <<'EOF' >/etc/profile.d/01-prismcast-urls.sh
+_pc_ip=$(ip -4 route get 1 2>/dev/null | sed -n 's/.* src \([0-9.]\+\).*/\1/p' | head -1)
+echo " PrismCast tuner (add manually in Plex as ${_pc_ip}:5004): http://${_pc_ip}:5004/discover.json"
+echo " PrismCast web interface: http://${_pc_ip}:5589"
+echo " Chrome direct VNC: vnc://${_pc_ip}:5900"
+echo " Chrome noVNC (recommended): http://${_pc_ip}:6080/vnc.html"
+echo ""
+unset _pc_ip
+EOF
+chmod +x /etc/profile.d/01-prismcast-urls.sh
+customize
+cleanup_lxc

--- a/json/prismcast.json
+++ b/json/prismcast.json
@@ -1,0 +1,54 @@
+{
+  "name": "PrismCast",
+  "slug": "prismcast",
+  "categories": [
+    13
+  ],
+  "date_created": "2026-08-02",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": false,
+  "interface_port": 5589,
+  "documentation": "https://github.com/hjdhjd/prismcast",
+  "website": "https://github.com/hjdhjd/prismcast",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/google-chrome.webp",
+  "config_path": "/opt/prismcast_data/config.json",
+  "description": "PrismCast uses Google Chrome to navigate to browser-based streaming sites, captures the video output, and serves it as HLS streams. It emulates an HDHomeRun tuner on the network, letting Plex or Channels DVR discover it as a Live TV source without any physical tuner hardware.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/prismcast.sh",
+      "config_path": "/opt/prismcast_data/config.json",
+      "resources": {
+        "cpu": 4,
+        "ram": 4096,
+        "hdd": 10,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Requires Google Chrome (not Chromium) and has no ARM64 support, since Google does not publish an arm64 Chrome package for Linux.",
+      "type": "warning"
+    },
+    {
+      "text": "On first use, open noVNC at http://<IP>:6080/vnc.html to log in to your streaming provider inside the container's browser session. The session persists in the Chrome profile afterward.",
+      "type": "info"
+    },
+    {
+      "text": "Add the tuner to Plex or Channels DVR using <IP>:5004 (HDHomeRun emulation port).",
+      "type": "info"
+    },
+    {
+      "text": "GPU passthrough is offered at container creation (Advanced install) and, when a device is passed through, hardware VAAPI decode/encode drivers are installed automatically and enabled in Chrome. The virtual display itself still composites in software (stock Debian Xvfb has no DRI3 device backing), so the heaviest cost - video decode - is accelerated, but on-screen compositing is not. Without GPU passthrough, everything runs in software and multiple concurrent streams may require increasing the allocated CPU.",
+      "type": "info"
+    }
+  ]
+}

--- a/json/prismcast.json
+++ b/json/prismcast.json
@@ -47,8 +47,12 @@
       "type": "info"
     },
     {
-      "text": "GPU passthrough is offered at container creation (Advanced install) and, when a device is passed through, hardware VAAPI decode/encode drivers are installed automatically and enabled in Chrome. The virtual display itself still composites in software (stock Debian Xvfb has no DRI3 device backing), so the heaviest cost - video decode - is accelerated, but on-screen compositing is not. Without GPU passthrough, everything runs in software and multiple concurrent streams may require increasing the allocated CPU.",
+      "text": "GPU passthrough is offered at container creation (Advanced install); when a device is passed through, VAAPI decode/encode drivers are installed automatically and Chrome is launched with --use-gl=angle --use-angle=gl-egl, which gets real GPU-backed rendering via direct EGL/GBM access to the DRM device even though stock Debian's Xvfb has no DRI3 support of its own. Without GPU passthrough, everything runs in software and multiple concurrent streams may require increasing the allocated CPU.",
       "type": "info"
+    },
+    {
+      "text": "Chrome is launched with a spoofed Windows User-Agent. Xfinity Stream's guide page checks the client OS and blocks Linux outright (\"Update your browser to start streaming\"), which breaks every channel with a guide-load timeout regardless of login state - this affects any Linux-hosted deployment (Docker or LXC), not just this script. Without the override, the Xfinity integration does not work at all.",
+      "type": "warning"
     }
   ]
 }


### PR DESCRIPTION
## ✍️ Description
Adds a bare-metal LXC install for [PrismCast](https://github.com/hjdhjd/prismcast), a browser-based live TV capture server that emulates an HDHomeRun tuner so Plex/Channels DVR can use browser-only streaming sites (e.g. Xfinity Stream) as a Live TV source. Installs Xvfb + x11vnc + noVNC + Google Chrome (Chrome, not Chromium, per upstream's own requirement) directly via systemd services, builds PrismCast from its GitHub release tarball, and offers optional GPU passthrough (`var_gpu=yes` + `setup_hwaccel`, same pattern as `seanime`).

Two fixes worth calling out since they weren't obvious going in:
- Persistent data lives in `/opt/prismcast_data`, not `/opt/prismcast` - the framework's own GitHub-release version-tracking file is written to `~/.prismcast`, which is identical to PrismCast's *default* data directory of the same name. Left as-is, `update_script`'s `CLEAN_INSTALL` re-fetch would collide with it.
- Chrome is launched with `--use-gl=angle --use-angle=gl-egl` (real GPU-backed rendering via direct EGL/GBM access, since stock Debian's Xvfb has no DRI3 device backing) and a spoofed Windows User-Agent. Without the UA override, Xfinity Stream's guide page hard-blocks Linux clients outright ("Update your browser to start streaming") - this affects any Linux-hosted deployment of this app (Docker or LXC), not just this script, and without it the app's primary use case doesn't work at all.

Note on my previous attempt at this: I opened #2105 with a custom PR description instead of this template and it was auto-closed - resubmitting with the same work, correct template this time.

## 🔗 Related PR / Issue
Link: #2105 (closed - wrong template, same underlying change)

## ✅ Prerequisites
- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support

- [ ] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [x] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

Google does not publish an arm64 Chrome package for Linux, and PrismCast requires Chrome (not Chromium).

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**

---

## 🔍 Code & Security Review

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`.

---

## 🤖 AI Assistance

- [ ] **No AI used**
- [x] **AI was used** – I confirm the scripts were built using `AGENTS.md` and `.github/agents/pve-script-creator.agent.md` as guidance, and the output has been reviewed and corrected to match those guidelines.

Built with Claude (Sonnet 5, standard/default reasoning effort), with review and live end-to-end testing against a real Proxmox VE 9.1.4 host by me throughout.

---

## 📋 Additional Information (optional)
Tested end-to-end on a real Proxmox VE 9.1.4 host, unprivileged LXC, Debian 13, with Intel GPU passthrough auto-configured:
- Container creation and full install complete without errors, including a clean re-run from scratch
- All four services (`xvfb`, `x11vnc`, `novnc`, `prismcast`) active and enabled after install
- Web UI responds (`GET /health` → `"status":"healthy"`, `"browser":{"connected":true}`), noVNC responds, HDHomeRun `discover.json`/`lineup.json` responds correctly and was verified against Plex's manual tuner setup
- Confirmed via direct X11 screenshots (`xwd`) that without the Chrome flags described above, Xfinity Stream redirects to `xfinity.com/stream/upgrade` and blocks all channels; with them, Chrome reports real GPU-backed rendering and the actual channel guide loads (358 channels found in one real account's lineup)
- `update_script` reviewed against `check_for_gh_release`/`fetch_and_deploy_gh_release` conventions

## 🌐 Source
https://github.com/hjdhjd/prismcast