### PR TITLE
feat: add NetWatcher community script

### DIFF
--- a/ct/netwatcher.sh
+++ b/ct/netwatcher.sh
@@ -34,7 +34,7 @@ function update_script() {
     exit
   fi
 
-  local new_tag new_ver old_target old_ver release_dir stamp backup_dir
+  local new_ver old_target old_ver release_dir stamp backup_dir
   new_ver="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
   [[ -n "$new_ver" ]] || {
     msg_error "Could not resolve latest NetWatcher release"

--- a/ct/netwatcher.sh
+++ b/ct/netwatcher.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: andrewtryder
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/andrewtryder/unifi-netwatcher
+
+APP="NetWatcher"
+var_tags="${var_tags:-network;unifi;monitoring;security}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-1024}"
+var_disk="${var_disk:-6}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /etc/netwatcher/netwatcher.env ]] || [[ ! -f /etc/systemd/system/netwatcher.service ]] || [[ ! -L /opt/netwatcher/current ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if ! check_for_gh_release "netwatcher" "andrewtryder/unifi-netwatcher"; then
+    exit
+  fi
+
+  local new_tag new_ver old_target old_ver release_dir stamp backup_dir
+  new_tag="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
+  [[ -n "$new_tag" ]] || {
+    msg_error "Could not resolve latest NetWatcher release"
+    exit 1
+  }
+  new_ver="${new_tag#v}"
+  old_target="$(readlink -f /opt/netwatcher/current)"
+  old_ver="$(basename "$old_target")"
+
+  if [[ "$old_ver" == "$new_ver" ]]; then
+    msg_ok "Already up to date ($new_ver)"
+    exit
+  fi
+
+  release_dir="/opt/netwatcher/releases/${new_ver}"
+  if [[ -d "$release_dir" ]]; then
+    msg_info "Removing incomplete release directory ${release_dir}"
+    rm -rf "$release_dir"
+  fi
+
+  fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "$new_tag" "$release_dir"
+
+  if [[ ! -f "${release_dir}/app/web/static/app.css" ]] || [[ ! -f "${release_dir}/app/web/static/js/htmx.min.js" ]]; then
+    msg_error "Release ${new_ver} is missing built static assets (app.css / htmx.min.js)"
+    rm -rf "$release_dir"
+    exit 1
+  fi
+
+  msg_info "Installing Python dependencies (${new_ver})"
+  cd "$release_dir" || exit 1
+  $STD uv sync --frozen --no-dev
+  chown -R root:root "$release_dir"
+  find "$release_dir" -type d -exec chmod 755 {} +
+  find "$release_dir" -type f -exec chmod 644 {} +
+  chmod -R a+x "${release_dir}/.venv/bin"
+  $STD "${release_dir}/.venv/bin/python" -c "import uvicorn, alembic, app.main"
+  msg_ok "Installed Python dependencies"
+
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  backup_dir="/var/lib/netwatcher/backups/${stamp}"
+  msg_info "Creating pre-update backup"
+  install -d -m 0700 -o netwatcher -g netwatcher /var/lib/netwatcher/backups
+  install -d -m 0700 -o root -g root "$backup_dir"
+  cp -a /etc/netwatcher/netwatcher.env "$backup_dir/netwatcher.env"
+  if [[ -f /var/lib/netwatcher/netwatcher.db ]]; then
+    cp -a /var/lib/netwatcher/netwatcher.db "$backup_dir/netwatcher.db"
+    shopt -s nullglob
+    for wal in /var/lib/netwatcher/netwatcher.db-*; do
+      cp -a "$wal" "$backup_dir/"
+    done
+    shopt -u nullglob
+  fi
+  if [[ -f /var/lib/netwatcher/app-secret.key ]]; then
+    install -m 0600 -o root -g root /var/lib/netwatcher/app-secret.key "$backup_dir/app-secret.key"
+  fi
+  printf '%s\n' "$old_target" >"$backup_dir/previous-release"
+  chmod -R go-rwx "$backup_dir"
+  msg_ok "Created backup at ${backup_dir}"
+
+  msg_info "Stopping Service"
+  systemctl stop netwatcher
+  msg_ok "Stopped Service"
+
+  rollback_update() {
+    msg_error "Update failed — rolling back to ${old_ver}"
+    systemctl stop netwatcher >/dev/null 2>&1 || true
+    if [[ -f "$backup_dir/netwatcher.db" ]]; then
+      cp -a "$backup_dir/netwatcher.db" /var/lib/netwatcher/netwatcher.db
+      chown netwatcher:netwatcher /var/lib/netwatcher/netwatcher.db
+      chmod 0600 /var/lib/netwatcher/netwatcher.db
+      shopt -s nullglob
+      for wal in /var/lib/netwatcher/netwatcher.db-*; do
+        rm -f "$wal"
+      done
+      for wal in "$backup_dir"/netwatcher.db-*; do
+        cp -a "$wal" /var/lib/netwatcher/
+        chown netwatcher:netwatcher "/var/lib/netwatcher/$(basename "$wal")"
+        chmod 0600 "/var/lib/netwatcher/$(basename "$wal")"
+      done
+      shopt -u nullglob
+    fi
+    if [[ -f "$backup_dir/app-secret.key" ]]; then
+      install -m 0600 -o netwatcher -g netwatcher "$backup_dir/app-secret.key" /var/lib/netwatcher/app-secret.key
+    fi
+    if [[ -f "$backup_dir/netwatcher.env" ]]; then
+      install -m 0640 -o root -g netwatcher "$backup_dir/netwatcher.env" /etc/netwatcher/netwatcher.env
+    fi
+    ln -sfn "$old_target" /opt/netwatcher/current
+    systemctl start netwatcher
+    for _ in $(seq 1 60); do
+      if curl -fsS http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+        msg_ok "Rolled back to ${old_ver} and /readyz is healthy"
+        return 0
+      fi
+      sleep 1
+    done
+    msg_error "Rollback started ${old_ver} but /readyz did not become healthy"
+    return 1
+  }
+
+  msg_info "Running database migrations"
+  set -a
+  # shellcheck source=/dev/null
+  source /etc/netwatcher/netwatcher.env
+  set +a
+  if ! (
+    cd "$release_dir" || exit 1
+    runuser -u netwatcher --preserve-environment -- \
+      "${release_dir}/.venv/bin/alembic" upgrade head
+  ); then
+    rollback_update
+    exit 1
+  fi
+  msg_ok "Ran database migrations"
+
+  msg_info "Activating release ${new_ver}"
+  ln -sfn "$release_dir" /opt/netwatcher/current
+  msg_ok "Activated ${new_ver}"
+
+  msg_info "Starting Service"
+  systemctl start netwatcher
+  local ready=0
+  for _ in $(seq 1 60); do
+    if curl -fsS http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$ready" -ne 1 ]]; then
+    rollback_update
+    exit 1
+  fi
+  msg_ok "Started Service (/readyz OK)"
+
+  # Retain previous release for rollback; prune older ones (keep newest 2 dirs + current).
+  msg_info "Pruning obsolete releases and backups"
+  local keep_dirs=("$release_dir" "$old_target")
+  shopt -s nullglob
+  for d in /opt/netwatcher/releases/*; do
+    local keep=0
+    for k in "${keep_dirs[@]}"; do
+      [[ "$(readlink -f "$d")" == "$(readlink -f "$k")" ]] && keep=1 && break
+    done
+    if [[ "$keep" -eq 0 ]]; then
+      rm -rf "$d"
+    fi
+  done
+  mapfile -t backup_list < <(ls -1dt /var/lib/netwatcher/backups/* 2>/dev/null || true)
+  if ((${#backup_list[@]} > 3)); then
+    for ((i = 3; i < ${#backup_list[@]}; i++)); do
+      rm -rf "${backup_list[$i]}"
+    done
+  fi
+  shopt -u nullglob
+  msg_ok "Pruned obsolete releases/backups"
+
+  msg_ok "Updated successfully to ${new_ver}!"
+  echo -e "${INFO}${YW}Previous release retained at:${CL} ${old_target}"
+  echo -e "${INFO}${YW}Backup retained at:${CL} ${backup_dir}"
+  echo -e "${INFO}${YW}Database and app-secret.key must be restored together.${CL}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}NetWatcher URL:${CL} ${GATEWAY}${BGN}http://${IP}:8080${CL}"
+echo -e "${INFO}${YW}Bootstrap login:${CL} ${BGN}admin / admin${CL}"
+echo -e "${INFO}${YW}Change the bootstrap password immediately via Security.${CL}"
+echo -e "${INFO}${YW}Configuration:${CL} ${BGN}/etc/netwatcher/netwatcher.env${CL}"
+echo -e "${INFO}${YW}Data:${CL} ${BGN}/var/lib/netwatcher${CL}"
+echo -e "${INFO}${YW}Service:${CL} ${BGN}systemctl status netwatcher${CL}"
+echo -e "${INFO}${YW}Logs:${CL} ${BGN}journalctl -u netwatcher -f${CL}"
+echo -e "${INFO}${YW}NetWatcher starts in UniFi mock mode. Configure UniFi settings, set UNIFI_MOCK_MODE=false, then:${CL}"
+echo -e "${GATEWAY}${BGN}systemctl restart netwatcher${CL}"
+echo -e "${INFO}${YW}Trusted hosts: private/loopback IP literals work initially. Add DNS names under Security → Trusted Hosts.${CL}"
+echo -e "${INFO}${YW}Intended for LAN use. Prefer an HTTPS reverse proxy for higher-security environments.${CL}"

--- a/ct/netwatcher.sh
+++ b/ct/netwatcher.sh
@@ -35,12 +35,11 @@ function update_script() {
   fi
 
   local new_tag new_ver old_target old_ver release_dir stamp backup_dir
-  new_tag="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
-  [[ -n "$new_tag" ]] || {
+  new_ver="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
+  [[ -n "$new_ver" ]] || {
     msg_error "Could not resolve latest NetWatcher release"
     exit 1
   }
-  new_ver="${new_tag#v}"
   old_target="$(readlink -f /opt/netwatcher/current)"
   old_ver="$(basename "$old_target")"
 
@@ -55,7 +54,8 @@ function update_script() {
     rm -rf "$release_dir"
   fi
 
-  fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "$new_tag" "$release_dir"
+  # Use "latest" so GitHub resolves the real tag name (e.g. v0.3.0).
+  fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "latest" "$release_dir"
 
   if [[ ! -f "${release_dir}/app/web/static/app.css" ]] || [[ ! -f "${release_dir}/app/web/static/js/htmx.min.js" ]]; then
     msg_error "Release ${new_ver} is missing built static assets (app.css / htmx.min.js)"

--- a/docs/netwatcher.md
+++ b/docs/netwatcher.md
@@ -1,0 +1,82 @@
+# NetWatcher (Proxmox Community Script)
+
+Native Debian LXC installer for [NetWatcher](https://github.com/andrewtryder/unifi-netwatcher) (UniFi unknown-device monitor).
+
+## Install (after merge to ProxmoxVED)
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/ct/netwatcher.sh)"
+```
+
+Final intended command after acceptance into Community Scripts:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/netwatcher.sh)"
+```
+
+## Defaults
+
+| Setting | Value |
+|---|---|
+| OS | Debian 13 |
+| CPU | 2 |
+| RAM | 1024 MiB |
+| Disk | 6 GiB |
+| Privilege | Unprivileged |
+| Architectures | AMD64, ARM64 |
+| Port | 8080 |
+
+## Layout
+
+```text
+/opt/netwatcher/current -> /opt/netwatcher/releases/<version>
+/etc/netwatcher/netwatcher.env
+/var/lib/netwatcher/{netwatcher.db,app-secret.key,backups/}
+```
+
+Service user: `netwatcher` (non-login). Application source is root-owned; only `/var/lib/netwatcher` is writable by the service.
+
+## First boot
+
+1. Open `http://<container-ip>:8080`
+2. Sign in with `admin` / `admin` and change the password immediately
+3. Edit `/etc/netwatcher/netwatcher.env` with UniFi URL/credentials
+4. Set `UNIFI_MOCK_MODE=false`
+5. `systemctl restart netwatcher`
+
+`APP_SECRET_KEY` is left empty so NetWatcher generates `/var/lib/netwatcher/app-secret.key` on first start.
+
+## Updates
+
+Re-run the Community Script **inside** the NetWatcher LXC. The updater:
+
+- Downloads the latest stable release into a new versioned directory
+- Installs locked dependencies with `uv sync --frozen --no-dev`
+- Backs up env + DB + key under `/var/lib/netwatcher/backups/<timestamp>/`
+- Runs Alembic migrations
+- Atomically switches `/opt/netwatcher/current`
+- Polls `/readyz` and rolls back on failure
+
+Never overwrite env/DB/key except during explicit rollback restore. Always restore the database and `app-secret.key` together.
+
+## Operations
+
+```bash
+systemctl status netwatcher
+journalctl -u netwatcher -f
+systemctl restart netwatcher
+```
+
+## Security notes
+
+- Trusted-host checks are enabled; LAN IP-literal access works initially
+- Add DNS names under **Security → Trusted Hosts**
+- Prefer an HTTPS reverse proxy; do not expose to the public internet
+- HTTP Basic credentials are not encrypted on plain HTTP
+- `MemoryDenyWriteExecute` is omitted because Python C extensions (cryptography / argon2) need executable mappings
+
+## Known limitations / eligibility
+
+- NetWatcher GitHub stars may be below the Community Scripts new-app threshold for upstream `ProxmoxVE` acceptance; this lives in **ProxmoxVED** for testing first
+- Releases use GitHub source tarballs; built static assets (`app.css`, `js/`, `fonts/`) must remain committed in the tagged release (no Node build inside the LXC)
+- No checksum assets are published yet; downloads fail closed on incomplete archives and missing static files

--- a/install/netwatcher-install.sh
+++ b/install/netwatcher-install.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: andrewtryder
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/andrewtryder/unifi-netwatcher
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  sqlite3 \
+  tzdata
+msg_ok "Installed Dependencies"
+
+PYTHON_VERSION="3.14" setup_uv
+
+msg_info "Creating NetWatcher user and directories"
+if ! getent group netwatcher >/dev/null; then
+  groupadd --system netwatcher
+fi
+if ! id -u netwatcher >/dev/null 2>&1; then
+  useradd --system --gid netwatcher --home-dir /var/lib/netwatcher \
+    --shell /usr/sbin/nologin --create-home netwatcher
+fi
+install -d -m 0755 -o root -g root /opt/netwatcher
+install -d -m 0755 -o root -g root /opt/netwatcher/releases
+install -d -m 0750 -o root -g netwatcher /etc/netwatcher
+install -d -m 0700 -o netwatcher -g netwatcher /var/lib/netwatcher
+install -d -m 0700 -o netwatcher -g netwatcher /var/lib/netwatcher/backups
+msg_ok "Created NetWatcher user and directories"
+
+RELEASE_TAG="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
+[[ -n "$RELEASE_TAG" ]] || {
+  msg_error "Could not resolve latest NetWatcher release from GitHub"
+  exit 1
+}
+RELEASE_VER="${RELEASE_TAG#v}"
+RELEASE_DIR="/opt/netwatcher/releases/${RELEASE_VER}"
+
+fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "$RELEASE_TAG" "$RELEASE_DIR"
+
+msg_info "Validating release assets"
+if [[ ! -f "${RELEASE_DIR}/app/web/static/app.css" ]]; then
+  msg_error "Missing built static asset: app/web/static/app.css"
+  exit 1
+fi
+if [[ ! -f "${RELEASE_DIR}/app/web/static/js/htmx.min.js" ]]; then
+  msg_error "Missing built static asset: app/web/static/js/htmx.min.js"
+  exit 1
+fi
+if [[ ! -d "${RELEASE_DIR}/app/web/static/fonts" ]]; then
+  msg_error "Missing built static fonts directory"
+  exit 1
+fi
+if [[ ! -f "${RELEASE_DIR}/uv.lock" ]] || [[ ! -f "${RELEASE_DIR}/alembic.ini" ]]; then
+  msg_error "Release is missing uv.lock or alembic.ini"
+  exit 1
+fi
+msg_ok "Validated release assets"
+
+msg_info "Installing Python environment (uv sync --frozen)"
+cd "$RELEASE_DIR" || exit 1
+$STD uv sync --frozen --no-dev
+chown -R root:root "$RELEASE_DIR"
+chmod -R a+rX "$RELEASE_DIR"
+# Keep the venv usable by the service user for execution (dirs need traverse)
+find "$RELEASE_DIR" -type d -exec chmod 755 {} +
+find "$RELEASE_DIR" -type f -exec chmod 644 {} +
+chmod -R a+x "${RELEASE_DIR}/.venv/bin"
+$STD "${RELEASE_DIR}/.venv/bin/python" -c "import uvicorn, alembic, app.main"
+ln -sfn "$RELEASE_DIR" /opt/netwatcher/current
+msg_ok "Installed Python environment"
+
+msg_info "Writing configuration"
+cat <<EOF >/etc/netwatcher/netwatcher.env
+APP_ENV=production
+APP_SECRET_KEY=
+APP_SECRET_KEY_PATH=/var/lib/netwatcher/app-secret.key
+
+DATABASE_URL=sqlite:////var/lib/netwatcher/netwatcher.db
+
+UNIFI_URL=https://unifi.example.local
+UNIFI_USERNAME=netwatcher
+UNIFI_PASSWORD=change-me
+UNIFI_SITE=default
+UNIFI_VERIFY_SSL=true
+UNIFI_TIMEOUT_SECONDS=10
+UNIFI_MOCK_MODE=true
+UNIFI_DRY_RUN_BLOCKS=true
+
+SCAN_INTERVAL_SECONDS=300
+ALERT_COOLDOWN_SECONDS=21600
+OBSERVATION_RETENTION_DAYS=30
+EVENT_RETENTION_DAYS=90
+
+SECURITY_RECOVERY_BYPASS=false
+EOF
+chown root:netwatcher /etc/netwatcher/netwatcher.env
+chmod 0640 /etc/netwatcher/netwatcher.env
+msg_ok "Wrote configuration"
+
+msg_info "Running database migrations"
+set -a
+# shellcheck source=/dev/null
+source /etc/netwatcher/netwatcher.env
+set +a
+cd /opt/netwatcher/current || exit 1
+runuser -u netwatcher --preserve-environment -- \
+  /opt/netwatcher/current/.venv/bin/alembic upgrade head
+# Ensure DB files are private to the service user
+if [[ -f /var/lib/netwatcher/netwatcher.db ]]; then
+  chown netwatcher:netwatcher /var/lib/netwatcher/netwatcher.db
+  chmod 0600 /var/lib/netwatcher/netwatcher.db
+fi
+msg_ok "Ran database migrations"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/netwatcher.service
+[Unit]
+Description=NetWatcher for UniFi
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=netwatcher
+Group=netwatcher
+WorkingDirectory=/opt/netwatcher/current
+EnvironmentFile=/etc/netwatcher/netwatcher.env
+Environment=PATH=/opt/netwatcher/current/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+ExecStart=/opt/netwatcher/current/.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers 1
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=120
+TimeoutStopSec=30
+UMask=0077
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+LockPersonality=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=/var/lib/netwatcher
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target
+EOF
+# MemoryDenyWriteExecute is intentionally omitted: Python C extensions
+# (cryptography / argon2-cffi) require executable mappings.
+systemctl enable -q --now netwatcher
+msg_ok "Created Service"
+
+msg_info "Waiting for /readyz"
+READY=0
+for _ in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$READY" -ne 1 ]]; then
+  msg_error "NetWatcher did not become ready on http://127.0.0.1:8080/readyz"
+  journalctl -u netwatcher -n 50 --no-pager || true
+  exit 1
+fi
+# Key file is generated on first start when APP_SECRET_KEY is empty
+if [[ -f /var/lib/netwatcher/app-secret.key ]]; then
+  chown netwatcher:netwatcher /var/lib/netwatcher/app-secret.key
+  chmod 0600 /var/lib/netwatcher/app-secret.key
+fi
+msg_ok "NetWatcher is ready"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/netwatcher-install.sh
+++ b/install/netwatcher-install.sh
@@ -36,15 +36,15 @@ install -d -m 0700 -o netwatcher -g netwatcher /var/lib/netwatcher
 install -d -m 0700 -o netwatcher -g netwatcher /var/lib/netwatcher/backups
 msg_ok "Created NetWatcher user and directories"
 
-RELEASE_TAG="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
-[[ -n "$RELEASE_TAG" ]] || {
+RELEASE_VER="$(get_latest_github_release "andrewtryder/unifi-netwatcher")"
+[[ -n "$RELEASE_VER" ]] || {
   msg_error "Could not resolve latest NetWatcher release from GitHub"
   exit 1
 }
-RELEASE_VER="${RELEASE_TAG#v}"
 RELEASE_DIR="/opt/netwatcher/releases/${RELEASE_VER}"
 
-fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "$RELEASE_TAG" "$RELEASE_DIR"
+# Use "latest" so the helper resolves the real GitHub tag (e.g. v0.3.0).
+fetch_and_deploy_gh_release "netwatcher" "andrewtryder/unifi-netwatcher" "tarball" "latest" "$RELEASE_DIR"
 
 msg_info "Validating release assets"
 if [[ ! -f "${RELEASE_DIR}/app/web/static/app.css" ]]; then

--- a/json/netwatcher.json
+++ b/json/netwatcher.json
@@ -1,0 +1,64 @@
+{
+  "name": "NetWatcher",
+  "slug": "netwatcher",
+  "categories": [
+    4,
+    6,
+    9
+  ],
+  "date_created": "2026-08-05",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 8080,
+  "documentation": "https://github.com/andrewtryder/unifi-netwatcher/blob/main/README.md",
+  "website": "https://github.com/andrewtryder/unifi-netwatcher",
+  "logo": "https://raw.githubusercontent.com/andrewtryder/unifi-netwatcher/main/docs/assets/netwatcher-logo.svg",
+  "config_path": "/etc/netwatcher/netwatcher.env",
+  "description": "NetWatcher monitors UniFi Network for unknown devices, stores history in SQLite, and sends pluggable alerts. Native Debian LXC install with uv-managed Python 3.14, systemd hardening, and safe in-place upgrades.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/netwatcher.sh",
+      "config_path": "/etc/netwatcher/netwatcher.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 1024,
+        "hdd": 6,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": "admin"
+  },
+  "notes": [
+    {
+      "text": "Change the bootstrap Web UI password (admin/admin) immediately under Security after first login.",
+      "type": "warning"
+    },
+    {
+      "text": "NetWatcher starts in UniFi mock mode. Edit /etc/netwatcher/netwatcher.env with your UniFi URL and dedicated account, set UNIFI_MOCK_MODE=false, then run: systemctl restart netwatcher",
+      "type": "info"
+    },
+    {
+      "text": "Persistent data lives in /var/lib/netwatcher (SQLite DB + app-secret.key). Configuration is /etc/netwatcher/netwatcher.env. Always back up the database and app-secret.key together — restoring only the DB without the matching key makes encrypted notification settings unreadable.",
+      "type": "warning"
+    },
+    {
+      "text": "Trusted-host checks are enabled by default. Access via http://<container-ip>:8080 initially (private/loopback IP literals). Add DNS names under Security → Trusted Hosts. Prefer an HTTPS reverse proxy; do not expose NetWatcher directly to the public internet.",
+      "type": "info"
+    },
+    {
+      "text": "Update by re-running the Community Script inside the LXC. Updates preserve configuration, database, and encryption key, and roll back automatically on failure.",
+      "type": "info"
+    },
+    {
+      "text": "Logs: journalctl -u netwatcher -f — Status: systemctl status netwatcher",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Debian LXC install/update scripts for [UniFi NetWatcher](https://github.com/andrewtryder/unifi-netwatcher) (native `uv` + Python, no Docker)
- Register app metadata (`json/netwatcher.json`) and operator docs (`docs/netwatcher.md`)
- Release layout: `/opt/netwatcher/releases/<ver>` + `current` symlink; config in `/etc/netwatcher`; data in `/var/lib/netwatcher`; systemd on port 8080

## Notes
- Targets ProxmoxVED for community testing (app is young / low stars)
- `fetch_and_deploy_gh_release` uses tag `"latest"` so the real GitHub release tag (e.g. `v0.3.0`) is used for the tarball URL
- `MemoryDenyWriteExecute` omitted due to cryptography/argon2 native deps

## Test plan
- [ ] Create CT via menu / `ct/netwatcher.sh` on a Proxmox host
- [ ] Confirm install reaches UI on `:8080` and `/readyz` succeeds
- [ ] Confirm update path backs up env/data and rolls forward cleanly
- [ ] Confirm rollback on failed update restores previous release


Made with [Cursor](https://cursor.com)