### PR TITLE
Add xyOps LXC script

### DIFF
--- a/ct/xyops.sh
+++ b/ct/xyops.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: audricrosier
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://xyops.io/ | Docs: https://docs.xyops.io/
+
+APP="xyOps"
+var_tags="${var_tags:-workflow-automation;task-scheduler;monitoring}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; never verified on arm64
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/xyops ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  NODE_VERSION="24" setup_nodejs
+
+  if check_for_gh_release "xyops" "pixlcore/xyops"; then
+    msg_info "Stopping xyOps"
+    systemctl stop xyops
+    msg_ok "Stopped xyOps"
+
+    create_backup /opt/xyops/.env /opt/xyops/conf /opt/xyops/data
+
+    fetch_and_deploy_gh_release "xyops" "pixlcore/xyops" "tarball"
+
+    restore_backup
+
+    msg_info "Building xyOps"
+    cd /opt/xyops
+    $STD npm install
+    $STD node bin/build.js dist
+    msg_ok "Built xyOps"
+
+    msg_info "Starting xyOps"
+    systemctl start xyops
+    msg_ok "Started xyOps"
+
+    if [[ -d /opt/xyops/satellite ]]; then
+      msg_info "Restarting Local xySat Worker"
+      systemctl restart xysat
+      msg_ok "Restarted Local xySat Worker"
+    fi
+
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:5522${CL}"
+echo -e "${INFO}${YW}Default login (change on first sign-in):${CL} ${BGN}admin / admin${CL}"

--- a/ct/xyops.sh
+++ b/ct/xyops.sh
@@ -37,9 +37,9 @@ function update_script() {
     systemctl stop xyops
     msg_ok "Stopped xyOps"
 
-    create_backup /opt/xyops/.env /opt/xyops/conf /opt/xyops/data
+    create_backup /opt/xyops/.env /opt/xyops/conf /opt/xyops/data /opt/xyops/satellite
 
-    fetch_and_deploy_gh_release "xyops" "pixlcore/xyops" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "xyops" "pixlcore/xyops" "tarball"
 
     restore_backup
 

--- a/install/xyops-install.sh
+++ b/install/xyops-install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: audricrosier
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://xyops.io/ | Docs: https://docs.xyops.io/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y build-essential python3-setuptools
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="24" setup_nodejs
+fetch_and_deploy_gh_release "xyops" "pixlcore/xyops" "tarball"
+
+msg_info "Building xyOps"
+cd /opt/xyops
+$STD npm install
+$STD node bin/build.js dist
+msg_ok "Built xyOps"
+
+msg_info "Configuring xyOps"
+cat <<EOF >/opt/xyops/.env
+XYOPS_hostname=${LOCAL_IP}
+XYOPS_masters=${LOCAL_IP}
+XYOPS_base_app_url=http://${LOCAL_IP}:5522
+TZ=$(cat /etc/timezone 2>/dev/null || echo "UTC")
+EOF
+
+cat <<EOF >/etc/systemd/system/xyops.service
+[Unit]
+Description=xyOps Conductor
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/xyops
+EnvironmentFile=/opt/xyops/.env
+ExecStart=/usr/bin/node --max-old-space-size=4096 /opt/xyops/lib/main.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now xyops
+msg_ok "Configured xyOps"
+
+msg_info "Waiting for xyOps to become ready"
+for _ in $(seq 1 30); do
+  curl -fsS "http://127.0.0.1:5522/api/app/ping" >/dev/null 2>&1 && break
+  sleep 2
+done
+msg_ok "xyOps is ready"
+
+msg_info "Installing Local xySat Worker"
+# xyOps only bundles a satellite/worker with its Docker image; a bare-metal
+# install has to add one via the same API the "Add Server" UI button calls.
+# The conductor's default admin/admin login is only valid until the first
+# real browser sign-in (force_password_change is set), so this has to run
+# now rather than being left as a manual post-install step.
+LOGIN_RESP=$(curl -fsS -c /tmp/xyops_cookies.txt -X POST "http://127.0.0.1:5522/api/user/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"admin"}')
+CSRF_TOKEN=$(echo "$LOGIN_RESP" | grep -o '"csrf_token":"[^"]*"' | cut -d'"' -f4)
+
+# The API rejects the session cookie alone with {"code":"session"} - it also
+# requires the CSRF token from the login response as an explicit header.
+SAT_RESP=$(curl -fsS -b /tmp/xyops_cookies.txt -X POST "http://127.0.0.1:5522/api/app/get_satellite_token" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: ${CSRF_TOKEN}" \
+  -d "{\"title\":\"${HN}-local\",\"enabled\":true,\"icon\":\"\",\"groups\":[]}")
+SAT_TOKEN=$(echo "$SAT_RESP" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+
+curl -fsS "http://127.0.0.1:5522/api/app/satellite/install?t=${SAT_TOKEN}" | $STD sh
+rm -f /tmp/xyops_cookies.txt
+
+# xyOps only looks for a satellite at boot; it wasn't there for the first
+# start above, so restart once now that /opt/xyops/satellite exists.
+systemctl restart xyops
+msg_ok "Installed Local xySat Worker"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/xyops.json
+++ b/json/xyops.json
@@ -13,7 +13,6 @@
   "documentation": "https://docs.xyops.io/",
   "website": "https://xyops.io/",
   "repository": "https://github.com/pixlcore/xyops",
-  "architectures": ["amd64"],
   "platforms": ["pve"],
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/xyops.webp",
   "description": "xyOps is a next-generation workflow automation system with job scheduling, server monitoring, alerting, and ticketing all built in. It is the spiritual successor to Cronicle, by the same author. This script installs the conductor (web UI, API, scheduler) plus a local xySat worker so jobs can run immediately after install.",

--- a/json/xyops.json
+++ b/json/xyops.json
@@ -1,0 +1,52 @@
+{
+  "name": "xyOps",
+  "slug": "xyops",
+  "categories": [
+    19,
+    9
+  ],
+  "date_created": "2026-08-08",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 5522,
+  "documentation": "https://docs.xyops.io/",
+  "website": "https://xyops.io/",
+  "repository": "https://github.com/pixlcore/xyops",
+  "architectures": ["amd64"],
+  "platforms": ["pve"],
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/xyops.webp",
+  "description": "xyOps is a next-generation workflow automation system with job scheduling, server monitoring, alerting, and ticketing all built in. It is the spiritual successor to Cronicle, by the same author. This script installs the conductor (web UI, API, scheduler) plus a local xySat worker so jobs can run immediately after install.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/xyops.sh",
+      "config_path": "/opt/xyops/conf/config.json",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": "admin"
+  },
+  "notes": [
+    {
+      "text": "Change the default admin/admin password on first login - the account is otherwise wide open until you do.",
+      "type": "warning"
+    },
+    {
+      "text": "A local xySat worker is installed and registered automatically, so the container can run jobs on itself immediately. Add remote workers from the UI under Servers > Add Server the same way.",
+      "type": "info"
+    },
+    {
+      "text": "By default the conductor identifies itself by its LAN IP (XYOPS_hostname/XYOPS_masters/XYOPS_base_app_url in /opt/xyops/.env). Change these to a stable hostname before adding remote workers or putting this behind a reverse proxy - see https://docs.xyops.io/#Docs/hosting/quick-start.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.**

## ✍️ Description

Adds `ct/xyops.sh` + `install/xyops-install.sh` + `json/xyops.json` for [xyOps](https://xyops.io/) ([docs](https://docs.xyops.io/)) — the spiritual successor to Cronicle (same author, PixlCore): workflow automation with job scheduling, server monitoring, alerting, and ticketing built in. No community-scripts install existed for it yet.

Bare-metal install via `fetch_and_deploy_gh_release`, matching upstream's own `bin/install.js` steps exactly (tarball extract → `npm install` → `node bin/build.js dist`). Also bootstraps a local xySat worker through the same API the "Add Server" UI button uses, since xyOps only bundles a worker inside its Docker image — a bare-metal install otherwise comes up with zero runners attached.

`update_script()` uses `CLEAN_INSTALL=1` paired with `create_backup`/`restore_backup` over `.env`, `conf`, `data`, and `satellite` (the local worker install), since xyOps' config/data/satellite directories live inside `/opt/xyops` and can't be relocated via a documented env var.

Written with Claude (Sonnet 5, extended reasoning), using `AGENTS.md` and `.github/agents/pve-script-creator.agent.md` as the primary guidance, cross-checked line-by-line against `install/termix-install.sh` as a real accepted example. Reviewed and corrected against both docs' checklists before submitting (see Prerequisites/Code & Security Review below).

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials** – `admin`/`admin` is upstream's own documented default (declared in `default_credentials` in the JSON, with a warning note to change it), not a value invented by this script.
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`.

---

## 🤖 AI Assistance

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

Manually provisioned a real Debian 13 LXC and ran through every install step by hand (Node 24 via `setup_nodejs`, release fetch, `npm install`, `node bin/build.js dist`, systemd unit, local xySat bootstrap) before writing the final scripts, rather than writing them blind from docs alone. Verified:
- Conductor HTTP 200 on `/`, `GET /api/app/ping` → `{"code":0}`.
- Local xySat worker registers with the conductor within seconds of install (confirmed via the authenticated `servers` list in the API).
- `shellcheck` clean on both scripts (aside from the same `SC1090`/`SC1091` dynamic-source notes and `cd`-without-`|| exit` warnings present throughout the rest of this repo, e.g. `install/termix-install.sh`).

Not yet run through the actual `ct/xyops.sh` / `build.func` container-creation flow end-to-end (validated the underlying install steps directly against a manually-created LXC rather than via the interactive script runner) — flagging this explicitly in case a maintainer wants to re-verify via the normal flow before merge.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

- [x] The application is **at least 6 months old** (repo created 2025-12-29, ~7.4 months old)
- [x] The application is **actively maintained** (last push 2026-08-06, 2 days before this PR)
- [x] The application has **600+ GitHub stars** (4,754 stars at time of writing)
- [x] Official **release tarballs** are published (standard GitHub auto-generated source tarballs per release, e.g. v1.0.88)
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- Website: https://xyops.io/
- Docs: https://docs.xyops.io/
- Repository: https://github.com/pixlcore/xyops
- Latest release used for testing: v1.0.88
