### PR TITLE
feat: add bookshelf

### DIFF
--- a/ct/bookshelf.sh
+++ b/ct/bookshelf.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: savagecore
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/pennydreadful/bookshelf
+
+APP="Bookshelf"
+var_tags="${var_tags:-media;eBook}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/bookshelf ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+  cd /opt/bookshelf-src
+  $STD git fetch -q
+  RELEASE=$(git log -1 --format=%h origin/develop)
+  if [[ ! -f /opt/Bookshelf_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/Bookshelf_version.txt)" ]]; then
+    msg_info "Stopping ${APP}"
+    systemctl stop bookshelf
+    msg_ok "Stopped ${APP}"
+
+    create_backup /var/lib/bookshelf
+
+    msg_info "Updating ${APP} to ${RELEASE}"
+    git reset --hard origin/develop
+    $STD ./build.sh --backend --frontend --packages -f net6.0 -r linux-x64
+    rm -rf /opt/bookshelf/bin
+    mkdir -p /opt/bookshelf/bin
+    $STD cp -r _artifacts/linux-x64/net6.0/Readarr/* /opt/bookshelf/bin/
+    chmod +x /opt/bookshelf/bin/Readarr
+    rm -rf _output _artifacts _tests
+    msg_ok "Updated ${APP} to ${RELEASE}"
+
+    restore_backup
+
+    msg_info "Starting ${APP}"
+    systemctl start bookshelf
+    msg_ok "Started ${APP}"
+
+    echo "${RELEASE}" >/opt/Bookshelf_version.txt
+    msg_ok "Update Successful"
+  else
+    msg_ok "No update required. ${APP} is already up to date."
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8787${CL}"

--- a/frontend/public/json/bookshelf.json
+++ b/frontend/public/json/bookshelf.json
@@ -1,0 +1,35 @@
+{
+    "name": "Bookshelf",
+    "slug": "bookshelf",
+    "categories": [
+        14
+    ],
+    "date_created": "2026-08-09",
+    "type": "ct",
+    "updateable": true,
+    "privileged": false,
+    "interface_port": 8787,
+    "documentation": "https://github.com/pennydreadful/bookshelf/blob/develop/README.md",
+    "config_path": "/var/lib/bookshelf",
+    "website": "https://github.com/pennydreadful/bookshelf",
+    "logo": null,
+    "description": "Bookshelf is a revival of Readarr - an ebook and audiobook collection manager for Usenet and BitTorrent users. It monitors RSS feeds for new books from your favorite authors and will grab, sort, and rename them. This LXC builds Bookshelf from source and is configured with the Hardcover metadata provider.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/bookshelf.sh",
+            "resources": {
+                "cpu": 2,
+                "ram": 4096,
+                "hdd": 8,
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": null,
+        "password": null
+    },
+    "notes": []
+}

--- a/install/bookshelf-install.sh
+++ b/install/bookshelf-install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: savagecore
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/pennydreadful/bookshelf
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc \
+  git \
+  jq \
+  xmlstarlet \
+  ca-certificates \
+  libsqlite3-0
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up Microsoft .NET repository"
+setup_deb822_repo \
+  "microsoft" \
+  "https://packages.microsoft.com/keys/microsoft-2025.asc" \
+  "https://packages.microsoft.com/debian/12/prod/" \
+  "bookworm" \
+  "main"
+$STD apt-get install -y dotnet-sdk-6.0
+msg_ok "Installed .NET SDK 6.0"
+
+NODE_VERSION="20" NODE_MODULE="yarn" setup_nodejs
+
+msg_info "Setup ${APP}"
+$STD git clone --branch develop --depth 1 https://github.com/pennydreadful/bookshelf.git /opt/bookshelf-src
+cd /opt/bookshelf-src
+export READARRVERSION="0.4.20.0"
+$STD ./build.sh --backend --frontend --packages -f net6.0 -r linux-x64
+mkdir -p /opt/bookshelf/bin
+$STD cp -r _artifacts/linux-x64/net6.0/Readarr/* /opt/bookshelf/bin/
+chmod +x /opt/bookshelf/bin/Readarr
+mkdir -p /var/lib/bookshelf
+chmod 775 /var/lib/bookshelf
+RELEASE=$(git log -1 --format=%h origin/develop)
+cat <<EOF >/opt/bookshelf/package_info
+UpdateMethod=External
+Branch=develop
+PackageVersion=${RELEASE}
+PackageAuthor=community-scripts
+EOF
+echo "${RELEASE}" >/opt/Bookshelf_version.txt
+rm -rf /opt/bookshelf-src/_output /opt/bookshelf-src/_artifacts /opt/bookshelf-src/_tests
+msg_ok "Setup ${APP}"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/bookshelf.service
+[Unit]
+Description=Bookshelf Daemon
+After=syslog.target network.target
+
+[Service]
+UMask=0002
+Type=simple
+Environment=METADATA_URL=https://hardcover.bookinfo.pro
+Environment=HARDCOVER=true
+WorkingDirectory=/opt/bookshelf/bin
+ExecStart=/opt/bookshelf/bin/Readarr -nobrowser -data=/var/lib/bookshelf
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now bookshelf
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## Bookshelf (Readarr revival) - bare-metal source build

Builds [Bookshelf](https://github.com/pennydreadful/bookshelf) (a revival of Readarr) from source on Debian 12 with the **Hardcover** metadata provider (`METADATA_URL=https://hardcover.bookinfo.pro`, `HARDCOVER=true` set as systemd `Environment=`). Successfully built and tested on a PVE node (container reachable at http://192.168.50.107:8787).

### Notes

- **Debian 12 + `dotnet-sdk-6.0` (bookworm):** Bookshelf targets `net6.0` exactly. The .NET 6.0 SDK is only available in Microsoft's *bookworm* apt repo (not trixie), so staying on Debian 12 with `apt install dotnet-sdk-6.0` is the closest match to the upstream target framework and was verified working in the test build. .NET 6 is EOL upstream but is the framework Bookshelf itself targets.
- **`update_script` uses git-hash not `check_for_gh_release`:** Bookshelf has zero GitHub releases (https://api.github.com/repos/pennydreadful/bookshelf/releases/latest returns 404; releases page is empty). A `check_for_gh_release` call would fail; `update_script` therefore compares the `develop` branch HEAD hash against `/opt/Bookshelf_version.txt` and rebuilds from source when changed. Flagged for reviewer awareness as a documented-undealt exception.
- Install script uses repo helpers: `setup_deb822_repo` (Microsoft repo) + `apt install dotnet-sdk-6.0`, `NODE_VERSION="20" NODE_MODULE="yarn" setup_nodejs`, and `create_backup`/`restore_backup` around the update build path. Runs as root per repo convention.

### Heads-up - pre-existing `main` bugs (NOT addressed here)

This PR touches `frontend/**` (it adds `frontend/public/json/bookshelf.json`), which triggers `frontend-cicd` -> `validate-json.test.ts` iterating over every json file. Two json files on `main` already fail the schema and will make this PR's frontend CI red regardless of `bookshelf.json` being correct:

- `frontend/public/json/piler.json` (commit a3ba39b9) - missing the schema-required `config_path` field (required since 79fd16a3, 2025-04-23).
- `frontend/public/json/nextexplorer.json` - also fails the schema.

`bookshelf.json` itself passes both schema tests. Recommend a separate maintainer PR to add `config_path` to `piler.json` / `nextexplorer.json`; deliberately left untouched here to keep this PR single-concern.