### PR TITLE
feat: add Slidev community script

### DIFF
--- a/ct/slidev.sh
+++ b/ct/slidev.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/shared/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/shared/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Filan-glitch
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://sli.dev/
+
+APP="Slidev"
+var_tags="${var_tags:-presentation;markdown}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /home/slidev/my-slides ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  su - slidev -c "cd my-slides && npm install"
+  systemctl restart slidev
+  msg_ok "Updated ${APP}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3030${CL}"
+echo -e "${INFO}${YW}MCP server entrypoint (run over SSH from your client):${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}ssh slidev@${IP} /home/slidev/mcp-start.sh${CL}"

--- a/install/slidev-install.sh
+++ b/install/slidev-install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Filan-glitch
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://sli.dev/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  git \
+  build-essential
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Creating slidev user"
+useradd -m -s /bin/bash slidev
+if [[ -s /root/.ssh/authorized_keys ]]; then
+  mkdir -p /home/slidev/.ssh
+  cp /root/.ssh/authorized_keys /home/slidev/.ssh/authorized_keys
+  chmod 700 /home/slidev/.ssh
+  chmod 600 /home/slidev/.ssh/authorized_keys
+  chown -R slidev:slidev /home/slidev/.ssh
+fi
+SLIDEV_SSH_PASS="$(openssl rand -base64 18)"
+echo "slidev:${SLIDEV_SSH_PASS}" | chpasswd
+msg_ok "Created slidev user"
+
+msg_info "Scaffolding Slidev project"
+su - slidev -c "CI=1 npx --yes create-slidev@latest my-slides --template=default --theme=default -y" </dev/null
+msg_ok "Scaffolded Slidev project"
+
+msg_info "Installing npm dependencies"
+su - slidev -c "cd my-slides && npm install" </dev/null
+msg_ok "Installed npm dependencies"
+
+msg_info "Creating service"
+NODE_BIN_DIR=$(su - slidev -c 'dirname "$(which node)"')
+cat <<EOF >/etc/systemd/system/slidev.service
+[Unit]
+Description=Slidev Presentation Server
+After=network.target
+
+[Service]
+Type=simple
+User=slidev
+WorkingDirectory=/home/slidev/my-slides
+Environment=PATH=${NODE_BIN_DIR}:/usr/bin:/bin
+ExecStart=${NODE_BIN_DIR}/npm run dev -- --remote --port 3030
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now slidev
+msg_ok "Created service"
+
+msg_info "Installing Slidev MCP server helper"
+su - slidev -c "cd my-slides && npm install -D @slidev/cli@latest" </dev/null
+cat <<'EOF' >/home/slidev/mcp-start.sh
+#!/usr/bin/env bash
+cd /home/slidev/my-slides
+exec npx slidev mcp --entry slides.md
+EOF
+chmod +x /home/slidev/mcp-start.sh
+chown slidev:slidev /home/slidev/mcp-start.sh
+msg_ok "Installed Slidev MCP server helper"
+
+motd_ssh
+customize
+
+msg_ok "SSH login for slidev user: slidev / ${SLIDEV_SSH_PASS}"
+cleanup_lxc

--- a/json/slidev.json
+++ b/json/slidev.json
@@ -1,0 +1,44 @@
+{
+  "name": "Slidev",
+  "slug": "slidev",
+  "categories": [12],
+  "date_created": "2026-08-10",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "architectures": ["amd64"],
+  "interface_port": 3030,
+  "documentation": "https://sli.dev/",
+  "website": "https://sli.dev/",
+  "repository": "https://github.com/slidevjs/slidev",
+  "logo": "https://sli.dev/favicon.png",
+  "description": "Slidev is a markdown-based slide deck maker and presenter, built for developers. Self-hosted instance runs a live dev server with hot reload, plus an MCP server entrypoint so AI agents (Claude Code/Desktop) can edit slides directly.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/slidev.sh",
+      "config_path": "/home/slidev/my-slides/slides.md",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "slidev",
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Dev server binds 0.0.0.0:3030, no auth built in — restrict to LAN/firewall.",
+      "type": "warning"
+    },
+    {
+      "text": "MCP server entrypoint at /home/slidev/mcp-start.sh, invoke over SSH from client-side Claude Code config.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds [Slidev](https://sli.dev) as a new community script — a markdown-based slide deck maker with a live dev server, and an SSH-reachable MCP entrypoint so an AI agent (Claude Code/Desktop) can edit the deck directly.

- `ct/slidev.sh`
- `install/slidev-install.sh`
- `json/slidev.json`

## Why the dedicated `slidev` user

The install creates a non-root `slidev` system user rather than running as root. This is intentional, not an oversight: the MCP entrypoint (`ssh slidev@<ip> /home/slidev/mcp-start.sh`) needs an SSH-reachable account, and the Slidev dev server itself has no built-in auth — running it as an unprivileged user limits blast radius given it binds `0.0.0.0:3030`. The user is provisioned with the container's root `authorized_keys` (when present) plus a random fallback password shown once during install.

## Testing

Tested end-to-end on Proxmox VE 9.2.9, Debian 13 LXC:
- Fresh install (default and advanced settings)
- `update_script` path
- systemd service comes up, dev server reachable on `:3030`
- MCP entrypoint over SSH, verified against a real client (added as an MCP server, used it to build and edit an actual multi-slide deck — including LaTeX, Mermaid, code-highlight, and animation features — confirming the round trip works, not just that the process starts)

## Notes

- Ran into an unrelated upstream `community-scripts/core` regression while testing (`_dev_step_start: command not found`, exit 127) — filed separately: community-scripts/core#3. Not caused by and doesn't affect this script.
