### PR TITLE
feat: add WRP (Web Rendering Proxy) LXC script

### DIFF
--- a/ct/wrp.sh
+++ b/ct/wrp.sh
@@ -35,14 +35,7 @@ function update_script() {
     systemctl stop wrp
     msg_ok "Stopped Service"
 
-    local wrp_asset
-    case "$(dpkg --print-architecture)" in
-      amd64) wrp_asset="wrp-amd64-linux" ;;
-      arm64) wrp_asset="wrp-arm64-linux" ;;
-      armhf) wrp_asset="wrp-arm-linux" ;;
-      *) msg_error "Unsupported architecture: $(dpkg --print-architecture)"; exit ;;
-    esac
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$wrp_asset"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$(arch_resolve "wrp-amd64-linux" "wrp-arm64-linux")"
 
     msg_info "Starting Service"
     systemctl start wrp

--- a/ct/wrp.sh
+++ b/ct/wrp.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../misc/build.func" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_URL:-https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main}/misc/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: N0t4R0b0t
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/tenox7/wrp
+
+APP="WRP"
+var_tags="${var_tags:-proxy;network;browser}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /opt/wrp/wrp ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "wrp" "tenox7/wrp"; then
+    msg_info "Stopping Service"
+    systemctl stop wrp
+    msg_ok "Stopped Service"
+
+    local wrp_asset
+    case "$(dpkg --print-architecture)" in
+      amd64) wrp_asset="wrp-amd64-linux" ;;
+      arm64) wrp_asset="wrp-arm64-linux" ;;
+      armhf) wrp_asset="wrp-arm-linux" ;;
+      *) msg_error "Unsupported architecture: $(dpkg --print-architecture)"; exit ;;
+    esac
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$wrp_asset"
+
+    msg_info "Starting Service"
+    systemctl start wrp
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Point a legacy browser at:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:8080${CL}"

--- a/ct/wrp.sh
+++ b/ct/wrp.sh
@@ -35,7 +35,7 @@ function update_script() {
     systemctl stop wrp
     msg_ok "Stopped Service"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$(arch_resolve "wrp-amd64-linux" "wrp-arm64-linux")"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "wrp-$(arch_resolve)-linux"
 
     msg_info "Starting Service"
     systemctl start wrp
@@ -51,5 +51,5 @@ description
 
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW}Point a legacy browser at:${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
 echo -e "${GATEWAY}${BGN}http://${IP}:8080${CL}"

--- a/install/wrp-install.sh
+++ b/install/wrp-install.sh
@@ -17,14 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y chromium fonts-liberation
 msg_ok "Installed Dependencies"
 
-wrp_asset=""
-case "$(dpkg --print-architecture)" in
-amd64) wrp_asset="wrp-amd64-linux" ;;
-arm64) wrp_asset="wrp-arm64-linux" ;;
-armhf) wrp_asset="wrp-arm-linux" ;;
-*) msg_error "Unsupported architecture: $(dpkg --print-architecture)" && exit 1 ;;
-esac
-fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$wrp_asset"
+fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$(arch_resolve "wrp-amd64-linux" "wrp-arm64-linux")"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/wrp.service

--- a/install/wrp-install.sh
+++ b/install/wrp-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y chromium fonts-liberation
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$(arch_resolve "wrp-amd64-linux" "wrp-arm64-linux")"
+fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "wrp-$(arch_resolve)-linux"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/wrp.service

--- a/install/wrp-install.sh
+++ b/install/wrp-install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: N0t4R0b0t
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/tenox7/wrp
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y chromium fonts-liberation
+msg_ok "Installed Dependencies"
+
+wrp_asset=""
+case "$(dpkg --print-architecture)" in
+amd64) wrp_asset="wrp-amd64-linux" ;;
+arm64) wrp_asset="wrp-arm64-linux" ;;
+armhf) wrp_asset="wrp-arm-linux" ;;
+*) msg_error "Unsupported architecture: $(dpkg --print-architecture)" && exit 1 ;;
+esac
+fetch_and_deploy_gh_release "wrp" "tenox7/wrp" "singlefile" "latest" "/opt/wrp" "$wrp_asset"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/wrp.service
+[Unit]
+Description=WRP - Web Rendering Proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/wrp/wrp -l :8080 -b $(command -v chromium || command -v chromium-browser)
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now wrp
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/wrp.json
+++ b/json/wrp.json
@@ -35,11 +35,7 @@
   },
   "notes": [
     {
-      "text": "No dedicated icon exists yet for WRP; the Chromium icon is used as a placeholder since WRP is a Chromium-driven proxy.",
-      "type": "info"
-    },
-    {
-      "text": "Point a legacy browser (or its proxy settings) at http://<container-ip>:8080. To change listen address or add flags (-t, -g, -m, etc.), edit ExecStart in /etc/systemd/system/wrp.service and run systemctl restart wrp.",
+      "text": "Point a legacy browser (or its proxy settings) at http://<container-ip>:8080.",
       "type": "info"
     }
   ]

--- a/json/wrp.json
+++ b/json/wrp.json
@@ -13,6 +13,7 @@
   "documentation": "https://github.com/tenox7/wrp#readme",
   "website": "https://github.com/tenox7/wrp",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/chromium.webp",
+  "config_path": "/etc/systemd/system/wrp.service",
   "description": "WRP (Web Rendering Proxy) is a browser-in-browser proxy server that lets historical and vintage web browsers use the modern web. It drives a headless Chromium instance and renders pages back as clickable images or simplified HTML, so clients as old as Mosaic can browse today's HTTPS-only web.",
   "install_methods": [
     {

--- a/json/wrp.json
+++ b/json/wrp.json
@@ -1,0 +1,45 @@
+{
+  "name": "WRP",
+  "slug": "wrp",
+  "categories": [
+    4
+  ],
+  "date_created": "2026-07-27",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "has_arm": true,
+  "interface_port": 8080,
+  "documentation": "https://github.com/tenox7/wrp#readme",
+  "website": "https://github.com/tenox7/wrp",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/chromium.webp",
+  "description": "WRP (Web Rendering Proxy) is a browser-in-browser proxy server that lets historical and vintage web browsers use the modern web. It drives a headless Chromium instance and renders pages back as clickable images or simplified HTML, so clients as old as Mosaic can browse today's HTTPS-only web.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/wrp.sh",
+      "config_path": "/etc/systemd/system/wrp.service",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "No dedicated icon exists yet for WRP; the Chromium icon is used as a placeholder since WRP is a Chromium-driven proxy.",
+      "type": "info"
+    },
+    {
+      "text": "Point a legacy browser (or its proxy settings) at http://<container-ip>:8080. To change listen address or add flags (-t, -g, -m, etc.), edit ExecStart in /etc/systemd/system/wrp.service and run systemctl restart wrp.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds a new LXC script for **WRP (Web Rendering Proxy)** — a browser-in-browser proxy that drives a headless Chromium and renders pages back as clickable images or simplified HTML, so vintage browsers can reach the modern HTTPS-only web.

Structure follows `ct/hister.sh` closely, as both are single-binary GitHub-release apps:

- `check_for_gh_release` gates the update path.
- `fetch_and_deploy_gh_release ... "singlefile"` with an explicit per-architecture asset name.
- Service config lives in a plain systemd unit; no custom download or version-check logic.

Upstream publishes per-arch static binaries, so the arch case statement maps `dpkg --print-architecture` onto the exact published asset names (`wrp-amd64-linux`, `wrp-arm64-linux`, `wrp-arm-linux`), and errors out on anything else rather than guessing.

I run this container daily and have exercised both a clean install and an in-place update through `update_script`.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

<!-- Upstream publishes wrp-arm64-linux and wrp-arm-linux assets and the script
     selects them, but I have only run this on amd64. -->

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

A couple of deliberate choices worth calling out:

- **Logo is a placeholder.** No dedicated WRP icon exists in the selfhst icon set, so the Chromium icon is used, since WRP is a Chromium-driven proxy. Noted in `wrp.json` so it is not mistaken for an oversight. Happy to swap it if the org would rather add a proper icon first.
- **Config surface.** WRP is configured entirely through `ExecStart` flags rather than a config file, so `config_path` points at the systemd unit and a note explains how to add flags (`-t`, `-g`, `-m`, …) and restart.
- **Dependencies** are `chromium` and `fonts-liberation` only — no core packages re-listed.

---

## 📦 Application Requirements (for new scripts)

- [X] The application is **at least 6 months old** <!-- repo created 2016-01-24 -->
- [X] The application is **actively maintained** <!-- last push 2026-08-09 -->
- [X] The application has **600+ GitHub stars** <!-- 1,275 -->
- [X] Official **release tarballs** are published <!-- tagged releases with per-arch static binaries; latest 4.10.3 -->
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

Upstream: https://github.com/tenox7/wrp
Latest release: https://github.com/tenox7/wrp/releases/latest
