### PR TITLE
Add LX Family LXC helper

### DIFF
--- a/ct/lx-family.sh
+++ b/ct/lx-family.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/shared/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/shared/build.func")
+# Copyright (c) 2026 community-scripts ORG
+# Author: LaxXx Lab (laxxx-lab)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/laxxx-lab/lx-family-planner
+
+APP="LX Family"
+var_tags="${var_tags:-family;calendar;chores;shopping;self-hosted}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-10}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; not verified on bare-metal ARM yet
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function build_lx_family() {
+  cd /opt/lx-family
+  msg_info "Installing LX Family"
+  $STD npm ci
+  $STD npm run build
+  msg_ok "Installed LX Family"
+}
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/lx-family ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "lx-family" "laxxx-lab/lx-family-planner"; then
+    msg_info "Stopping Service"
+    systemctl stop lx-family
+    msg_ok "Stopped Service"
+
+    create_backup /opt/lx-family/.env /opt/lx-family/data /opt/lx-family/backups
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "lx-family" "laxxx-lab/lx-family-planner" "tarball"
+
+    restore_backup
+    build_lx_family
+
+    msg_info "Starting Service"
+    systemctl start lx-family
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:3001${CL}"

--- a/install/lx-family-install.sh
+++ b/install/lx-family-install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 community-scripts ORG
+# Author: LaxXx Lab (laxxx-lab)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/laxxx-lab/lx-family-planner
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+# The Helper-Scripts completion hook uses the lower-case application slug to
+# create `/usr/bin/update`. It is not always exported into the LXC context.
+app="${app:-lx-family}"
+export app
+
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# NodeSource keys are ASCII-armored and therefore need the `gpg` executable
+# before the Helper-Scripts Node.js repository helper imports them. Checking
+# the executable (rather than the `gnupg` meta package) also handles fresh
+# Debian containers where that package name may only be a removed-package
+# residue.
+ensure_dependencies curl ca-certificates gpg
+
+NODE_VERSION="22" setup_nodejs
+
+fetch_and_deploy_gh_release "lx-family" "laxxx-lab/lx-family-planner" "tarball"
+
+msg_info "Configuring LX Family"
+mkdir -p /opt/lx-family/data /opt/lx-family/backups
+chmod 700 /opt/lx-family/data /opt/lx-family/backups
+cat <<EOF >/opt/lx-family/.env
+APP_SECRET="$(node -e "process.stdout.write(require('node:crypto').randomBytes(48).toString('hex'))")"
+NODE_ENV=production
+PORT=3001
+APP_LANGUAGE=de
+SESSION_COOKIE_SECURE=auto
+REGISTRATION_MODE=first-family
+DATABASE_FILE=/opt/lx-family/data/family_planner.sqlite
+LEGACY_DATABASE_FILE=/opt/lx-family/data/family_db.json
+BACKUP_DIRECTORY=/opt/lx-family/backups
+EOF
+chmod 600 /opt/lx-family/.env
+msg_ok "Configured LX Family"
+
+msg_info "Installing LX Family"
+cd /opt/lx-family
+$STD npm ci
+$STD npm run build
+msg_ok "Installed LX Family"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/lx-family.service
+[Unit]
+Description=LX Family Private Family OS
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/lx-family
+ExecStart=/usr/bin/node --env-file-if-exists=.env server.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now lx-family
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/lx-family.json
+++ b/json/lx-family.json
@@ -1,0 +1,49 @@
+{
+  "name": "LX Family",
+  "slug": "lx-family",
+  "categories": [10, 12, 19],
+  "date_created": "2026-08-10",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 3001,
+  "documentation": "https://github.com/laxxx-lab/lx-family-planner#readme",
+  "website": "https://github.com/laxxx-lab/lx-family-planner",
+  "repository": "https://github.com/laxxx-lab/lx-family-planner",
+  "architectures": ["amd64"],
+  "platforms": ["pve"],
+  "logo": "https://raw.githubusercontent.com/laxxx-lab/lx-family-planner/main/public/icon-512.png",
+  "description": "LX Family is a private, self-hosted Family OS for calendars, chores, shopping, meals, chat, reminders and shared family files.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/lx-family.sh",
+      "config_path": "/opt/lx-family/.env",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 10,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Open http://<LXC-IP>:3001 and create the first family in LX Family onboarding. Further public registration is protected by default.",
+      "type": "info"
+    },
+    {
+      "text": "This Helper Script uses a native Node.js service inside an unprivileged Debian LXC. It intentionally does not install Docker, Nextcloud or other optional integrations.",
+      "type": "info"
+    },
+    {
+      "text": "Family data and local database backups live in /opt/lx-family/data and /opt/lx-family/backups. Include both paths in your Proxmox backup plan.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **LX Family**, a private self-hosted Family OS, as a native unprivileged Debian 13 LXC helper.

- Node.js 22 service on port 3001
- Calendar, chores, shopping, meal planning, reminders, chat and family files
- Persistent data and local backups in `/opt/lx-family/data` and `/opt/lx-family/backups`
- Built-in `update` path preserves `.env`, data and backups
- Intentionally no Docker, bundled Nextcloud or privileged container

## Validation

- Fresh install tested on Proxmox VE 8.4.19 in an unprivileged Debian 13 LXC
- Confirmed Node.js 22 setup, release deployment, production build and systemd service
- Confirmed `systemctl is-active lx-family` = `active`
- Confirmed `http://127.0.0.1:3001` returns HTTP 200
- Bash syntax and JSON validation passed locally

The test network assigned the LXC address late, so the initial framework network wait elapsed; once networking was available, the same install script completed successfully. This change explicitly ensures the `gpg` executable before NodeSource key import, which fresh Debian 13 containers need.