### PR TITLE
New script: fwupd-webui

### DIFF
--- a/ct/fwupd-webui.sh
+++ b/ct/fwupd-webui.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Vadim Yuzi (yuzi-co)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/yuzi-co/fwupd-webui
+
+APP="fwupd-webui"
+var_tags="${var_tags:-hardware;monitoring;firmware}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
+
+# Privileged, deliberately, and the only setting here that is not a default.
+#
+# Enumerating firmware means issuing NVMe admin commands and SCSI generic ioctls
+# against the host's disks. Measured on real hardware: a privileged container
+# finds 8 devices, and 2 is the ceiling for everything short of it --
+# --cap-add=ALL with seccomp and AppArmor unconfined still reaches only 2.
+# Explicit device-cgroup rules make it worse, returning 0.
+#
+# build.func already emits the device access a privileged container needs, so no
+# custom LXC configuration is added by this script.
+var_unprivileged="${var_unprivileged:-0}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/fwupd-webui ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Stopping Service"
+  systemctl stop fwupd-webui
+  msg_ok "Stopped Service"
+
+  msg_info "Updating $APP"
+  cd /opt/fwupd-webui/src-checkout || exit
+  $STD git fetch origin main
+  $STD git checkout FETCH_HEAD
+  $STD /opt/fwupd-webui/venv/bin/pip install --upgrade /opt/fwupd-webui/src-checkout
+  msg_ok "Updated $APP"
+
+  msg_info "Starting Service"
+  systemctl start fwupd-webui
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8099${CL}"
+echo -e "${INFO}${YW}Firmware flashing is disabled by default. Enable it in${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}/etc/fwupd-webui/env${CL}"

--- a/install/fwupd-webui-install.sh
+++ b/install/fwupd-webui-install.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: yuzi-co
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/yuzi-co/fwupd-webui
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+# fwupd brings fwupdtool, which runs the fwupd engine in-process. The fwupd
+# daemon and its systemd units arrive in the same package but are never used.
+$STD apt install -y \
+  fwupd \
+  python3 \
+  python3-venv \
+  git
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up fwupd-webui"
+$STD git clone --depth 1 https://github.com/yuzi-co/fwupd-webui.git /opt/fwupd-webui/src-checkout
+$STD python3 -m venv /opt/fwupd-webui/venv
+$STD /opt/fwupd-webui/venv/bin/pip install --upgrade pip
+$STD /opt/fwupd-webui/venv/bin/pip install /opt/fwupd-webui/src-checkout
+msg_ok "Set up fwupd-webui"
+
+msg_info "Creating Configuration"
+mkdir -p /etc/fwupd-webui
+cat <<EOF >/etc/fwupd-webui/env
+FWUPD_WEBUI_PORT=8099
+
+# Firmware writes are OFF by default. While this is false the flash routes are
+# not registered at all. Even when enabled, every flash requires typing the
+# device name, and system firmware (BIOS, UEFI capsule, SPI flash) is refused.
+FWUPD_WEBUI_ENABLE_FLASHING=false
+EOF
+chmod 0640 /etc/fwupd-webui/env
+msg_ok "Created Configuration"
+
+msg_info "Creating Service"
+# Runs as root: device enumeration requires it. The hardening below is what can
+# be applied without hiding the hardware this service exists to read.
+cat <<EOF >/etc/systemd/system/fwupd-webui.service
+[Unit]
+Description=fwupd Web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/fwupd-webui/env
+ExecStart=/opt/fwupd-webui/venv/bin/python -m fwupd_webui
+Restart=on-failure
+RestartSec=5
+User=root
+NoNewPrivileges=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+ReadWritePaths=/var/lib/fwupd
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now fwupd-webui
+msg_ok "Created Service"
+
+motd_ssh
+customize
+
+msg_info "Cleaning up"
+$STD apt -y autoremove
+$STD apt -y autoclean
+msg_ok "Cleaned"

--- a/json/fwupd-webui.json
+++ b/json/fwupd-webui.json
@@ -1,0 +1,49 @@
+{
+  "name": "fwupd-webui",
+  "slug": "fwupd-webui",
+  "categories": [9],
+  "date_created": "2026-08-12",
+  "type": "ct",
+  "updateable": true,
+  "privileged": true,
+  "interface_port": 8099,
+  "documentation": "https://github.com/yuzi-co/fwupd-webui#readme",
+  "website": "https://github.com/yuzi-co/fwupd-webui",
+  "repository": "https://github.com/yuzi-co/fwupd-webui",
+  "architectures": ["amd64"],
+  "platforms": ["pve"],
+  "logo": "https://raw.githubusercontent.com/yuzi-co/fwupd-webui/main/unraid/icon.png",
+  "description": "Web UI for fwupd. Lists every device fwupd can enumerate on the Proxmox host - NVMe drives, SATA disks, HBAs, network cards, Thunderbolt controllers - with current firmware versions and any updates available from LVFS. Read-only by default; firmware flashing is off unless explicitly enabled.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/fwupd-webui.sh",
+      "config_path": "/etc/fwupd-webui/env",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Privileged by design. Enumerating firmware means issuing NVMe admin commands and SCSI ioctls against the host's disks. Measured: 8 devices privileged, 2 with --cap-add=ALL plus seccomp and AppArmor unconfined.",
+      "type": "warning"
+    },
+    {
+      "text": "Reports the firmware of the Proxmox host, not of the container. An LXC shares the host kernel, so /sys and /dev describe the real machine.",
+      "type": "info"
+    },
+    {
+      "text": "Firmware flashing is disabled by default. Set FWUPD_WEBUI_ENABLE_FLASHING=true in /etc/fwupd-webui/env and restart the service. Even then, every flash requires typing the device name, and BIOS, UEFI capsule and SPI flash writes are refused outright.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

**fwupd-webui** is a web UI for [fwupd](https://fwupd.org). It lists every device fwupd can enumerate on the Proxmox host — NVMe drives, SATA disks, HBAs, network cards, Thunderbolt controllers — with current firmware versions and any updates available from LVFS, and can flash the devices that are safe to write at runtime.

Read-only by default. Flashing is off unless `FWUPD_WEBUI_ENABLE_FLASHING=true` is set; while it is off the flash routes are not registered on the application at all. Even when enabled, every flash requires typing the device name to confirm, storage devices carry a data-loss warning, and system firmware — `uefi_capsule`, `uefi_dbx` and `mtd` — is refused outright, because a failed write there costs the motherboard rather than a peripheral.

### On the privileged container

This asks for `var_unprivileged=0`, which I know is unusual here, so here is the evidence rather than an assertion. Enumerating firmware means issuing NVMe admin commands and SCSI generic ioctls against the host's disks. Measured on a real Proxmox 9.2.10 host with 8 enumerable devices:

| Configuration | Devices found |
| --- | --- |
| `--privileged` | **8** |
| `--cap-add=ALL` + seccomp and AppArmor unconfined + all mounts | 2 |
| all bind mounts, unprivileged | 2 |
| explicit `--device-cgroup-rule` sets | 0 |

The two that always appear are the CPU and the display, neither of which needs hardware access. Nothing short of privileged reaches the disks. The script adds **no custom LXC configuration** — `build.func` already emits the device access a privileged container needs.

Upstream: https://github.com/yuzi-co/fwupd-webui (MIT, 198 tests, published container image, also packaged for Docker and Unraid).

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – See the testing note below for exactly what was and was not exercised.
- [x] **No breaking changes** – New script only.
- [x] **No security risks** – No hardcoded secrets. The privilege level is the feature and is justified with measurements above; nothing else is elevated.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [x] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

`var_arm64="no"`, `"architectures": ["amd64"]`. To be precise: this is not an upstream limitation — fwupd builds fine on arm64 — but device enumeration has not been verified on arm64 hardware, and shipping it untested seemed worse than declaring it unsupported. Happy to change this to "not tested" if you would prefer.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix**
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change**

---

## 🤖 AI Assistance

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and the agent guidance as reference, and the output has been reviewed and corrected to match those guidelines.

Model: **Claude Opus 4.5** (Anthropic), high reasoning effort, driven interactively via Claude Code.

Worth stating plainly: the first draft was modelled on an existing script in ProxmoxVE and did **not** match `AGENTS.md` — it used the old `misc/build.func` sourcing block, and the JSON was missing `repository`, `architectures` and `platforms`. Both files were rewritten against the templates in `AGENTS.md`, and the engine boot block is now byte-identical to the one in `ct/airtrail.sh`.

---

## 🧪 Testing note

Being precise, since the checkbox above is coarse.

**Verified on a real Proxmox 9.2.10 host (kernel 7.0.14-9-pve):**

- A privileged Debian 13 LXC created by the equivalent standalone installer enumerates 10 devices belonging to the host, including SATA disks and the SPI flash controllers.
- The install steps this script performs — apt dependencies, venv, systemd unit, config file — run cleanly and produce a healthy service on port 8099.
- The safety policy behaves correctly against that hardware: BIOS `mtd` devices refused, SATA disks gated behind the typed-name confirmation.
- `shellcheck` clean; JSON validates against the required-field list in `AGENTS.md`.

**Not verified:** `ct/fwupd-webui.sh` end to end, because it resolves its installer by name from the community-scripts repositories and so cannot run until it lives in one. That is my understanding of what ProxmoxVED is for, and I will iterate on test feedback.

**Opened as a draft** pending the author's own line-by-line review, which is what the self-review checkbox above asserts.
