### PR TITLE
fix(onetimesecret): install libsodium23 and preserve X-Forwarded-Proto behind reverse proxy

### DIFF
--- a/install/onetimesecret-install.sh
+++ b/install/onetimesecret-install.sh
@@ -21,6 +21,7 @@ $STD apt install -y \
   libgmp-dev \
   libpq-dev \
   libreadline-dev \
+  libsodium23 \
   libsqlite3-dev \
   libssl-dev \
   libxml2-dev \
@@ -115,6 +116,16 @@ msg_ok "Created Service"
 
 msg_info "Configuring Nginx"
 cat <<'EOF' >/etc/nginx/sites-available/onetimesecret
+# Preserve X-Forwarded-Proto from an upstream TLS-terminating reverse proxy.
+# Without this, nginx always reports its own scheme (http, since it only
+# listens on port 80), which clobbers a proxy-supplied "https" value, causes
+# secure session cookies to be dropped, and breaks account creation (CSRF
+# session-continuity failures) when this container sits behind another proxy.
+map $http_x_forwarded_proto $ots_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
   listen 80 default_server;
   server_name _;
@@ -127,7 +138,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $ots_forwarded_proto;
   }
 }
 EOF


### PR DESCRIPTION
## Problem
Fresh installs of the OneTimeSecret LXC (via `ct/onetimesecret.sh` → `install/onetimesecret-install.sh`) are broken out of the box in two ways:

1. **Secret generation always fails with HTTP 500.**
   `rbnacl` (used by `familia`'s XChaCha20-Poly1305 encryption provider) is a pure Ruby FFI binding around the native `libsodium` C library. The install script never installs `libsodium23`, so `RbNaCl::Sodium` fails to load and every `POST /guest/secret/generate` / `/guest/secret/conceal` request crashes with:
   ```
   NameError: uninitialized constant RbNaCl::Hash
   ```

2. **Account creation fails with CSRF 403 whenever the container sits behind an external TLS-terminating reverse proxy** (nginx/Caddy/Traefik/Cloudflare Tunnel/etc. — a very common setup for self-hosted services).
   The generated `/etc/nginx/sites-available/onetimesecret` vhost only listens on port 80 and hardcodes:
   ```
   proxy_set_header X-Forwarded-Proto $scheme;
   ```
   Since this nginx never terminates TLS itself, `$scheme` is always `http`, which **overwrites** the `X-Forwarded-Proto: https` header set by an upstream proxy. With `SSL=true` (or `site.ssl`), the app marks its session cookie `Secure`, but since it now (incorrectly) believes the request is plain HTTP, it refuses to persist the cookie. This breaks session continuity, and `/auth/create-account` fails CSRF validation with a 403 (`session lost or not persisted`).

Both issues were reproduced and root-caused on a live deployment (Debian 13 LXC, nginx → Puma), confirmed via `journalctl` logs, and verified fixed after applying the equivalent changes manually.

## Fix
In `install/onetimesecret-install.sh`:
- Add `libsodium23` to the `apt install` dependency list.
- Add an nginx `map` that passes through an existing `X-Forwarded-Proto` value from an upstream proxy, only falling back to `$scheme` when the app is reached directly (no upstream proxy). This is the standard fix for a reverse proxy sitting behind another reverse proxy.

## Testing
- Installed `libsodium23` and confirmed `RbNaCl::Hash`/`RbNaCl::PasswordHash` load without error, and `/guest/secret/generate` no longer 500s.
- Simulated a request with `X-Forwarded-Proto: https` before/after the nginx change: before, the app logged `[Session] cookie NOT written: secure cookie over a request the app sees as non-SSL`; after, the `Set-Cookie` response correctly includes `secure`, and the CSRF failure mode changed from `session-continuity break: ... session lost or not persisted` to a normal `token-mismatch` (expected for a raw curl request without a full browser-driven CSRF handshake), confirming session persistence now works correctly.
- `nginx -t` passes with the updated config.