### PR TITLE
New script: crosspoint-sync

### DIFF
--- a/ct/crosspoint-sync.sh
+++ b/ct/crosspoint-sync.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Boisti13
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/crosspoint-reader/crosspoint-sync
+
+APP="Crosspoint-Sync"
+var_tags="${var_tags:-ebook;koreader;sync}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+var_unprivileged="${var_unprivileged:-1}"
+var_testurl="${var_testurl:-https://github.com/community-scripts/ProxmoxVED/issues/2182}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/crosspoint-sync ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_branch "crosspoint-sync" "crosspoint-reader/crosspoint-sync"; then
+    msg_info "Stopping Service"
+    systemctl stop crosspoint-sync
+    msg_ok "Stopped Service"
+
+    fetch_and_deploy_gh_branch "crosspoint-sync" "crosspoint-reader/crosspoint-sync"
+
+    msg_info "Building Crosspoint-Sync"
+    cd /opt/crosspoint-sync
+    $STD npm ci
+    $STD npm run build
+    $STD npm prune --omit=dev
+    msg_ok "Built Crosspoint-Sync"
+
+    msg_info "Starting Service"
+    systemctl start crosspoint-sync
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:8080${CL}"

--- a/install/crosspoint-sync-install.sh
+++ b/install/crosspoint-sync-install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Boisti13
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/crosspoint-reader/crosspoint-sync
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+NODE_VERSION="24" setup_nodejs
+
+fetch_and_deploy_gh_branch "crosspoint-sync" "crosspoint-reader/crosspoint-sync"
+
+msg_info "Building Crosspoint-Sync"
+cd /opt/crosspoint-sync
+$STD npm ci
+$STD npm run build
+$STD npm prune --omit=dev
+msg_ok "Built Crosspoint-Sync"
+
+msg_info "Configuring Crosspoint-Sync"
+mkdir -p /opt/crosspoint-sync-data
+cat <<EOF >/opt/crosspoint-sync.env
+NODE_ENV=production
+PORT=8080
+DATABASE_PATH=/opt/crosspoint-sync-data/crosspoint.db
+REGISTRATION_DISABLED=false
+EOF
+chmod 600 /opt/crosspoint-sync.env
+msg_ok "Configured Crosspoint-Sync"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/crosspoint-sync.service
+[Unit]
+Description=crosspoint-sync
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/crosspoint-sync
+EnvironmentFile=/opt/crosspoint-sync.env
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now crosspoint-sync
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/crosspoint-sync.json
+++ b/json/crosspoint-sync.json
@@ -1,0 +1,53 @@
+{
+  "name": "Crosspoint-Sync",
+  "slug": "crosspoint-sync",
+  "categories": [
+    12
+  ],
+  "date_created": "2026-08-15",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 8080,
+  "documentation": "https://github.com/crosspoint-reader/crosspoint-sync#readme",
+  "website": "https://github.com/crosspoint-reader/crosspoint-sync",
+  "repository": "https://github.com/crosspoint-reader/crosspoint-sync",
+  "logo": "https://raw.githubusercontent.com/crosspoint-reader/crosspoint-sync/main/assets/logo.png",
+  "description": "Lightweight, self-hostable, KOSync-compatible reading-progress sync server. Purpose-built for CrossPoint/CrossInk e-reader firmware (full position metadata, bookmark/clipping sync, per-device reading stats) but fully compatible with plain KOReader's built-in Progress sync plugin too. Stores everything in SQLite via Node's built-in node:sqlite, no external database or native dependencies.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/crosspoint-sync.sh",
+      "config_path": "/opt/crosspoint-sync.env",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "No default account is created. Register from a device's KOReader/CrossPoint sync settings, or create one manually: curl -X POST http://<ip>:8080/users/create -H 'content-type: application/json' -d '{\"username\":\"you\",\"password\":\"<md5-of-password>\"}' (password field must be an MD5 hash).",
+      "type": "info"
+    },
+    {
+      "text": "Registration is open by default (REGISTRATION_DISABLED=false in /opt/crosspoint-sync.env) - anyone who can reach the container can create an account. Set it to true and restart the service once your devices are registered.",
+      "type": "warning"
+    },
+    {
+      "text": "The server uses unencrypted HTTP. Restrict access to a trusted local network or place a VPN or HTTPS reverse proxy in front of it before exposing it publicly.",
+      "type": "warning"
+    },
+    {
+      "text": "Upstream has not published tagged releases yet, so this script deploys from the main branch (fetch_and_deploy_gh_branch) and updates whenever main moves.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a bare-metal (no Docker) LXC install script for [crosspoint-sync](https://github.com/crosspoint-reader/crosspoint-sync) — a lightweight, self-hostable, KOSync-compatible reading-progress sync server.

- Purpose-built for CrossPoint/CrossInk e-reader firmware (syncs full position metadata, bookmarks/clippings, per-device reading stats) but fully compatible with plain KOReader's built-in "Progress sync" plugin too.
- Node.js + SQLite (`node:sqlite`, no native dependencies) — deployed via `NODE_VERSION="24" setup_nodejs`.
- Upstream has not published tagged releases yet, so this uses `fetch_and_deploy_gh_branch` / `check_for_gh_branch` against `main` rather than `fetch_and_deploy_gh_release`.
- Runs directly as root per repo convention, no dedicated system user.
- App code lives in `/opt/crosspoint-sync` (replaced wholesale on update); config (`/opt/crosspoint-sync.env`) and the SQLite database (`/opt/crosspoint-sync-data/`) live outside that directory so `fetch_and_deploy_gh_branch`'s `git clean -fd` never touches them — no explicit backup/restore needed in the update function.
- Registration is open by default (matches upstream's own default); a JSON note explains why and how to lock it down after devices are registered.

Feedback tracking issue: community-scripts/ProxmoxVED#2182

## Test plan

- [x] `bash -n` passes on both `ct/crosspoint-sync.sh` and `install/crosspoint-sync-install.sh`
- [x] `json/crosspoint-sync.json` validated as well-formed JSON
- [x] Manually verified against `AGENTS.md`'s anti-pattern list and PR checklist (no Docker, no dedicated user, no `daemon-reload` on a new unit, `$STD` on all build commands, heredocs only, no core packages listed as deps, etc.)
- [x] Tested end-to-end on a real Proxmox VE 9.1.9 host: default-settings install succeeds, service is active/enabled, `/healthz` responds, and upstream's own `scripts/curl-smoke.sh` (registration, auth, progress sync, bookmarks, clippings, stats, document metadata) passes in full against the live instance. See comment below for details.