### PR TITLE
Add nzbfast

### DIFF
--- a/ct/nzbfast.sh
+++ b/ct/nzbfast.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: nzbfast (nzbfast)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/nzbfast/nzbfast
+
+APP="nzbfast"
+var_tags="${var_tags:-usenet;downloader}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-10}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-yes}" # unset = ask the user; the release ships a
+# linux-arm64 tarball and the script selects it, but nobody has run the result
+# on arm64 yet, so this stays unset rather than claiming a verification.
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/nzbfast ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "nzbfast" "nzbfast/nzbfast"; then
+    msg_info "Stopping Service"
+    systemctl stop nzbfast
+    msg_ok "Stopped Service"
+
+    # Settings, the API key, the queue and the index live in
+    # /opt/nzbfast_data, so a clean replace of the program directory keeps
+    # every one of them. Nothing below touches that directory.
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nzbfast" "nzbfast/nzbfast" "prebuild" "latest" "/opt/nzbfast" "nzbfast-*-linux-$(arch_resolve x64 arm64).tar.gz"
+
+    # Same wrapper-directory flattening the install does - see the comment
+    # there. CLEAN_INSTALL empties /opt/nzbfast first, so this runs on the
+    # freshly unpacked tree every update.
+    find /opt/nzbfast -name '._*' -delete
+    if [[ ! -f /opt/nzbfast/nzbfast ]]; then
+      nzbfast_wrapper="$(find /opt/nzbfast -mindepth 1 -maxdepth 1 -type d -name 'nzbfast-*' -print -quit)"
+      if [[ -n "$nzbfast_wrapper" ]]; then
+        mv "$nzbfast_wrapper"/* /opt/nzbfast/
+        rmdir "$nzbfast_wrapper"
+      fi
+    fi
+    chmod +x /opt/nzbfast/nzbfast
+
+    msg_info "Starting Service"
+    systemctl start nzbfast
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:6789${CL}"

--- a/install/nzbfast-install.sh
+++ b/install/nzbfast-install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: nzbfast (nzbfast)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/nzbfast/nzbfast
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# No dependency block: nzbfast is one statically linked binary. RAR
+# extraction, PAR2 verify and Reed-Solomon repair are all native, so there is
+# no unrar, par2 or 7z to install.
+
+fetch_and_deploy_gh_release "nzbfast" "nzbfast/nzbfast" "prebuild" "latest" "/opt/nzbfast" "nzbfast-*-linux-$(arch_resolve x64 arm64).tar.gz"
+
+msg_info "Setting up nzbfast"
+# The tarball wraps its payload in a versioned directory, and releases up to
+# 1.1.2 also carry macOS AppleDouble siblings (._name). Those extra top-level
+# entries stop the deploy helper collapsing the wrapper, so the binary lands a
+# level down. Flatten it and drop the resource forks; both are no-ops on a
+# tarball that does not have the problem.
+find /opt/nzbfast -name '._*' -delete
+if [[ ! -f /opt/nzbfast/nzbfast ]]; then
+  nzbfast_wrapper="$(find /opt/nzbfast -mindepth 1 -maxdepth 1 -type d -name 'nzbfast-*' -print -quit)"
+  if [[ -n "$nzbfast_wrapper" ]]; then
+    mv "$nzbfast_wrapper"/* /opt/nzbfast/
+    rmdir "$nzbfast_wrapper"
+  fi
+fi
+chmod +x /opt/nzbfast/nzbfast
+msg_ok "Set up nzbfast"
+
+msg_info "Creating Service"
+mkdir -p /opt/nzbfast_data/{downloads,watch}
+cat <<EOF >/etc/systemd/system/nzbfast.service
+[Unit]
+Description=nzbfast Usenet downloader
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/nzbfast_data
+# This install is managed by the community script, which owns the update
+# (see update_script in ct/nzbfast.sh). Marking it bundled stops nzbfast
+# self-swapping its own binary underneath that; it still reports when a
+# newer release is out.
+Environment=NZBFAST_BUNDLED=1
+ExecStart=/opt/nzbfast/nzbfast serve \\
+    --config /opt/nzbfast_data/config.json \\
+    --port 6789 \\
+    --out /opt/nzbfast_data/downloads \\
+    --watch /opt/nzbfast_data/watch \\
+    --index-db /opt/nzbfast_data/index.db
+Restart=on-failure
+RestartSec=5
+# config.json holds the Usenet provider password and the sibling apikey file
+# is the credential every *arr authenticates with, so nothing the daemon
+# creates should inherit a world-readable 0022.
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now nzbfast
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/nzbfast.json
+++ b/json/nzbfast.json
@@ -1,0 +1,53 @@
+{
+  "name": "nzbfast",
+  "slug": "nzbfast",
+  "categories": [
+    11
+  ],
+  "date_created": "2026-08-15",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 6789,
+  "documentation": "https://nzbfast.github.io/nzbfast/MANUAL.html",
+  "website": "https://nzbfast.github.io/nzbfast/",
+  "repository": "https://github.com/nzbfast/nzbfast",
+  "logo": "https://raw.githubusercontent.com/nzbfast/unraid-templates/main/icons/nzbfast.png",
+  "description": "nzbfast is a speed-focused Usenet (NZB) downloader written in Rust. It is one statically linked binary that saturates a fast line with a handful of connections and keeps its memory footprint small. Articles are verified as they arrive, so most jobs finish with no separate verify pass, and repair and unpack run only when they are needed. The web dashboard also serves a SABnzbd-compatible API, plus an NZBGet JSON-RPC facade, so Sonarr, Radarr, Prowlarr and the mobile remotes connect with no extra glue.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/nzbfast.sh",
+      "config_path": "/opt/nzbfast_data/config.json",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 10,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Open http://<IP>:6789 and add your Usenet provider in the Welcome panel. There is no config file to edit first, and the settings apply live.",
+      "type": "info"
+    },
+    {
+      "text": "An API key is generated on the first start. Read it with 'cat /opt/nzbfast_data/apikey', or copy it from Settings > Security in the dashboard, and paste it into Sonarr/Radarr when you add nzbfast as a SABnzbd download client.",
+      "type": "info"
+    },
+    {
+      "text": "Settings, the API key, the queue, the watch folder and the index all live in /opt/nzbfast_data, deliberately outside the program directory, so an update replaces only the binary and never the install.",
+      "type": "info"
+    },
+    {
+      "text": "Downloads land in /opt/nzbfast_data/downloads on the container disk. Mount a share or a larger volume there before you start pulling releases, or size the container disk for what you download.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds `ct/nzbfast.sh`, `install/nzbfast-install.sh` and `json/nzbfast.json` for [nzbfast](https://github.com/nzbfast/nzbfast), a speed-focused Usenet (NZB) downloader written in Rust. Bare-metal install of the upstream static binary into an unprivileged Debian 13 LXC, with a systemd unit and an `update_script` driven by `check_for_gh_release`.

**Written with AI assistance, as the header asks: Claude Opus 5, high reasoning effort**, using `AGENTS.md` as the guide. The output was reviewed and corrected against those guidelines, and the install script was smoke-run rather than assumed - see Additional Information, which includes a defect that run found and the fix for it.

**Read the Application Requirements section at the bottom first.** nzbfast is 69 stars and about four weeks old, so it does not currently meet the 600-star or 6-month thresholds, and I have not ticked boxes that are not true. Filing it anyway so the work is on the record, and so a maintainer scanning closed submissions can judge whether the project is worth an exception; I understand if the answer is "come back later" and I will not ping about it.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected. (Install script smoke-run end to end; the container-creation half is untested - see Additional Information.)
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

Upstream publishes a `linux-arm64` tarball and the script selects it via `arch_resolve x64 arm64`, but nobody has run the result on arm64, so `var_arm64` is left unset (commented out, with the reason) and `architectures` is omitted from the JSON.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Model: Claude Opus 5, high reasoning effort.

---

## 📋 Additional Information (optional)

**No dependency block.** The release artifact is a static musl binary, and RAR extraction, PAR2 verify and Reed-Solomon repair are all native, so there is no `unrar`, `par2` or `7z` to install. Confirmed on the deployed binary: `ELF 64-bit LSB executable, x86-64, statically linked, stripped`.

**The flatten step after the fetch is not gratuitous.** The release tarball wraps its payload in a versioned directory and, up to 1.1.2, also carries macOS AppleDouble members (`._name`). Those extra top-level entries stop `_deploy_unpacked_archive` collapsing the wrapper, so the binary lands at `/opt/nzbfast/nzbfast-1.1.2-linux-x64/nzbfast` and the service will not start. The smoke run below is what found that. The four lines normalise both shapes and become a no-op once the tarball is fixed upstream, which is being done separately.

**Data lives in `/opt/nzbfast_data`, outside the program directory**, because the update path is `CLEAN_INSTALL=1` and that empties `/opt/nzbfast`. Settings, the API key, the queue, the watch folder and the index database therefore survive an update.

**`Environment=NZBFAST_BUNDLED=1` in the unit.** nzbfast can self-update its own binary when it is a plain CLI install; this marks the install as managed so it does not swap the binary underneath `update_script`. It still reports when a newer release is out.

**`UMask=0077`**, because `config.json` holds the Usenet provider password and the sibling `apikey` file is the credential every *arr authenticates with.

**No default credentials, and no key is baked in.** nzbfast generates an API key on first start; the JSON notes point at `cat /opt/nzbfast_data/apikey` and at Settings → Security.

### Testing

`bash -n` and `shellcheck -S warning` are clean on both scripts (the only hit is SC1090 on the mandated core-sourcing header, identical to every merged script).

The install script was then smoke-run in a `debian:trixie` container against the genuine `community-scripts/core` helpers (`core.func`, `tools.func`, `forge.func`) fed in as `FUNCTIONS_FILE_PATH`, with only the LXC-lifecycle helpers stubbed (`setting_up_container`, `network_check`, `update_os`, `motd_ssh`, `customize`) and `systemctl` stubbed, since systemd is not PID 1 in a container. That run:

- resolved the asset, downloaded the real 1.1.2 release and landed `/opt/nzbfast/nzbfast` executable;
- produced a unit that passes `systemd-analyze verify`;
- started the daemon from that unit's exact `ExecStart`, served `GET /api?mode=version` → `{"nzbfast":"1.1.2",...}`, refused `mode=queue` with `API Key Required`, and wrote `/opt/nzbfast_data/apikey` at mode `600`.

I do not have a Proxmox host, so `ct/nzbfast.sh` has not been through a real `build_container`, and the update path is unexercised. Everything the install script itself does is covered above.

---

## 📦 Application Requirements (for new scripts)

- [ ] The application is **at least 6 months old** — no: the repository was created 21 Jul 2026, so it is about four weeks old.
- [X] The application is **actively maintained** — 17 releases since 28 Jul 2026, most recent commit this week.
- [ ] The application has **600+ GitHub stars** — no: 69 at the time of writing.
- [X] Official **release tarballs** are published — `nzbfast-<ver>-linux-x64.tar.gz` and `-linux-arm64.tar.gz` on every GitHub Release, which is what this script installs.
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- https://github.com/nzbfast/nzbfast
- https://nzbfast.github.io/nzbfast/
- Manual: https://nzbfast.github.io/nzbfast/MANUAL.html
