### PR TITLE
rustfs: fix release asset matching for versioned zip names

### DIFF
--- a/ct/rustfs.sh
+++ b/ct/rustfs.sh
@@ -40,7 +40,7 @@ function update_script() {
     systemctl stop rustfs
     msg_ok "Stopped Service"
 
-    GH_INCLUDE_PRERELEASE=1 CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rustfs" "rustfs/rustfs" "prebuild" "latest" "/opt/rustfs" "rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-latest.zip"
+    GH_INCLUDE_PRERELEASE=1 CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rustfs" "rustfs/rustfs" "prebuild" "latest" "/opt/rustfs" "rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-*.zip"
     chmod +x /opt/rustfs/rustfs
 
     msg_info "Starting Service"

--- a/install/rustfs-install.sh
+++ b/install/rustfs-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 mkdir -p /opt/rustfs_data/{data,logs}
-GH_INCLUDE_PRERELEASE=1 fetch_and_deploy_gh_release "rustfs" "rustfs/rustfs" "prebuild" "latest" "/opt/rustfs" "rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-latest.zip"
+GH_INCLUDE_PRERELEASE=1 fetch_and_deploy_gh_release "rustfs" "rustfs/rustfs" "prebuild" "latest" "/opt/rustfs" "rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-*.zip"
 chmod +x /opt/rustfs/rustfs
 
 msg_info "Configuring RustFS"


### PR DESCRIPTION
## ✍️ Description
AI agent (opencode, default reasoning level) prepared this fix and it was reviewed by the author before submission.

The newest rustfs release (`1.0.0-rc.2-preview.1`) ships only **versioned** assets (`rustfs-linux-x86_64-gnu-v1.0.0-rc.2-preview.1.zip`) and no longer provides the `-latest.zip` alias that every earlier release had. Both the install script and the update function hardcode `rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-latest.zip`, so the install fails with:

```
[ERROR] No asset matching 'rustfs-linux-x86_64-gnu-latest.zip' found
[ERROR] in line 1980: exit code 252 (App: Required file or resource not found)
```

The core fallback that scans older releases cannot help here either, because it skips pre-releases and **all** rustfs releases are pre-releases.

This PR changes the asset pattern to a glob (`rustfs-linux-$(arch_resolve x86_64 aarch64)-gnu-*.zip`) which:
- matches the versioned asset in the newest release (`rustfs-linux-x86_64-gnu-v1.0.0-rc.2-preview.1.zip`),
- still matches the `-latest.zip` alias if upstream ever restores it,
- keeps excluding the musl builds (`rustfs-linux-x86_64-musl-*`).

Verified against the GitHub API: the glob matches in `1.0.0-rc.2-preview.1`, `1.0.0-rc.2` and `1.0.0-rc.1`. Both files pass `bash -n`.

## 🔗 Related PR / Issue

Link: #2131

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)
Root cause analysis: the install first runs inside the container (`install/rustfs-install.sh`), where the release fetch picks the newest pre-release (`1.0.0-rc.2-preview.1`, because `GH_INCLUDE_PRERELEASE=1`) and fails to find the `-latest.zip` asset. The update path (`ct/rustfs.sh`) has the same latent bug.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- https://github.com/rustfs/rustfs/releases (asset names per release)
- https://github.com/community-scripts/ProxmoxVED/issues/2131
