### PR TITLE
feat: add Dockora addon

### DIFF
--- a/json/dockora.json
+++ b/json/dockora.json
@@ -1,0 +1,52 @@
+{
+  "name": "Dockora",
+  "slug": "dockora",
+  "categories": [3],
+  "date_created": "2026-08-22",
+  "type": "addon",
+  "updateable": true,
+  "privileged": false,
+  "architectures": ["amd64"],
+  "interface_port": 8080,
+  "documentation": "https://github.com/MarcelRuh/dockora",
+  "website": "https://github.com/MarcelRuh/dockora",
+  "repository": "https://github.com/MarcelRuh/dockora",
+  "logo": "https://raw.githubusercontent.com/MarcelRuh/dockora/main/apps/web/public/logo.png",
+  "description": "Self-hosted Docker management suite for Compose stacks, image updates, backups, and Discord notifications. Install as an addon on an existing Docker LXC.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "tools/addon/dockora.sh",
+      "config_path": "/opt/dockora/.env",
+      "resources": {
+        "cpu": null,
+        "ram": null,
+        "hdd": null,
+        "os": null,
+        "version": null
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin@dockora.local",
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Run this addon inside an existing Docker LXC (Helper Script: Docker). It will not create a new container.",
+      "type": "warning"
+    },
+    {
+      "text": "The UI is published on port 8080 through Dockora's nginx same-origin proxy (SSE/WebSocket).",
+      "type": "info"
+    },
+    {
+      "text": "Login email is admin@dockora.local. The generated password is printed once at install and stored in /opt/dockora/.env.",
+      "type": "info"
+    },
+    {
+      "text": "After install, update with `update_dockora` or by re-running this addon script.",
+      "type": "info"
+    }
+  ]
+}

--- a/tools/addon/dockora.sh
+++ b/tools/addon/dockora.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: MarcelRuh
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/MarcelRuh/dockora
+if ! command -v curl &>/dev/null; then
+  printf "\r\e[2K%b" '\033[93m Setup Source \033[m' >&2
+  apt-get update >/dev/null 2>&1
+  apt-get install -y curl >/dev/null 2>&1
+fi
+source <(curl -fsSL ${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/core.func)
+source <(curl -fsSL ${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/lib/tools.func)
+source <(curl -fsSL ${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/error_handler.func)
+source <(curl -fsSL ${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/api/api.func) 2>/dev/null || true
+declare -f init_tool_telemetry &>/dev/null && init_tool_telemetry "dockora" "addon"
+
+set -Eeuo pipefail
+trap 'error_handler' ERR
+
+APP="Dockora"
+APP_TYPE="addon"
+INSTALL_PATH="/opt/dockora"
+COMPOSE_FILE="${INSTALL_PATH}/docker-compose.yml"
+ENV_FILE="${INSTALL_PATH}/.env"
+REPO="MarcelRuh/dockora"
+DEFAULT_PORT=8080
+
+load_functions
+
+function header_info {
+  clear
+  cat <<"EOF"
+    ____             __
+   / __ \____  _____/ /______  _________ _
+  / / / / __ \/ ___/ //_/ __ \/ ___/ __ `/
+ / /_/ / /_/ / /__/ ,< / /_/ / /  / /_/ /
+/_____/\____/\___/_/|_|\____/_/   \__,_/
+
+EOF
+}
+
+function check_docker() {
+  if ! command -v docker &>/dev/null; then
+    msg_error "Docker is not installed. Run this addon inside an existing Docker LXC. Exiting."
+    exit 10
+  fi
+  if ! docker compose version &>/dev/null; then
+    msg_error "Docker Compose plugin is not available. Install it before running this script. Exiting."
+    exit 10
+  fi
+  msg_ok "Docker $(docker --version | cut -d' ' -f3 | tr -d ',') and Docker Compose are available"
+}
+
+function set_env() {
+  local key="$1" value="$2"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >>"$ENV_FILE"
+  fi
+}
+
+function deploy_release() {
+  if declare -f fetch_and_deploy_gh_release >/dev/null; then
+    fetch_and_deploy_gh_release "dockora" "$REPO" "tarball" "latest" "$INSTALL_PATH"
+  else
+    local tmp archive src
+    tmp="$(mktemp -d)"
+    archive="${tmp}/dockora.tar.gz"
+    curl -fsSL "https://github.com/${REPO}/archive/refs/heads/main.tar.gz" -o "$archive"
+    tar -xzf "$archive" -C "$tmp"
+    src="$(find "$tmp" -maxdepth 1 -type d -name 'dockora-*' | head -1)"
+    mkdir -p "$INSTALL_PATH"
+    shopt -s dotglob
+    cp -a "$src"/. "$INSTALL_PATH"/
+    shopt -u dotglob
+    rm -rf "$tmp"
+  fi
+  chmod +x "${INSTALL_PATH}/scripts/"*.sh 2>/dev/null || true
+}
+
+function uninstall() {
+  msg_info "Uninstalling ${APP}"
+  if [[ -f "$COMPOSE_FILE" ]]; then
+    cd "$INSTALL_PATH"
+    $STD docker compose -f docker-compose.yml -f docker-compose.images.yml --profile proxy down --volumes --remove-orphans
+  fi
+  rm -rf "$INSTALL_PATH"
+  rm -f /usr/local/bin/update_dockora
+  msg_ok "${APP} has been uninstalled"
+}
+
+function update() {
+  check_docker
+  if [[ ! -f "$ENV_FILE" ]]; then
+    msg_error "No ${APP} installation found!"
+    exit 233
+  fi
+
+  local env_backup
+  env_backup="$(mktemp)"
+  cp "$ENV_FILE" "$env_backup"
+
+  if declare -f check_for_gh_release >/dev/null && check_for_gh_release "dockora" "$REPO"; then
+    CLEAN_INSTALL=1 deploy_release
+    mv "$env_backup" "$ENV_FILE"
+  else
+    rm -f "$env_backup"
+  fi
+
+  msg_info "Pulling latest ${APP} images"
+  cd "$INSTALL_PATH"
+  $STD docker compose -f docker-compose.yml -f docker-compose.images.yml --profile proxy pull
+  msg_ok "Pulled latest images"
+
+  msg_info "Restarting ${APP}"
+  $STD docker compose -f docker-compose.yml -f docker-compose.images.yml --profile proxy up -d --remove-orphans
+  msg_ok "Restarted ${APP}"
+  msg_ok "Updated successfully"
+  exit
+}
+
+function install() {
+  local port="${1:-$DEFAULT_PORT}"
+  check_docker
+
+  msg_info "Deploying ${APP}"
+  mkdir -p "$INSTALL_PATH"
+  deploy_release
+  msg_ok "Deployed ${APP} to ${INSTALL_PATH}"
+
+  if [[ ! -f "${INSTALL_PATH}/.env.example" ]]; then
+    msg_error "Release is missing .env.example"
+    exit 1
+  fi
+
+  local jwt_secret admin_pass docker_gid
+  jwt_secret="$(openssl rand -hex 32)"
+  admin_pass="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c16)"
+  docker_gid="$(getent group docker 2>/dev/null | cut -d: -f3 || true)"
+  docker_gid="${docker_gid:-999}"
+
+  msg_info "Writing configuration"
+  cp "${INSTALL_PATH}/.env.example" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  set_env JWT_SECRET "$jwt_secret"
+  set_env BOOTSTRAP_ADMIN_EMAIL "admin@dockora.local"
+  set_env BOOTSTRAP_ADMIN_PASSWORD "$admin_pass"
+  set_env DOCKER_GID "$docker_gid"
+  set_env DOCKORA_INSTALL_DIR "$INSTALL_PATH"
+  set_env DOCKORA_REPO "$REPO"
+  set_env DOCKORA_UPDATE_BRANCH "main"
+  set_env DOCKORA_IMAGE_TAG "latest"
+  set_env DOCKORA_PROXY_PORT "$port"
+  set_env CORS_ORIGIN "http://${LOCAL_IP}:${port}"
+  msg_ok "Wrote ${ENV_FILE}"
+
+  msg_info "Starting ${APP}"
+  cd "$INSTALL_PATH"
+  $STD docker compose -f docker-compose.yml -f docker-compose.images.yml --profile proxy up -d
+  msg_ok "Started ${APP}"
+
+  msg_info "Creating update script"
+  cat <<'UPDATEEOF' >/usr/local/bin/update_dockora
+#!/usr/bin/env bash
+type=update bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/tools/addon/dockora.sh)"
+UPDATEEOF
+  chmod +x /usr/local/bin/update_dockora
+  msg_ok "Created update script (/usr/local/bin/update_dockora)"
+
+  echo ""
+  msg_ok "${APP} is reachable at: ${BL}http://${LOCAL_IP}:${port}${CL}"
+  echo ""
+  echo -e "Dockora Credentials"
+  echo -e "==================="
+  echo -e "Email:    admin@dockora.local"
+  echo -e "Password: ${admin_pass}"
+  echo -e "Config:   ${ENV_FILE}"
+  echo ""
+  msg_warn "Save the password now – it is not shown again."
+}
+
+if [[ "${type:-}" == "update" ]]; then
+  header_info
+  if [[ -f "$COMPOSE_FILE" ]]; then
+    update
+  else
+    msg_error "${APP} is not installed. Nothing to update."
+    exit 233
+  fi
+  exit 0
+fi
+
+header_info
+get_lxc_ip
+
+if [[ -f "$COMPOSE_FILE" && -f "$ENV_FILE" ]]; then
+  msg_warn "${APP} is already installed."
+  echo ""
+
+  echo -n "${TAB}Uninstall ${APP}? (y/N): "
+  read -r uninstall_prompt
+  if [[ "${uninstall_prompt,,}" =~ ^(y|yes)$ ]]; then
+    uninstall
+    exit 0
+  fi
+
+  echo -n "${TAB}Update ${APP}? (y/N): "
+  read -r update_prompt
+  if [[ "${update_prompt,,}" =~ ^(y|yes)$ ]]; then
+    update
+    exit 0
+  fi
+
+  msg_warn "No action selected. Exiting."
+  exit 0
+fi
+
+msg_warn "${APP} is not installed."
+echo ""
+echo -e "${TAB}${INFO} This addon installs Dockora on an existing Docker LXC (GHCR images + Compose)."
+echo -e "${TAB}${INFO} UI is served via the nginx same-origin proxy."
+echo ""
+
+echo -n "${TAB}UI port [${DEFAULT_PORT}]: "
+read -r port_input
+PORT="${port_input:-$DEFAULT_PORT}"
+
+echo -n "${TAB}Install ${APP}? (y/N): "
+read -r install_prompt
+if [[ "${install_prompt,,}" =~ ^(y|yes)$ ]]; then
+  install "$PORT"
+else
+  msg_warn "Installation cancelled. Exiting."
+  exit 0
+fi


### PR DESCRIPTION
## ✍️ Description

I'd like to add Dockora as an addon (`tools/addon/dockora.sh` + `json/dockora.json`).

Dockora is a self-hosted Docker management UI (Compose stacks, image updates, backups, Discord). Helper scripts don't install apps inside Docker, so this isn't a new CT — it needs to run on an existing Docker LXC, same idea as Arcane and Dockhand.

Install does roughly this:
- checks for Docker Engine + Compose v2
- puts the latest GitHub release into `/opt/dockora`
- starts the GHCR images with the official compose overlay and the nginx same-origin proxy (port 8080 by default)
- generates `JWT_SECRET` and a bootstrap admin password (printed once, also stored in `/opt/dockora/.env` and `/root/dockora.creds`)
- update/uninstall from the same script, plus `update_dockora`

Script layout follows the general addon pattern (qbittorrent-exporter / paperless-exporter / CronMaster): config, OS check, install / update / uninstall, main.

Test from inside a Docker LXC:

```bash
COMMUNITY_SCRIPTS_URL=https://raw.githubusercontent.com/MarcelRuh/ProxmoxVED/feat/add-dockora-addon \
bash -c "$(curl -fsSL https://raw.githubusercontent.com/MarcelRuh/ProxmoxVED/feat/add-dockora-addon/tools/addon/dockora.sh)"
```

Then open `http://<lxc-ip>:8080` and log in with `admin@dockora.local` + the password from the install output.

## 🔗 Related PR / Issue

Link: #2201

## ✅ Prerequisites  (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [ ] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [ ] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 📋 Additional Information (optional)

This is an **addon**, not a CT, so there is no `ct/` + `install/` pair — same as Arcane/Dockhand (`tools/addon/dockora.sh`).

Docker Compose is used on purpose: Dockora is a Docker management UI and has to sit on an existing Docker LXC. It does not create nested Docker to run a random app.

I have not run a full install on a fresh Docker LXC yet (script syntax-checked). Test command is in the description.

Dockora is too new for the 🆕 New script gates (age / stars / No Docker), so that box is left unchecked. This is the addon + JSON metadata only.

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [ ] The application is **at least 6 months old**
- [ ] The application is **actively maintained**
- [ ] The application has **600+ GitHub stars**
- [ ] Official **release tarballs** are published
- [ ] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

https://github.com/MarcelRuh/dockora
https://github.com/MarcelRuh/dockora/releases
