### PR TITLE
feat: add T3 Code LXC template

### DIFF
--- a/ct/t3-code.sh
+++ b/ct/t3-code.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Engine comes from community-scripts/core; this repo only ships the scripts.
-# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
-# so a fork or branch of core can be tested without editing this file.
 _cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
 source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
 # Copyright (c) 2021-2026 community-scripts ORG
@@ -18,166 +16,18 @@ var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
 #var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
 var_unprivileged="${var_unprivileged:-1}"
+export var_t3_providers="${var_t3_providers:-}"
+export var_t3_version_control="${var_t3_version_control:-git}"
+export var_t3_source_control="${var_t3_source_control:-}"
 
 t3_user="t3"
 t3_home="/home/${t3_user}"
+t3_data="/opt/t3-code_data"
 
 header_info "$APP"
 variables
 color
 catch_errors
-
-t3_provider_menu() {
-  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_providers:-}" ]]; then
-    var_t3_providers="${var_t3_providers//[[:space:]]/}"
-    export var_t3_providers
-    return
-  fi
-
-  if command -v pveversion >/dev/null 2>&1; then
-    ensure_whiptail
-    var_t3_providers=$(whiptail \
-      --backtitle "Proxmox VE Helper Scripts" \
-      --title "T3 Code Providers" \
-      --ok-button "Continue" \
-      --cancel-button "Skip Providers" \
-      --separate-output \
-      --checklist "\nSelect provider CLIs to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nNo providers are selected by default. Authentication is not performed." \
-      20 86 5 \
-      codex "OpenAI Codex CLI" off \
-      claude "Claude Code CLI" off \
-      cursor "Cursor Agent CLI" off \
-      grok "Grok Build CLI" off \
-      opencode "OpenCode CLI" off \
-      3>&1 1>&2 2>&3) || var_t3_providers=""
-  fi
-
-  var_t3_providers="${var_t3_providers//$'\n'/,}"
-  var_t3_providers="${var_t3_providers//[[:space:]]/}"
-  var_t3_providers="${var_t3_providers%,}"
-  export var_t3_providers
-}
-
-t3_version_control_menu() {
-  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_version_control+x}" ]]; then
-    var_t3_version_control="${var_t3_version_control:-git}"
-    var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
-    export var_t3_version_control
-    return
-  fi
-
-  if command -v pveversion >/dev/null 2>&1; then
-    ensure_whiptail
-    var_t3_version_control=$(whiptail \
-      --backtitle "Proxmox VE Helper Scripts" \
-      --title "T3 Code Version Control" \
-      --ok-button "Continue" \
-      --cancel-button "Skip Version Control" \
-      --separate-output \
-      --checklist "\nSelect version-control tools to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nGit is selected by default.\n\nJujutsu: Coming Soon" \
-      16 86 1 \
-      git "Git" on \
-      3>&1 1>&2 2>&3) || var_t3_version_control=""
-  fi
-
-  var_t3_version_control="${var_t3_version_control//$'\n'/,}"
-  var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
-  var_t3_version_control="${var_t3_version_control%,}"
-  [[ -z "$var_t3_version_control" ]] && var_t3_version_control="none"
-  export var_t3_version_control
-}
-
-t3_source_control_menu() {
-  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_source_control+x}" ]]; then
-    var_t3_source_control="${var_t3_source_control:-none}"
-    var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
-    export var_t3_source_control
-    return
-  fi
-
-  if command -v pveversion >/dev/null 2>&1; then
-    ensure_whiptail
-    var_t3_source_control=$(whiptail \
-      --backtitle "Proxmox VE Helper Scripts" \
-      --title "T3 Code Source Control Providers" \
-      --ok-button "Continue" \
-      --cancel-button "Skip Source Control" \
-      --separate-output \
-      --checklist "\nSelect source-control integrations to install or configure for the t3 user.\n\nUse Space to toggle and Enter to continue.\nNo integrations are selected by default.\n\nGitHub: installs the gh CLI.\nGitLab: installs the glab CLI.\nAzure DevOps: installs az and its DevOps extension.\nBitbucket: uses API-token environment variables, not a CLI." \
-      20 86 4 \
-      github "Not available - install gh CLI" off \
-      gitlab "Not available - install glab CLI" off \
-      azure "Not available - install az + DevOps extension" off \
-      bitbucket "Not authenticated - configure API token" off \
-      3>&1 1>&2 2>&3) || var_t3_source_control=""
-  fi
-
-  var_t3_source_control="${var_t3_source_control//$'\n'/,}"
-  var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
-  var_t3_source_control="${var_t3_source_control%,}"
-  [[ -z "$var_t3_source_control" ]] && var_t3_source_control="none"
-  export var_t3_source_control
-}
-
-t3_summary_list() {
-  local raw="${1:-}"
-  [[ -z "$raw" || "$raw" == "none" ]] && {
-    printf 'none'
-    return
-  }
-
-  local -a items=()
-  local item label separator=""
-  IFS=',' read -r -a items <<<"$raw"
-  for item in "${items[@]}"; do
-    case "$item" in
-    git) label="Git" ;;
-    github) label="GitHub" ;;
-    gitlab) label="GitLab" ;;
-    azure) label="Azure DevOps" ;;
-    bitbucket) label="Bitbucket" ;;
-    codex) label="Codex" ;;
-    claude) label="Claude" ;;
-    cursor) label="Cursor" ;;
-    grok) label="Grok" ;;
-    opencode) label="OpenCode" ;;
-    *) label="$item" ;;
-    esac
-    printf '%s%s' "$separator" "$label"
-    separator=', '
-  done
-}
-
-t3_append_summary() {
-  local t3_summary_version_control
-  local t3_summary_source_control
-  local t3_summary_providers
-
-  t3_summary_version_control="$(t3_summary_list "${var_t3_version_control:-none}")"
-  t3_summary_source_control="$(t3_summary_list "${var_t3_source_control:-none}")"
-  t3_summary_providers="$(t3_summary_list "${var_t3_providers:-none}")"
-  summary="${summary}
-
-Dependencies:
-  Version Control: ${t3_summary_version_control}
-  Source Control: ${t3_summary_source_control}
-  Agent CLIs: ${t3_summary_providers}"
-}
-
-# The shared engine owns the Advanced wizard. Insert the app-specific prompt
-# after the final settings step, before its confirmation dialog.
-eval "$(declare -f advanced_settings |
-  sed 's/^advanced_settings ()/_t3_advanced_settings ()/' |
-  sed '/^[[:space:]]*local ct_type_desc=/i\
-      t3_version_control_menu\
-      t3_source_control_menu\
-      t3_provider_menu' |
-  sed '/^[[:space:]]*if whiptail .*CONFIRM SETTINGS/i\
-      t3_append_summary\
-')"
-advanced_settings() {
-  _t3_advanced_settings "$@"
-}
 
 t3_exec() {
   $STD runuser --user "$t3_user" -- env \
@@ -186,16 +36,59 @@ t3_exec() {
     LOGNAME="$t3_user" \
     SHELL=/bin/bash \
     PATH="$t3_home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    T3CODE_HOME="$t3_data" \
     XDG_RUNTIME_DIR="/run/user/${t3_uid}" \
     DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${t3_uid}/bus" \
+    NPM_CONFIG_PREFIX="$t3_home/.local" \
     NPM_CONFIG_CACHE="$t3_home/.cache/npm" \
     "$@"
+}
+
+migrate_t3_data() {
+  t3_data_migrated=0
+  if [[ -d "$t3_home/.t3" && ! -e "$t3_data" ]]; then
+    msg_info "Migrating T3 Code Data"
+    t3_exec /usr/bin/systemctl --user stop t3code.service 2>/dev/null || true
+    mv "$t3_home/.t3" "$t3_data"
+    chown -R "$t3_user:$t3_user" "$t3_data"
+    t3_data_migrated=1
+    msg_ok "Migrated T3 Code Data"
+  elif [[ -d "$t3_home/.t3" && -d "$t3_data" ]]; then
+    if [[ -z "$(find "$t3_data" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+      msg_info "Migrating T3 Code Data"
+      t3_exec /usr/bin/systemctl --user stop t3code.service 2>/dev/null || true
+      rmdir "$t3_data"
+      mv "$t3_home/.t3" "$t3_data"
+      chown -R "$t3_user:$t3_user" "$t3_data"
+      t3_data_migrated=1
+      msg_ok "Migrated T3 Code Data"
+    else
+      msg_error "Both legacy and current T3 Code data directories exist; migration was not performed."
+      return 1
+    fi
+  fi
+}
+
+configure_t3_service_environment() {
+  mkdir -p "$t3_home/.config/systemd/user/t3code.service.d"
+  cat <<EOF >"$t3_home/.config/systemd/user/t3code.service.d/10-network.conf"
+[Service]
+Environment=HOME=${t3_home}
+Environment=PATH=${t3_home}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NPM_CONFIG_PREFIX=${t3_home}/.local
+Environment=T3CODE_HOME=${t3_data}
+Environment=T3CODE_HOST=0.0.0.0
+Environment=T3CODE_PORT=3773
+EOF
+  chown "$t3_user:$t3_user" \
+    "$t3_home/.config/systemd/user/t3code.service.d" \
+    "$t3_home/.config/systemd/user/t3code.service.d/10-network.conf"
 }
 
 fix_resource_monitor_permissions() {
   local monitor
   t3_resource_monitor_repaired=0
-  for monitor in "$t3_home"/.t3/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
+  for monitor in "$t3_data"/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
     [[ -f "$monitor" ]] || continue
     if [[ ! -x "$monitor" ]]; then
       chmod 755 "$monitor"
@@ -210,16 +103,16 @@ finish_t3_service_setup() {
 
   $STD loginctl enable-linger "$t3_user"
   if [[ ! -f "$t3_home/.config/systemd/user/t3code.service" ||
-    ! -f "$t3_home/.t3/runtime/service-launcher.mjs" ||
-    ! -f "$t3_home/.t3/runtime/service-state.json" ]]; then
+    ! -f "$t3_data/runtime/service-launcher.mjs" ||
+    ! -f "$t3_data/runtime/service-state.json" ]]; then
     return 1
   fi
 
-  installed_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  installed_version=$(jq -r '.activeVersion // empty' "$t3_data/runtime/service-state.json" 2>/dev/null || true)
   [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
   [[ -z "$expected_version" || "$installed_version" == "$expected_version" ]] || return 1
-  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
-  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/.install-complete" ]] || return 1
+  [[ -f "$t3_data/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
+  [[ -f "$t3_data/runtime/versions/${installed_version}/.install-complete" ]] || return 1
 
   t3_exec /usr/bin/systemctl --user daemon-reload
   t3_exec /usr/bin/systemctl --user enable t3code.service
@@ -227,7 +120,7 @@ finish_t3_service_setup() {
 
 sync_t3_version() {
   local version
-  version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  version=$(jq -r '.activeVersion // empty' "$t3_data/runtime/service-state.json" 2>/dev/null || true)
   if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     msg_error "Unable to determine the installed T3 Code version."
     exit 1
@@ -248,13 +141,25 @@ function update_script() {
   fi
 
   t3_uid="$(id -u "$t3_user")"
+  if ! migrate_t3_data; then
+    exit 1
+  fi
+  configure_t3_service_environment
+  t3_exec /usr/bin/systemctl --user daemon-reload
+  if [[ "$t3_data_migrated" -eq 1 ]]; then
+    t3_exec /usr/bin/systemctl --user restart t3code.service
+    if ! t3_exec /usr/bin/systemctl --user is-active --quiet t3code.service; then
+      msg_error "${APP} service failed to start after data migration"
+      exit 1
+    fi
+  fi
   fix_resource_monitor_permissions
 
   if check_for_gh_release "t3-code" "pingdotgg/t3code"; then
     NODE_VERSION="24" setup_nodejs
 
     msg_info "Updating ${APP}"
-    if ! t3_exec /usr/bin/npx --yes "t3@${CHECK_UPDATE_RELEASE#v}" service update; then
+    if ! t3_exec /usr/bin/npx --yes "t3@${CHECK_UPDATE_RELEASE#v}" service update --base-dir "$t3_data"; then
       msg_warn "T3 could not enable lingering from the unprivileged user; completing service setup as root."
       if ! finish_t3_service_setup "${CHECK_UPDATE_RELEASE#v}"; then
         msg_error "T3 Code service update failed"
@@ -289,5 +194,4 @@ echo -e "${INFO}${YW}Access it using the following URL:${CL}"
 echo -e "${GATEWAY}${BGN}http://${IP}:3773${CL}"
 echo -e "${INFO}${YW}A one-time pairing URL with a one-hour lifetime is printed during installation.${CL}"
 echo -e "${INFO}${YW}To generate another one inside the container as the t3 user:${CL}"
-echo -e "${TAB}${BGN}npx --yes t3@latest pair --base-dir /home/t3/.t3 --ttl 1h${CL}"
-echo -e "${INFO}${YW}If providers or source-control integrations were selected, use the authentication commands printed during installation.${CL}"
+echo -e "${TAB}${BGN}npx --yes t3@latest pair --base-dir /opt/t3-code_data --ttl 1h${CL}"

--- a/ct/t3-code.sh
+++ b/ct/t3-code.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: lukdz
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://t3.codes/ | Github: https://github.com/pingdotgg/t3code
+
+APP="T3-Code"
+var_tags="${var_tags:-ai;coding}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+var_unprivileged="${var_unprivileged:-1}"
+
+t3_user="t3"
+t3_home="/home/${t3_user}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+t3_provider_menu() {
+  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_providers:-}" ]]; then
+    var_t3_providers="${var_t3_providers//[[:space:]]/}"
+    export var_t3_providers
+    return
+  fi
+
+  if command -v pveversion >/dev/null 2>&1; then
+    ensure_whiptail
+    var_t3_providers=$(whiptail \
+      --backtitle "Proxmox VE Helper Scripts" \
+      --title "T3 Code Providers" \
+      --ok-button "Continue" \
+      --cancel-button "Skip Providers" \
+      --separate-output \
+      --checklist "\nSelect provider CLIs to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nNo providers are selected by default. Authentication is not performed." \
+      20 86 5 \
+      codex "OpenAI Codex CLI" off \
+      claude "Claude Code CLI" off \
+      cursor "Cursor Agent CLI" off \
+      grok "Grok Build CLI" off \
+      opencode "OpenCode CLI" off \
+      3>&1 1>&2 2>&3) || var_t3_providers=""
+  fi
+
+  var_t3_providers="${var_t3_providers//$'\n'/,}"
+  var_t3_providers="${var_t3_providers//[[:space:]]/}"
+  var_t3_providers="${var_t3_providers%,}"
+  export var_t3_providers
+}
+
+t3_version_control_menu() {
+  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_version_control+x}" ]]; then
+    var_t3_version_control="${var_t3_version_control:-git}"
+    var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
+    export var_t3_version_control
+    return
+  fi
+
+  if command -v pveversion >/dev/null 2>&1; then
+    ensure_whiptail
+    var_t3_version_control=$(whiptail \
+      --backtitle "Proxmox VE Helper Scripts" \
+      --title "T3 Code Version Control" \
+      --ok-button "Continue" \
+      --cancel-button "Skip Version Control" \
+      --separate-output \
+      --checklist "\nSelect version-control tools to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nGit is selected by default.\n\nJujutsu: Coming Soon" \
+      16 86 1 \
+      git "Git" on \
+      3>&1 1>&2 2>&3) || var_t3_version_control=""
+  fi
+
+  var_t3_version_control="${var_t3_version_control//$'\n'/,}"
+  var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
+  var_t3_version_control="${var_t3_version_control%,}"
+  [[ -z "$var_t3_version_control" ]] && var_t3_version_control="none"
+  export var_t3_version_control
+}
+
+t3_source_control_menu() {
+  if [[ "${PHS_SILENT:-0}" == "1" || -n "${var_t3_source_control+x}" ]]; then
+    var_t3_source_control="${var_t3_source_control:-none}"
+    var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
+    export var_t3_source_control
+    return
+  fi
+
+  if command -v pveversion >/dev/null 2>&1; then
+    ensure_whiptail
+    var_t3_source_control=$(whiptail \
+      --backtitle "Proxmox VE Helper Scripts" \
+      --title "T3 Code Source Control Providers" \
+      --ok-button "Continue" \
+      --cancel-button "Skip Source Control" \
+      --separate-output \
+      --checklist "\nSelect source-control integrations to install or configure for the t3 user.\n\nUse Space to toggle and Enter to continue.\nNo integrations are selected by default.\n\nGitHub: installs the gh CLI.\nGitLab: installs the glab CLI.\nAzure DevOps: installs az and its DevOps extension.\nBitbucket: uses API-token environment variables, not a CLI." \
+      20 86 4 \
+      github "Not available - install gh CLI" off \
+      gitlab "Not available - install glab CLI" off \
+      azure "Not available - install az + DevOps extension" off \
+      bitbucket "Not authenticated - configure API token" off \
+      3>&1 1>&2 2>&3) || var_t3_source_control=""
+  fi
+
+  var_t3_source_control="${var_t3_source_control//$'\n'/,}"
+  var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
+  var_t3_source_control="${var_t3_source_control%,}"
+  [[ -z "$var_t3_source_control" ]] && var_t3_source_control="none"
+  export var_t3_source_control
+}
+
+t3_summary_list() {
+  local raw="${1:-}"
+  [[ -z "$raw" || "$raw" == "none" ]] && {
+    printf 'none'
+    return
+  }
+
+  local -a items=()
+  local item label separator=""
+  IFS=',' read -r -a items <<<"$raw"
+  for item in "${items[@]}"; do
+    case "$item" in
+    git) label="Git" ;;
+    github) label="GitHub" ;;
+    gitlab) label="GitLab" ;;
+    azure) label="Azure DevOps" ;;
+    bitbucket) label="Bitbucket" ;;
+    codex) label="Codex" ;;
+    claude) label="Claude" ;;
+    cursor) label="Cursor" ;;
+    grok) label="Grok" ;;
+    opencode) label="OpenCode" ;;
+    *) label="$item" ;;
+    esac
+    printf '%s%s' "$separator" "$label"
+    separator=', '
+  done
+}
+
+t3_append_summary() {
+  local t3_summary_version_control
+  local t3_summary_source_control
+  local t3_summary_providers
+
+  t3_summary_version_control="$(t3_summary_list "${var_t3_version_control:-none}")"
+  t3_summary_source_control="$(t3_summary_list "${var_t3_source_control:-none}")"
+  t3_summary_providers="$(t3_summary_list "${var_t3_providers:-none}")"
+  summary="${summary}
+
+Dependencies:
+  Version Control: ${t3_summary_version_control}
+  Source Control: ${t3_summary_source_control}
+  Agent CLIs: ${t3_summary_providers}"
+}
+
+# The shared engine owns the Advanced wizard. Insert the app-specific prompt
+# after the final settings step, before its confirmation dialog.
+eval "$(declare -f advanced_settings |
+  sed 's/^advanced_settings ()/_t3_advanced_settings ()/' |
+  sed '/^[[:space:]]*local ct_type_desc=/i\
+      t3_version_control_menu\
+      t3_source_control_menu\
+      t3_provider_menu' |
+  sed '/^[[:space:]]*if whiptail .*CONFIRM SETTINGS/i\
+      t3_append_summary\
+')"
+advanced_settings() {
+  _t3_advanced_settings "$@"
+}
+
+t3_exec() {
+  $STD runuser --user "$t3_user" -- env \
+    HOME="$t3_home" \
+    USER="$t3_user" \
+    LOGNAME="$t3_user" \
+    SHELL=/bin/bash \
+    PATH="$t3_home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    XDG_RUNTIME_DIR="/run/user/${t3_uid}" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${t3_uid}/bus" \
+    NPM_CONFIG_CACHE="$t3_home/.cache/npm" \
+    "$@"
+}
+
+fix_resource_monitor_permissions() {
+  local monitor
+  t3_resource_monitor_repaired=0
+  for monitor in "$t3_home"/.t3/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
+    [[ -f "$monitor" ]] || continue
+    if [[ ! -x "$monitor" ]]; then
+      chmod 755 "$monitor"
+      t3_resource_monitor_repaired=1
+    fi
+  done
+}
+
+finish_t3_service_setup() {
+  local expected_version="${1:-}"
+  local installed_version
+
+  $STD loginctl enable-linger "$t3_user"
+  if [[ ! -f "$t3_home/.config/systemd/user/t3code.service" ||
+    ! -f "$t3_home/.t3/runtime/service-launcher.mjs" ||
+    ! -f "$t3_home/.t3/runtime/service-state.json" ]]; then
+    return 1
+  fi
+
+  installed_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  [[ -z "$expected_version" || "$installed_version" == "$expected_version" ]] || return 1
+  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
+  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/.install-complete" ]] || return 1
+
+  t3_exec /usr/bin/systemctl --user daemon-reload
+  t3_exec /usr/bin/systemctl --user enable t3code.service
+}
+
+sync_t3_version() {
+  local version
+  version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    msg_error "Unable to determine the installed T3 Code version."
+    exit 1
+  fi
+  cat <<EOF >/root/.t3-code
+${version}
+EOF
+}
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if ! id "$t3_user" >/dev/null 2>&1 || [[ ! -f "$t3_home/.config/systemd/user/t3code.service" ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  t3_uid="$(id -u "$t3_user")"
+  fix_resource_monitor_permissions
+
+  if check_for_gh_release "t3-code" "pingdotgg/t3code"; then
+    NODE_VERSION="24" setup_nodejs
+
+    msg_info "Updating ${APP}"
+    if ! t3_exec /usr/bin/npx --yes "t3@${CHECK_UPDATE_RELEASE#v}" service update; then
+      msg_warn "T3 could not enable lingering from the unprivileged user; completing service setup as root."
+      if ! finish_t3_service_setup "${CHECK_UPDATE_RELEASE#v}"; then
+        msg_error "T3 Code service update failed"
+        exit 1
+      fi
+    fi
+    fix_resource_monitor_permissions
+    t3_exec /usr/bin/systemctl --user restart t3code.service
+    sync_t3_version
+    msg_ok "Updated ${APP}"
+
+    if ! t3_exec /usr/bin/systemctl --user is-active --quiet t3code.service; then
+      msg_error "${APP} service failed to start"
+      exit 1
+    fi
+    msg_ok "Updated successfully!"
+  elif [[ "$t3_resource_monitor_repaired" -eq 1 ]]; then
+    msg_info "Restarting ${APP} after resource monitor repair"
+    t3_exec /usr/bin/systemctl --user restart t3code.service
+    msg_ok "Restarted ${APP}"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:3773${CL}"
+echo -e "${INFO}${YW}A one-time pairing URL with a one-hour lifetime is printed during installation.${CL}"
+echo -e "${INFO}${YW}To generate another one inside the container as the t3 user:${CL}"
+echo -e "${TAB}${BGN}npx --yes t3@latest pair --base-dir /home/t3/.t3 --ttl 1h${CL}"
+echo -e "${INFO}${YW}If providers or source-control integrations were selected, use the authentication commands printed during installation.${CL}"

--- a/ct/t3-code.sh
+++ b/ct/t3-code.sh
@@ -29,6 +29,92 @@ variables
 color
 catch_errors
 
+t3_list_values() {
+  local value="${1:-}"
+  [[ -z "$value" || "$value" == "none" ]] && {
+    printf 'none'
+    return
+  }
+  printf '%s' "${value//,/", "}"
+}
+
+advanced_settings_app_configure() {
+  local selected
+  local git_state="off"
+  local codex_state="off"
+  local claude_state="off"
+  local grok_state="off"
+  local opencode_state="off"
+  local github_state="off"
+  local gitlab_state="off"
+  local azure_state="off"
+
+  [[ ",${var_t3_version_control,,}," == *,git,* ]] && git_state="on"
+  [[ ",${var_t3_providers,,}," == *,codex,* ]] && codex_state="on"
+  [[ ",${var_t3_providers,,}," == *,claude,* ]] && claude_state="on"
+  [[ ",${var_t3_providers,,}," == *,grok,* ]] && grok_state="on"
+  [[ ",${var_t3_providers,,}," == *,opencode,* ]] && opencode_state="on"
+  [[ ",${var_t3_source_control,,}," == *,github,* ]] && github_state="on"
+  [[ ",${var_t3_source_control,,}," == *,gitlab,* ]] && gitlab_state="on"
+  [[ ",${var_t3_source_control,,}," == *,azure,* ]] && azure_state="on"
+
+  selected=$(whiptail \
+    --backtitle "Proxmox VE Helper Scripts" \
+    --title "T3 Code Version Control" \
+    --ok-button "Continue" \
+    --cancel-button "Skip Version Control" \
+    --separate-output \
+    --checklist "\nSelect version-control tools to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nGit is selected by default." \
+    15 86 1 \
+    git "Git" "$git_state" \
+    3>&1 1>&2 2>&3) || selected=""
+  var_t3_version_control="${selected//$'\n'/,}"
+  var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
+  [[ -z "$var_t3_version_control" ]] && var_t3_version_control="none"
+  export var_t3_version_control
+
+  selected=$(whiptail \
+    --backtitle "Proxmox VE Helper Scripts" \
+    --title "T3 Code Agent Providers" \
+    --ok-button "Continue" \
+    --cancel-button "Skip Providers" \
+    --separate-output \
+    --checklist "\nSelect provider CLIs to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nAuthentication is not performed automatically.\nCursor is not installed by this script." \
+    20 86 4 \
+    codex "OpenAI Codex CLI" "$codex_state" \
+    claude "Claude Code CLI" "$claude_state" \
+    grok "Grok Build CLI" "$grok_state" \
+    opencode "OpenCode CLI" "$opencode_state" \
+    3>&1 1>&2 2>&3) || selected=""
+  var_t3_providers="${selected//$'\n'/,}"
+  var_t3_providers="${var_t3_providers//[[:space:]]/}"
+  export var_t3_providers
+
+  selected=$(whiptail \
+    --backtitle "Proxmox VE Helper Scripts" \
+    --title "T3 Code Source Control" \
+    --ok-button "Continue" \
+    --cancel-button "Skip Source Control" \
+    --separate-output \
+    --checklist "\nSelect source-control CLIs to install for the t3 user.\n\nUse Space to toggle and Enter to continue.\nAuthentication is not performed automatically." \
+    18 86 3 \
+    github "GitHub CLI (gh)" "$github_state" \
+    gitlab "GitLab CLI (glab)" "$gitlab_state" \
+    azure "Azure CLI + DevOps extension" "$azure_state" \
+    3>&1 1>&2 2>&3) || selected=""
+  var_t3_source_control="${selected//$'\n'/,}"
+  var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
+  [[ -z "$var_t3_source_control" ]] && var_t3_source_control="none"
+  export var_t3_source_control
+}
+
+advanced_settings_app_summary() {
+  printf 'T3 Code:\n'
+  printf '  Version Control: %s\n' "$(t3_list_values "${var_t3_version_control:-none}")"
+  printf '  Agent CLIs: %s\n' "$(t3_list_values "${var_t3_providers:-none}")"
+  printf '  Source Control: %s' "$(t3_list_values "${var_t3_source_control:-none}")"
+}
+
 t3_exec() {
   $STD runuser --user "$t3_user" -- env \
     HOME="$t3_home" \

--- a/install/t3-code-install.sh
+++ b/install/t3-code-install.sh
@@ -15,6 +15,7 @@ update_os
 
 t3_user="t3"
 t3_home="/home/${t3_user}"
+t3_data="/opt/t3-code_data"
 var_t3_providers="${var_t3_providers:-}"
 var_t3_providers="${var_t3_providers//[[:space:]]/}"
 var_t3_version_control="${var_t3_version_control:-git}"
@@ -22,19 +23,16 @@ var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
 var_t3_source_control="${var_t3_source_control:-none}"
 var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y \
+ensure_dependencies jq
+install_packages_with_retry \
   build-essential \
   python3 \
   dbus \
   dbus-user-session \
   libpam-systemd
-msg_ok "Installed Dependencies"
 
 if [[ ",${var_t3_version_control,,}," == *,git,* ]]; then
-  msg_info "Installing Git"
-  $STD apt-get install -y git
-  msg_ok "Installed Git"
+  install_packages_with_retry git
 fi
 
 NODE_VERSION="24" setup_nodejs
@@ -43,7 +41,7 @@ msg_info "Creating T3 User"
 if ! id "$t3_user" >/dev/null 2>&1; then
   $STD useradd --create-home --user-group --home-dir "$t3_home" --shell /bin/bash "$t3_user"
 fi
-# T3 can execute provider agent commands, so keep its server and project work non-root.
+# T3 executes provider agent commands, so its server and project work stay non-root.
 $STD passwd --lock "$t3_user"
 $STD chmod 750 "$t3_home"
 if ! grep -q '^export XDG_RUNTIME_DIR=' "$t3_home/.profile" 2>/dev/null; then
@@ -88,6 +86,7 @@ t3_exec() {
     LOGNAME="$t3_user" \
     SHELL=/bin/bash \
     PATH="$t3_home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    T3CODE_HOME="$t3_data" \
     XDG_RUNTIME_DIR="/run/user/${t3_uid}" \
     DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${t3_uid}/bus" \
     NPM_CONFIG_PREFIX="$t3_home/.local" \
@@ -95,10 +94,30 @@ t3_exec() {
     "$@"
 }
 
+if [[ -d "$t3_home/.t3" && -d "$t3_data" ]]; then
+  if [[ -z "$(find "$t3_data" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+    msg_info "Migrating T3 Code Data"
+    t3_exec /usr/bin/systemctl --user stop t3code.service 2>/dev/null || true
+    rmdir "$t3_data"
+    mv "$t3_home/.t3" "$t3_data"
+    msg_ok "Migrated T3 Code Data"
+  else
+    msg_error "Both legacy and current T3 Code data directories exist; migration was not performed."
+    exit 1
+  fi
+elif [[ -d "$t3_home/.t3" && ! -e "$t3_data" ]]; then
+  msg_info "Migrating T3 Code Data"
+  t3_exec /usr/bin/systemctl --user stop t3code.service 2>/dev/null || true
+  mv "$t3_home/.t3" "$t3_data"
+  msg_ok "Migrated T3 Code Data"
+fi
+mkdir -p "$t3_data"
+chown -R "$t3_user:$t3_user" "$t3_data"
+
 fix_resource_monitor_permissions() {
   local monitor
   t3_resource_monitor_repaired=0
-  for monitor in "$t3_home"/.t3/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
+  for monitor in "$t3_data"/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
     [[ -f "$monitor" ]] || continue
     if [[ ! -x "$monitor" ]]; then
       chmod 755 "$monitor"
@@ -130,25 +149,14 @@ install_selected_providers() {
     install_npm_provider "Codex CLI" "@openai/codex"
     t3_providers_installed=1
   fi
-
   if provider_selected claude; then
     setup_deb822_repo "claude-code" \
       "https://downloads.claude.ai/keys/claude-code.asc" \
       "https://downloads.claude.ai/claude-code/apt/stable" \
       "stable" "main"
-    msg_info "Installing Claude Code CLI"
-    $STD apt-get install -y claude-code
-    msg_ok "Installed Claude Code CLI"
+    install_packages_with_retry claude-code
     t3_providers_installed=1
   fi
-
-  if provider_selected cursor; then
-    msg_info "Installing Cursor Agent CLI"
-    t3_exec /bin/bash -c 'set -o pipefail; curl -fsSL https://cursor.com/install | bash'
-    msg_ok "Installed Cursor Agent CLI"
-    t3_providers_installed=1
-  fi
-
   if provider_selected grok; then
     install_npm_provider "Grok Build CLI" "@xai-official/grok"
     t3_providers_installed=1
@@ -165,66 +173,6 @@ source_control_selected() {
   [[ "$selected" == *",${provider},"* ]]
 }
 
-install_gitlab_cli() {
-  local arch="$(dpkg --print-architecture)"
-  local release_url="https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest"
-  local package_url
-  package_url=$(curl -fsSL --retry 3 --retry-connrefused --connect-timeout 10 --max-time 30 "$release_url" |
-    jq -r --arg arch "$arch" '
-      (.tag_name | ltrimstr("v")) as $version |
-      .assets.links[] |
-      select(.name == ("glab_" + $version + "_linux_" + $arch + ".deb")) |
-      .url' | head -n 1)
-  [[ -n "$package_url" && "$package_url" != "null" ]] || {
-    msg_error "Could not find a GitLab CLI package for ${arch}."
-    return 1
-  }
-
-  local package_file
-  package_file=$(mktemp --suffix=.deb)
-  msg_info "Installing GitLab CLI"
-  if ! curl -fsSL --retry 3 --retry-connrefused --connect-timeout 10 --max-time 120 "$package_url" -o "$package_file"; then
-    rm -f "$package_file"
-    msg_error "Failed to download GitLab CLI."
-    return 1
-  fi
-  if ! $STD dpkg -i "$package_file"; then
-    $STD apt-get install -f -y
-  fi
-  rm -f "$package_file"
-  command -v glab >/dev/null 2>&1 || {
-    msg_error "GitLab CLI installation did not provide glab."
-    return 1
-  }
-  msg_ok "Installed GitLab CLI"
-}
-
-configure_bitbucket_environment() {
-  local env_dir="/etc/t3-code"
-  local env_file="${env_dir}/source-control.env"
-  mkdir -p "$env_dir"
-  if [[ ! -f "$env_file" ]]; then
-    cat <<'EOF' >"$env_file"
-# Bitbucket credentials for T3 Code. Set either the access token, or the
-# email/API-token pair, then restart the T3 Code user service.
-# T3CODE_BITBUCKET_ACCESS_TOKEN=
-# T3CODE_BITBUCKET_EMAIL=
-# T3CODE_BITBUCKET_API_TOKEN=
-EOF
-  fi
-  chown root:"$t3_user" "$env_file"
-  chmod 640 "$env_file"
-
-  mkdir -p "$t3_home/.config/systemd/user/t3code.service.d"
-  cat <<EOF >"$t3_home/.config/systemd/user/t3code.service.d/20-source-control.conf"
-[Service]
-EnvironmentFile=-${env_file}
-EOF
-  chown "$t3_user:$t3_user" \
-    "$t3_home/.config/systemd/user/t3code.service.d" \
-    "$t3_home/.config/systemd/user/t3code.service.d/20-source-control.conf"
-}
-
 install_source_control_tools() {
   t3_source_control_configured=0
   [[ -n "${var_t3_source_control:-}" && "${var_t3_source_control,,}" != "none" ]] || return 0
@@ -234,34 +182,22 @@ install_source_control_tools() {
       "https://cli.github.com/packages/githubcli-archive-keyring.gpg" \
       "https://cli.github.com/packages" \
       "stable" "main" "$(dpkg --print-architecture)"
-    msg_info "Installing GitHub CLI"
-    $STD apt-get install -y gh
-    msg_ok "Installed GitHub CLI"
+    install_packages_with_retry gh
     t3_source_control_configured=1
   fi
-
   if source_control_selected gitlab; then
-    install_gitlab_cli
+    fetch_and_deploy_gl_release "glab" "gitlab-org/cli" "binary"
     t3_source_control_configured=1
   fi
-
   if source_control_selected azure; then
     setup_deb822_repo "azure-cli" \
       "https://packages.microsoft.com/keys/microsoft.asc" \
       "https://packages.microsoft.com/repos/azure-cli/" \
       "bookworm" "main" "$(dpkg --print-architecture)"
-    msg_info "Installing Azure CLI"
-    $STD apt-get install -y azure-cli
-    msg_ok "Installed Azure CLI"
+    install_packages_with_retry azure-cli
     msg_info "Installing Azure DevOps extension"
     t3_exec /usr/bin/az extension add --name azure-devops
     msg_ok "Installed Azure DevOps extension"
-    t3_source_control_configured=1
-  fi
-
-  if source_control_selected bitbucket; then
-    configure_bitbucket_environment
-    msg_ok "Prepared Bitbucket environment configuration"
     t3_source_control_configured=1
   fi
 }
@@ -274,11 +210,10 @@ show_provider_login_commands() {
   echo -e "${INFO}${BOLD}${DGN}Provider Authentication${CL}"
   echo
   echo -e "${TAB}${YW}Selected provider CLIs are installed but not authenticated. Run these commands from the Proxmox host:${CL}"
-  echo -e "${TAB}${YW}After authentication, enable Cursor, Grok and OpenCode in T3 Code Settings if you selected them.${CL}"
+  echo -e "${TAB}${YW}After authentication, enable Grok and OpenCode in T3 Code Settings if you selected them.${CL}"
   echo -e "${TAB}${YW}Authentication commands may open a browser or require terminal input.${CL}"
   provider_selected codex && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'codex login'${CL}"
   provider_selected claude && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'claude auth login'${CL}"
-  provider_selected cursor && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'agent login'${CL}"
   provider_selected grok && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'grok login'${CL}"
   provider_selected opencode && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'opencode auth login'${CL}"
   msg_ok "Provider Authentication Instructions"
@@ -291,18 +226,11 @@ show_source_control_login_commands() {
   echo
   echo -e "${INFO}${BOLD}${DGN}Source Control Authentication${CL}"
   echo
-  echo -e "${TAB}${YW}Selected source-control integrations are installed or prepared but not authenticated. Run these commands from the Proxmox host:${CL}"
+  echo -e "${TAB}${YW}Selected source-control CLIs are installed but not authenticated. Run these commands from the Proxmox host:${CL}"
   echo -e "${TAB}${YW}Authentication is performed as the t3 user and is never done automatically.${CL}"
   source_control_selected github && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'gh auth login'${CL}"
   source_control_selected gitlab && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'glab auth login'${CL}"
   source_control_selected azure && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'az login'${CL}"
-  if source_control_selected bitbucket; then
-    echo -e "${TAB}${YW}Edit /etc/t3-code/source-control.env in CT ${CTID} and set either:${CL}"
-    echo -e "${TAB}${YW}T3CODE_BITBUCKET_ACCESS_TOKEN=your-access-token${CL}"
-    echo -e "${TAB}${YW}or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN.${CL}"
-    echo -e "${TAB}${YW}Then restart T3 Code:${CL}"
-    echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'systemctl --user restart t3code.service'${CL}"
-  fi
   msg_ok "Source Control Authentication Instructions"
 }
 
@@ -312,23 +240,26 @@ finish_t3_service_setup() {
 
   $STD loginctl enable-linger "$t3_user"
   if [[ ! -f "$t3_home/.config/systemd/user/t3code.service" ||
-    ! -f "$t3_home/.t3/runtime/service-launcher.mjs" ||
-    ! -f "$t3_home/.t3/runtime/service-state.json" ]]; then
+    ! -f "$t3_data/runtime/service-launcher.mjs" ||
+    ! -f "$t3_data/runtime/service-state.json" ]]; then
     return 1
   fi
 
-  installed_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  installed_version=$(jq -r '.activeVersion // empty' "$t3_data/runtime/service-state.json" 2>/dev/null || true)
   [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
   [[ -z "$expected_version" || "$installed_version" == "$expected_version" ]] || return 1
-  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
-  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/.install-complete" ]] || return 1
+  [[ -f "$t3_data/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
+  [[ -f "$t3_data/runtime/versions/${installed_version}/.install-complete" ]] || return 1
 
   t3_exec /usr/bin/systemctl --user daemon-reload
   t3_exec /usr/bin/systemctl --user enable t3code.service
 }
 
+var_t3_providers="${var_t3_providers//[[:space:]]/}"
+var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
+
 msg_info "Installing T3 Code"
-if ! t3_exec /usr/bin/npx --yes t3@latest service install; then
+if ! t3_exec /usr/bin/npx --yes t3@latest service install --base-dir "$t3_data"; then
   msg_warn "T3 could not enable lingering from the unprivileged user; completing service setup as root."
   if ! finish_t3_service_setup; then
     msg_error "T3 Code service installation failed"
@@ -348,6 +279,7 @@ cat <<EOF >"$t3_home/.config/systemd/user/t3code.service.d/10-network.conf"
 Environment=HOME=${t3_home}
 Environment=PATH=${t3_home}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=NPM_CONFIG_PREFIX=${t3_home}/.local
+Environment=T3CODE_HOME=${t3_data}
 Environment=T3CODE_HOST=0.0.0.0
 Environment=T3CODE_PORT=3773
 EOF
@@ -370,7 +302,7 @@ if [[ "${t3_providers_installed:-0}" -eq 1 || "${t3_source_control_configured:-0
   msg_ok "Refreshed T3 Integration Status"
 fi
 
-t3_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+t3_version=$(jq -r '.activeVersion // empty' "$t3_data/runtime/service-state.json" 2>/dev/null || true)
 if [[ ! "$t3_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   msg_error "Unable to determine the installed T3 Code version."
   exit 1
@@ -382,7 +314,7 @@ EOF
 msg_info "Generating Pairing URL"
 t3_pair_output=""
 for _ in {1..30}; do
-  if t3_pair_output=$(STD="" t3_exec /usr/bin/npx --yes "t3@${t3_version}" pair --base-dir "$t3_home/.t3" --ttl 1h 2>/dev/null); then
+  if t3_pair_output=$(STD="" t3_exec /usr/bin/npx --yes "t3@${t3_version}" pair --base-dir "$t3_data" --ttl 1h 2>/dev/null); then
     stop_spinner
     clear_line
     echo -e "${INFO}${YW}Generating Pairing URL${CL}"
@@ -392,7 +324,7 @@ for _ in {1..30}; do
   sleep 1
 done
 if [[ -z "$t3_pair_output" ]]; then
-  msg_warn "Could not generate a pairing URL automatically. Run this inside the container as the t3 user: npx --yes t3@${t3_version} pair --base-dir ${t3_home}/.t3 --ttl 1h"
+  msg_warn "Could not generate a pairing URL automatically. Run this inside the container as the t3 user: npx --yes t3@${t3_version} pair --base-dir ${t3_data} --ttl 1h"
 fi
 
 show_provider_login_commands

--- a/install/t3-code-install.sh
+++ b/install/t3-code-install.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: lukdz
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://t3.codes/ | Github: https://github.com/pingdotgg/t3code
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+t3_user="t3"
+t3_home="/home/${t3_user}"
+var_t3_providers="${var_t3_providers:-}"
+var_t3_providers="${var_t3_providers//[[:space:]]/}"
+var_t3_version_control="${var_t3_version_control:-git}"
+var_t3_version_control="${var_t3_version_control//[[:space:]]/}"
+var_t3_source_control="${var_t3_source_control:-none}"
+var_t3_source_control="${var_t3_source_control//[[:space:]]/}"
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  build-essential \
+  python3 \
+  dbus \
+  dbus-user-session \
+  libpam-systemd
+msg_ok "Installed Dependencies"
+
+if [[ ",${var_t3_version_control,,}," == *,git,* ]]; then
+  msg_info "Installing Git"
+  $STD apt-get install -y git
+  msg_ok "Installed Git"
+fi
+
+NODE_VERSION="24" setup_nodejs
+
+msg_info "Creating T3 User"
+if ! id "$t3_user" >/dev/null 2>&1; then
+  $STD useradd --create-home --user-group --home-dir "$t3_home" --shell /bin/bash "$t3_user"
+fi
+# T3 can execute provider agent commands, so keep its server and project work non-root.
+$STD passwd --lock "$t3_user"
+$STD chmod 750 "$t3_home"
+if ! grep -q '^export XDG_RUNTIME_DIR=' "$t3_home/.profile" 2>/dev/null; then
+  cat <<'EOF' >>"$t3_home/.profile"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+EOF
+fi
+if ! grep -q '^export PATH=' "$t3_home/.profile" 2>/dev/null; then
+  cat <<'EOF' >>"$t3_home/.profile"
+export PATH="$HOME/.local/bin:$PATH"
+EOF
+fi
+if ! grep -q '^export NPM_CONFIG_PREFIX=' "$t3_home/.profile" 2>/dev/null; then
+  cat <<'EOF' >>"$t3_home/.profile"
+export NPM_CONFIG_PREFIX="$HOME/.local"
+EOF
+fi
+chown "$t3_user:$t3_user" "$t3_home/.profile"
+chmod 640 "$t3_home/.profile"
+msg_ok "Created T3 User"
+
+t3_uid="$(id -u "$t3_user")"
+
+msg_info "Preparing T3 User Service"
+$STD systemctl start systemd-logind.service
+$STD loginctl enable-linger "$t3_user"
+$STD systemctl start "user-runtime-dir@${t3_uid}.service" "user@${t3_uid}.service"
+for _ in {1..30}; do
+  [[ -S "/run/user/${t3_uid}/bus" ]] && break
+  sleep 1
+done
+if [[ ! -S "/run/user/${t3_uid}/bus" ]]; then
+  msg_error "The T3 user service bus is unavailable. Ensure systemd user services are supported by this LXC."
+  exit 1
+fi
+msg_ok "Prepared T3 User Service"
+
+t3_exec() {
+  $STD runuser --user "$t3_user" -- env \
+    HOME="$t3_home" \
+    USER="$t3_user" \
+    LOGNAME="$t3_user" \
+    SHELL=/bin/bash \
+    PATH="$t3_home/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    XDG_RUNTIME_DIR="/run/user/${t3_uid}" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${t3_uid}/bus" \
+    NPM_CONFIG_PREFIX="$t3_home/.local" \
+    NPM_CONFIG_CACHE="$t3_home/.cache/npm" \
+    "$@"
+}
+
+fix_resource_monitor_permissions() {
+  local monitor
+  t3_resource_monitor_repaired=0
+  for monitor in "$t3_home"/.t3/runtime/versions/*/node_modules/t3/dist/resource-monitor/linux-*/t3-resource-monitor; do
+    [[ -f "$monitor" ]] || continue
+    if [[ ! -x "$monitor" ]]; then
+      chmod 755 "$monitor"
+      t3_resource_monitor_repaired=1
+    fi
+  done
+}
+
+provider_selected() {
+  local provider="${1,,}"
+  local selected=",${var_t3_providers,,},"
+  [[ "$selected" == *",${provider},"* ]]
+}
+
+install_npm_provider() {
+  local label="$1"
+  local package="$2"
+  msg_info "Installing ${label}"
+  t3_exec /usr/bin/npm install --global --prefix "$t3_home/.local" \
+    --allow-scripts="$package" "${package}@latest"
+  msg_ok "Installed ${label}"
+}
+
+install_selected_providers() {
+  t3_providers_installed=0
+  [[ -n "${var_t3_providers:-}" && "${var_t3_providers,,}" != "none" ]] || return 0
+
+  if provider_selected codex; then
+    install_npm_provider "Codex CLI" "@openai/codex"
+    t3_providers_installed=1
+  fi
+
+  if provider_selected claude; then
+    setup_deb822_repo "claude-code" \
+      "https://downloads.claude.ai/keys/claude-code.asc" \
+      "https://downloads.claude.ai/claude-code/apt/stable" \
+      "stable" "main"
+    msg_info "Installing Claude Code CLI"
+    $STD apt-get install -y claude-code
+    msg_ok "Installed Claude Code CLI"
+    t3_providers_installed=1
+  fi
+
+  if provider_selected cursor; then
+    msg_info "Installing Cursor Agent CLI"
+    t3_exec /bin/bash -c 'set -o pipefail; curl -fsSL https://cursor.com/install | bash'
+    msg_ok "Installed Cursor Agent CLI"
+    t3_providers_installed=1
+  fi
+
+  if provider_selected grok; then
+    install_npm_provider "Grok Build CLI" "@xai-official/grok"
+    t3_providers_installed=1
+  fi
+  if provider_selected opencode; then
+    install_npm_provider "OpenCode CLI" "opencode-ai"
+    t3_providers_installed=1
+  fi
+}
+
+source_control_selected() {
+  local provider="${1,,}"
+  local selected=",${var_t3_source_control,,},"
+  [[ "$selected" == *",${provider},"* ]]
+}
+
+install_gitlab_cli() {
+  local arch="$(dpkg --print-architecture)"
+  local release_url="https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest"
+  local package_url
+  package_url=$(curl -fsSL --retry 3 --retry-connrefused --connect-timeout 10 --max-time 30 "$release_url" |
+    jq -r --arg arch "$arch" '
+      (.tag_name | ltrimstr("v")) as $version |
+      .assets.links[] |
+      select(.name == ("glab_" + $version + "_linux_" + $arch + ".deb")) |
+      .url' | head -n 1)
+  [[ -n "$package_url" && "$package_url" != "null" ]] || {
+    msg_error "Could not find a GitLab CLI package for ${arch}."
+    return 1
+  }
+
+  local package_file
+  package_file=$(mktemp --suffix=.deb)
+  msg_info "Installing GitLab CLI"
+  if ! curl -fsSL --retry 3 --retry-connrefused --connect-timeout 10 --max-time 120 "$package_url" -o "$package_file"; then
+    rm -f "$package_file"
+    msg_error "Failed to download GitLab CLI."
+    return 1
+  fi
+  if ! $STD dpkg -i "$package_file"; then
+    $STD apt-get install -f -y
+  fi
+  rm -f "$package_file"
+  command -v glab >/dev/null 2>&1 || {
+    msg_error "GitLab CLI installation did not provide glab."
+    return 1
+  }
+  msg_ok "Installed GitLab CLI"
+}
+
+configure_bitbucket_environment() {
+  local env_dir="/etc/t3-code"
+  local env_file="${env_dir}/source-control.env"
+  mkdir -p "$env_dir"
+  if [[ ! -f "$env_file" ]]; then
+    cat <<'EOF' >"$env_file"
+# Bitbucket credentials for T3 Code. Set either the access token, or the
+# email/API-token pair, then restart the T3 Code user service.
+# T3CODE_BITBUCKET_ACCESS_TOKEN=
+# T3CODE_BITBUCKET_EMAIL=
+# T3CODE_BITBUCKET_API_TOKEN=
+EOF
+  fi
+  chown root:"$t3_user" "$env_file"
+  chmod 640 "$env_file"
+
+  mkdir -p "$t3_home/.config/systemd/user/t3code.service.d"
+  cat <<EOF >"$t3_home/.config/systemd/user/t3code.service.d/20-source-control.conf"
+[Service]
+EnvironmentFile=-${env_file}
+EOF
+  chown "$t3_user:$t3_user" \
+    "$t3_home/.config/systemd/user/t3code.service.d" \
+    "$t3_home/.config/systemd/user/t3code.service.d/20-source-control.conf"
+}
+
+install_source_control_tools() {
+  t3_source_control_configured=0
+  [[ -n "${var_t3_source_control:-}" && "${var_t3_source_control,,}" != "none" ]] || return 0
+
+  if source_control_selected github; then
+    setup_deb822_repo "github-cli" \
+      "https://cli.github.com/packages/githubcli-archive-keyring.gpg" \
+      "https://cli.github.com/packages" \
+      "stable" "main" "$(dpkg --print-architecture)"
+    msg_info "Installing GitHub CLI"
+    $STD apt-get install -y gh
+    msg_ok "Installed GitHub CLI"
+    t3_source_control_configured=1
+  fi
+
+  if source_control_selected gitlab; then
+    install_gitlab_cli
+    t3_source_control_configured=1
+  fi
+
+  if source_control_selected azure; then
+    setup_deb822_repo "azure-cli" \
+      "https://packages.microsoft.com/keys/microsoft.asc" \
+      "https://packages.microsoft.com/repos/azure-cli/" \
+      "bookworm" "main" "$(dpkg --print-architecture)"
+    msg_info "Installing Azure CLI"
+    $STD apt-get install -y azure-cli
+    msg_ok "Installed Azure CLI"
+    msg_info "Installing Azure DevOps extension"
+    t3_exec /usr/bin/az extension add --name azure-devops
+    msg_ok "Installed Azure DevOps extension"
+    t3_source_control_configured=1
+  fi
+
+  if source_control_selected bitbucket; then
+    configure_bitbucket_environment
+    msg_ok "Prepared Bitbucket environment configuration"
+    t3_source_control_configured=1
+  fi
+}
+
+show_provider_login_commands() {
+  [[ "${t3_providers_installed:-0}" -eq 1 ]] || return 0
+
+  stop_spinner
+  echo
+  echo -e "${INFO}${BOLD}${DGN}Provider Authentication${CL}"
+  echo
+  echo -e "${TAB}${YW}Selected provider CLIs are installed but not authenticated. Run these commands from the Proxmox host:${CL}"
+  echo -e "${TAB}${YW}After authentication, enable Cursor, Grok and OpenCode in T3 Code Settings if you selected them.${CL}"
+  echo -e "${TAB}${YW}Authentication commands may open a browser or require terminal input.${CL}"
+  provider_selected codex && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'codex login'${CL}"
+  provider_selected claude && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'claude auth login'${CL}"
+  provider_selected cursor && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'agent login'${CL}"
+  provider_selected grok && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'grok login'${CL}"
+  provider_selected opencode && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'opencode auth login'${CL}"
+  msg_ok "Provider Authentication Instructions"
+}
+
+show_source_control_login_commands() {
+  [[ "${t3_source_control_configured:-0}" -eq 1 ]] || return 0
+
+  stop_spinner
+  echo
+  echo -e "${INFO}${BOLD}${DGN}Source Control Authentication${CL}"
+  echo
+  echo -e "${TAB}${YW}Selected source-control integrations are installed or prepared but not authenticated. Run these commands from the Proxmox host:${CL}"
+  echo -e "${TAB}${YW}Authentication is performed as the t3 user and is never done automatically.${CL}"
+  source_control_selected github && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'gh auth login'${CL}"
+  source_control_selected gitlab && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'glab auth login'${CL}"
+  source_control_selected azure && echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'az login'${CL}"
+  if source_control_selected bitbucket; then
+    echo -e "${TAB}${YW}Edit /etc/t3-code/source-control.env in CT ${CTID} and set either:${CL}"
+    echo -e "${TAB}${YW}T3CODE_BITBUCKET_ACCESS_TOKEN=your-access-token${CL}"
+    echo -e "${TAB}${YW}or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN.${CL}"
+    echo -e "${TAB}${YW}Then restart T3 Code:${CL}"
+    echo -e "${TAB}${BGN}pct exec ${CTID} -- su - t3 -c 'systemctl --user restart t3code.service'${CL}"
+  fi
+  msg_ok "Source Control Authentication Instructions"
+}
+
+finish_t3_service_setup() {
+  local expected_version="${1:-}"
+  local installed_version
+
+  $STD loginctl enable-linger "$t3_user"
+  if [[ ! -f "$t3_home/.config/systemd/user/t3code.service" ||
+    ! -f "$t3_home/.t3/runtime/service-launcher.mjs" ||
+    ! -f "$t3_home/.t3/runtime/service-state.json" ]]; then
+    return 1
+  fi
+
+  installed_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+  [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  [[ -z "$expected_version" || "$installed_version" == "$expected_version" ]] || return 1
+  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/node_modules/t3/dist/bin.mjs" ]] || return 1
+  [[ -f "$t3_home/.t3/runtime/versions/${installed_version}/.install-complete" ]] || return 1
+
+  t3_exec /usr/bin/systemctl --user daemon-reload
+  t3_exec /usr/bin/systemctl --user enable t3code.service
+}
+
+msg_info "Installing T3 Code"
+if ! t3_exec /usr/bin/npx --yes t3@latest service install; then
+  msg_warn "T3 could not enable lingering from the unprivileged user; completing service setup as root."
+  if ! finish_t3_service_setup; then
+    msg_error "T3 Code service installation failed"
+    exit 1
+  fi
+fi
+msg_ok "Installed T3 Code"
+fix_resource_monitor_permissions
+if [[ "$t3_resource_monitor_repaired" -eq 1 ]]; then
+  msg_ok "Repaired T3 resource monitor permissions"
+fi
+
+msg_info "Configuring Network Access"
+mkdir -p "$t3_home/.config/systemd/user/t3code.service.d"
+cat <<EOF >"$t3_home/.config/systemd/user/t3code.service.d/10-network.conf"
+[Service]
+Environment=HOME=${t3_home}
+Environment=PATH=${t3_home}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NPM_CONFIG_PREFIX=${t3_home}/.local
+Environment=T3CODE_HOST=0.0.0.0
+Environment=T3CODE_PORT=3773
+EOF
+chown "$t3_user:$t3_user" \
+  "$t3_home/.config/systemd/user/t3code.service.d" \
+  "$t3_home/.config/systemd/user/t3code.service.d/10-network.conf"
+t3_exec /usr/bin/systemctl --user daemon-reload
+t3_exec /usr/bin/systemctl --user restart t3code.service
+if ! t3_exec /usr/bin/systemctl --user is-active --quiet t3code.service; then
+  msg_error "T3 Code service failed to start"
+  exit 1
+fi
+msg_ok "Configured Network Access"
+
+install_selected_providers
+install_source_control_tools
+if [[ "${t3_providers_installed:-0}" -eq 1 || "${t3_source_control_configured:-0}" -eq 1 ]]; then
+  msg_info "Refreshing T3 Integration Status"
+  t3_exec /usr/bin/systemctl --user restart t3code.service
+  msg_ok "Refreshed T3 Integration Status"
+fi
+
+t3_version=$(jq -r '.activeVersion // empty' "$t3_home/.t3/runtime/service-state.json" 2>/dev/null || true)
+if [[ ! "$t3_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  msg_error "Unable to determine the installed T3 Code version."
+  exit 1
+fi
+cat <<EOF >/root/.t3-code
+${t3_version}
+EOF
+
+msg_info "Generating Pairing URL"
+t3_pair_output=""
+for _ in {1..30}; do
+  if t3_pair_output=$(STD="" t3_exec /usr/bin/npx --yes "t3@${t3_version}" pair --base-dir "$t3_home/.t3" --ttl 1h 2>/dev/null); then
+    stop_spinner
+    clear_line
+    echo -e "${INFO}${YW}Generating Pairing URL${CL}"
+    printf '%s\n' "$t3_pair_output"
+    break
+  fi
+  sleep 1
+done
+if [[ -z "$t3_pair_output" ]]; then
+  msg_warn "Could not generate a pairing URL automatically. Run this inside the container as the t3 user: npx --yes t3@${t3_version} pair --base-dir ${t3_home}/.t3 --ttl 1h"
+fi
+
+show_provider_login_commands
+show_source_control_login_commands
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/t3-code.json
+++ b/json/t3-code.json
@@ -32,21 +32,21 @@
       "label": "Provider CLIs",
       "type": "text",
       "default": "",
-      "help": "Optional comma-separated values: codex, claude, grok, opencode. Authentication is always manual. Cursor is supported by T3 Code but is not installed automatically because its upstream installer is not compatible with community-scripts helper requirements."
+      "help": "Optional comma-separated values: codex, claude, grok, opencode. Advanced installs show a selection menu. Authentication is always manual. Cursor is supported by T3 Code but is not installed automatically because its upstream installer is not compatible with community-scripts helper requirements."
     },
     {
       "name": "var_t3_version_control",
       "label": "Version Control",
       "type": "text",
       "default": "git",
-      "help": "Set to none to skip Git installation."
+      "help": "Advanced installs show a selection menu. Set to none to skip Git installation."
     },
     {
       "name": "var_t3_source_control",
       "label": "Source Control CLIs",
       "type": "text",
       "default": "",
-      "help": "Optional comma-separated values: github, gitlab, azure. Authentication is always manual."
+      "help": "Optional comma-separated values: github, gitlab, azure. Advanced installs show a selection menu. Authentication is always manual."
     }
   ],
   "default_credentials": {

--- a/json/t3-code.json
+++ b/json/t3-code.json
@@ -10,13 +10,13 @@
   "documentation": "https://github.com/pingdotgg/t3code/blob/main/docs/user/install.md",
   "website": "https://t3.codes/",
   "repository": "https://github.com/pingdotgg/t3code",
-  "logo": "https://t3.codes/icon.webp",
-  "description": "T3 Code is an open-source control surface for coding agents. It provides a web interface for orchestrating local Claude Code, Codex, Cursor, Grok Build and OpenCode sessions from remote devices.",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/t3-code.webp",
+  "description": "T3 Code is an open-source control surface for coding agents. It provides a web interface for orchestrating Claude Code, Codex, Grok Build and OpenCode sessions from remote devices.",
   "install_methods": [
     {
       "type": "default",
       "script": "ct/t3-code.sh",
-      "config_path": "",
+      "config_path": "/opt/t3-code_data/userdata/settings.json",
       "resources": {
         "cpu": 4,
         "ram": 4096,
@@ -32,21 +32,21 @@
       "label": "Provider CLIs",
       "type": "text",
       "default": "",
-      "help": "Optional comma-separated values: codex, claude, cursor, grok, opencode. Advanced installs show a multi-select menu with none selected by default. Authentication is always manual."
+      "help": "Optional comma-separated values: codex, claude, grok, opencode. Authentication is always manual. Cursor is supported by T3 Code but is not installed automatically because its upstream installer is not compatible with community-scripts helper requirements."
     },
     {
       "name": "var_t3_version_control",
       "label": "Version Control",
       "type": "text",
       "default": "git",
-      "help": "Git is selected by default in Advanced setup. Jujutsu support is coming soon. Set to none to skip Git installation."
+      "help": "Set to none to skip Git installation."
     },
     {
       "name": "var_t3_source_control",
-      "label": "Source Control Providers",
+      "label": "Source Control CLIs",
       "type": "text",
       "default": "",
-      "help": "Optional comma-separated values: github, gitlab, azure, bitbucket. Advanced installs show a multi-select menu with none selected by default. Authentication is always manual; Bitbucket uses T3CODE_BITBUCKET_ACCESS_TOKEN or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN."
+      "help": "Optional comma-separated values: github, gitlab, azure. Authentication is always manual."
     }
   ],
   "default_credentials": {
@@ -55,23 +55,19 @@
   },
   "notes": [
     {
-      "text": "The service runs as the dedicated non-root t3 user. Add projects and authenticate provider CLIs as that user; provider authentication is never performed automatically.",
+      "text": "The service runs as the dedicated non-root t3 user. T3 Code data and runtime state are stored in /opt/t3-code_data so updates do not remove user data.",
       "type": "info"
     },
     {
-      "text": "During Advanced setup, optionally select provider CLIs from the multi-select menu. All providers are unselected by default. Selected CLIs are installed for the t3 user but are not authenticated automatically; the required pct exec commands are printed after installation.",
+      "text": "Provider and source-control CLIs are optional. Selected CLIs are installed for the t3 user but are not authenticated automatically; the required pct exec commands are printed after installation.",
       "type": "info"
     },
     {
-      "text": "After provider installation, the T3 Code provider health check may initially show an unauthenticated or disabled state. Authenticate selected providers with the pct exec commands printed by the installer, then refresh provider status in T3 Code. Cursor, Grok and OpenCode are disabled by default in T3 Code and must be enabled in Settings.",
+      "text": "Cursor is supported by T3 Code but is not installed by this script because its upstream installer is a remote shell script. Install Cursor CLI separately for the t3 user if required.",
       "type": "info"
     },
     {
-      "text": "During Advanced setup, optionally select GitHub, GitLab, Azure DevOps, or Bitbucket under Source Control Providers. No source-control integrations are selected by default. GitHub installs gh, GitLab installs glab, Azure DevOps installs az with the azure-devops extension, and Bitbucket uses T3CODE_BITBUCKET_ACCESS_TOKEN or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN. Authentication is always manual.",
-      "type": "info"
-    },
-    {
-      "text": "A one-time pairing URL with a one-hour lifetime is generated and printed at the end of installation. Generate another one inside the container with npx --yes t3@latest pair --base-dir /home/t3/.t3 --ttl 1h. Treat pairing links as passwords.",
+      "text": "A one-time pairing URL with a one-hour lifetime is generated and printed at the end of installation. Generate another one inside the container with npx --yes t3@latest pair --base-dir /opt/t3-code_data --ttl 1h. Treat pairing links as passwords.",
       "type": "info"
     },
     {

--- a/json/t3-code.json
+++ b/json/t3-code.json
@@ -1,0 +1,86 @@
+{
+  "name": "T3 Code",
+  "slug": "t3-code",
+  "categories": [20],
+  "date_created": "2026-08-22",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 3773,
+  "documentation": "https://github.com/pingdotgg/t3code/blob/main/docs/user/install.md",
+  "website": "https://t3.codes/",
+  "repository": "https://github.com/pingdotgg/t3code",
+  "logo": "https://t3.codes/icon.webp",
+  "description": "T3 Code is an open-source control surface for coding agents. It provides a web interface for orchestrating local Claude Code, Codex, Cursor, Grok Build and OpenCode sessions from remote devices.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/t3-code.sh",
+      "config_path": "",
+      "resources": {
+        "cpu": 4,
+        "ram": 4096,
+        "hdd": 20,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "app_vars": [
+    {
+      "name": "var_t3_providers",
+      "label": "Provider CLIs",
+      "type": "text",
+      "default": "",
+      "help": "Optional comma-separated values: codex, claude, cursor, grok, opencode. Advanced installs show a multi-select menu with none selected by default. Authentication is always manual."
+    },
+    {
+      "name": "var_t3_version_control",
+      "label": "Version Control",
+      "type": "text",
+      "default": "git",
+      "help": "Git is selected by default in Advanced setup. Jujutsu support is coming soon. Set to none to skip Git installation."
+    },
+    {
+      "name": "var_t3_source_control",
+      "label": "Source Control Providers",
+      "type": "text",
+      "default": "",
+      "help": "Optional comma-separated values: github, gitlab, azure, bitbucket. Advanced installs show a multi-select menu with none selected by default. Authentication is always manual; Bitbucket uses T3CODE_BITBUCKET_ACCESS_TOKEN or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN."
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The service runs as the dedicated non-root t3 user. Add projects and authenticate provider CLIs as that user; provider authentication is never performed automatically.",
+      "type": "info"
+    },
+    {
+      "text": "During Advanced setup, optionally select provider CLIs from the multi-select menu. All providers are unselected by default. Selected CLIs are installed for the t3 user but are not authenticated automatically; the required pct exec commands are printed after installation.",
+      "type": "info"
+    },
+    {
+      "text": "After provider installation, the T3 Code provider health check may initially show an unauthenticated or disabled state. Authenticate selected providers with the pct exec commands printed by the installer, then refresh provider status in T3 Code. Cursor, Grok and OpenCode are disabled by default in T3 Code and must be enabled in Settings.",
+      "type": "info"
+    },
+    {
+      "text": "During Advanced setup, optionally select GitHub, GitLab, Azure DevOps, or Bitbucket under Source Control Providers. No source-control integrations are selected by default. GitHub installs gh, GitLab installs glab, Azure DevOps installs az with the azure-devops extension, and Bitbucket uses T3CODE_BITBUCKET_ACCESS_TOKEN or T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN. Authentication is always manual.",
+      "type": "info"
+    },
+    {
+      "text": "A one-time pairing URL with a one-hour lifetime is generated and printed at the end of installation. Generate another one inside the container with npx --yes t3@latest pair --base-dir /home/t3/.t3 --ttl 1h. Treat pairing links as passwords.",
+      "type": "info"
+    },
+    {
+      "text": "The service listens on all interfaces at TCP port 3773 over HTTP. Restrict access to a trusted network or place it behind HTTPS before exposing it beyond your private network.",
+      "type": "warning"
+    },
+    {
+      "text": "The arm64 path has not been tested yet. Native node-pty dependencies may require a successful build on the target architecture.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

Adds a T3 Code LXC template for ProxmoxVED. T3 Code is installed bare-metal with Node.js 24 and runs as a dedicated non-root `t3` user under a systemd user service.

The implementation follows the ProxmoxVED script conventions:

- Uses `setup_nodejs`, `ensure_dependencies`, `install_packages_with_retry`, `setup_deb822_repo`, and the GitLab release helper.
- Stores T3 Code runtime and userdata in `/opt/t3-code_data`, outside the application home.
- Migrates legacy `/home/t3/.t3` data on update and rejects ambiguous dual-directory state.
- Restores provider, version-control, and source-control selection menus in Advanced mode through the generic hook from the related core PR: https://github.com/community-scripts/core/pull/8
- Preserves exported `var_*` values for unattended installs and app-default configuration.
- Generates one-hour pairing URLs.
- Supports optional Codex, Claude, Grok, OpenCode, GitHub CLI, GitLab CLI, and Azure CLI installation. Authentication remains manual.
- Does not use Docker, `apt-get`, `git pull`, custom release download logic, remote shell installers, or custom credential files.
- Cursor is documented but not installed automatically because its upstream installer is a remote shell script and cannot be used under the project rules.

The Advanced selection menus are implemented through `advanced_settings_app_configure` and `advanced_settings_app_summary`; no core function is replaced or parsed. Supplied `var_*` values remain available for non-interactive installs, while Advanced mode displays the current selections and allows changing them.

AI assistance disclosure: refactored and reviewed with OpenCode, model `gpt-5.6-luna`, reasoning level `high`, using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md).

## 🔗 Related PR / Issue

Link: https://github.com/community-scripts/core/pull/8

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Static validation passed; installation and Grok provider authentication were tested in an LXC.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use supported release/update mechanisms instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

Validation completed:

- `bash -n` passed for all 277 repository shell scripts.
- `jq empty` passed for all 103 JSON metadata files.
- Prohibited-pattern checks passed for the T3 files.
- T3 Code installation and Grok provider authentication were tested in an LXC before this refactor.
- The core hook branch passes engine syntax, prefetch, API, and whitespace checks.
- Test both branches together before the core hook merges:

```bash
export COMMUNITY_SCRIPTS_URL="https://raw.githubusercontent.com/lukdz/ProxmoxVED/feat/t3-code"
export COMMUNITY_SCRIPTS_CORE_URL="https://raw.githubusercontent.com/lukdz/core/feat/advanced-settings-hook"
bash -c "$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/ct/t3-code.sh")"
```

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [X] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [X] The application has **600+ GitHub stars**
- [X] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source

- Website: https://t3.codes/
- Repository: https://github.com/pingdotgg/t3code
- Installation documentation: https://github.com/pingdotgg/t3code/blob/main/docs/user/install.md
