### PR TITLE
feat: add NextDNS minimal Debian LXC

### DIFF
--- a/ct/nextdns.sh
+++ b/ct/nextdns.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nick Berardi (nberardi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://nextdns.io | https://github.com/nextdns/nextdns
+
+APP="NextDNS"
+var_tags="${var_tags:-dns;adblock;network}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-2}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -x /usr/bin/nextdns ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  $STD apt update
+  $STD apt install -y nextdns
+  msg_ok "Updated ${APP}"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}NextDNS is installed but not configured yet.${CL}"
+echo -e "${INFO}${YW}Inside the container, run:${CL}"
+echo -e "${TAB}${DEFAULT}sudo nextdns install \\${CL}"
+echo -e "${TAB}${DEFAULT}  -profile <your profile id> \\${CL}"
+echo -e "${TAB}${DEFAULT}  -report-client-info \\${CL}"
+echo -e "${TAB}${DEFAULT}  -setup-router${CL}"
+echo -e "${INFO}${YW}Get your profile ID from: https://my.nextdns.io${CL}"
+echo -e "${INFO}${YW}Container IP: ${BGN}${IP}${CL}"

--- a/install/nextdns-install.sh
+++ b/install/nextdns-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nick Berardi (nberardi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://nextdns.io | https://github.com/nextdns/nextdns
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+setup_deb822_repo \
+  "nextdns" \
+  "https://repo.nextdns.io/nextdns.gpg" \
+  "https://repo.nextdns.io/deb" \
+  "stable" \
+  "main"
+
+msg_info "Installing NextDNS"
+$STD apt install -y nextdns
+msg_ok "Installed NextDNS"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/nextdns.json
+++ b/json/nextdns.json
@@ -1,0 +1,53 @@
+{
+  "name": "NextDNS",
+  "slug": "nextdns",
+  "categories": [
+    5
+  ],
+  "date_created": "2026-08-23",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/nextdns/nextdns/wiki",
+  "website": "https://nextdns.io/",
+  "repository": "https://github.com/nextdns/nextdns",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/nextdns.webp",
+  "description": "NextDNS is a DNS-over-HTTPS (DoH) client and resolver that blocks ads, trackers and malware using cloud-managed profiles. This script installs a minimal Debian LXC with the official NextDNS CLI package from the NextDNS apt repository; you configure your profile after install.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/nextdns.sh",
+      "config_path": "/etc/nextdns.conf",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 2,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The package is installed but not activated. After the container is created, run inside it: sudo nextdns install -profile <your profile id> -report-client-info -setup-router",
+      "type": "warning"
+    },
+    {
+      "text": "Create or copy your profile ID from https://my.nextdns.io before configuring the client.",
+      "type": "info"
+    },
+    {
+      "text": "Router mode (-setup-router) makes this LXC the DNS server for your network. Point DHCP clients at the container IP (shown after install), or set it as the upstream DNS on your router.",
+      "type": "info"
+    },
+    {
+      "text": "Updates use the official NextDNS apt repository (repo.nextdns.io). Run the container update script or apt upgrade inside the LXC.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a minimal Debian 13 LXC script that installs the official **NextDNS CLI** from `repo.nextdns.io`
- Leaves profile activation to the user (no profile ID required during create)
- Includes CT + install + JSON metadata for ProxmoxVED review

## Motivation

NextDNS is a common home-lab DNS-over-HTTPS client. A dedicated minimal LXC matches existing Adblock and DNS scripts (Blocky, AdGuard, unbound) and follows the [Debian-based install wiki](https://github.com/nextdns/nextdns/wiki/Debian-Based-Distribution).

## Changes

| File | Role |
| --- | --- |
| `ct/nextdns.sh` | Host-side LXC create (1 CPU / 512 MB / 2 GB disk, Debian 13, unprivileged) + apt-based `update_script` |
| `install/nextdns-install.sh` | Adds NextDNS deb822 apt repo via `setup_deb822_repo`, installs `nextdns` package |
| `json/nextdns.json` | Metadata (category **5** Adblock and DNS), post-install notes |

### Post-install (printed after create + in JSON notes)

```bash
sudo nextdns install \
  -profile <your profile id> \
  -report-client-info \
  -setup-router
```

Profile ID: https://my.nextdns.io

## Test Plan

- [x] Scripts follow current ProxmoxVED / `AGENTS.md` patterns (`core/build.func` bootstrap, `setup_deb822_repo`, `$STD apt`, `motd_ssh` / `customize` / `cleanup_lxc`)
- [x] `bash -n` syntax check on ct + install scripts
- [x] JSON validates
- [x] Independent pre-commit code review (no security/logic blockers)
- [ ] Full create run on a Proxmox host against this fork branch (not available in contributor CI environment)
- [ ] After create: run `nextdns install` with a real profile and confirm DNS on port 53 / `nextdns status`

## Notes for Reviewers

- Package install only — `nextdns install` needs a user profile ID, so configuration is intentional post-setup (same idea as Cloudflared-style install binary, configure later).
- `config_path` is `/etc/nextdns.conf` (systemd default: `/etc/` + service name + `.conf`), created when the user runs `nextdns install`.
- `var_arm64` left unset (ask) — arm64 packages exist upstream but were not verified on arm64 hardware here.
- Resources kept minimal for a DNS client LXC.
