### PR TITLE
feat: add NextDNS minimal Debian LXC

### DIFF
--- a/ct/nextdns.sh
+++ b/ct/nextdns.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nick Berardi (nberardi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://nextdns.io | https://github.com/nextdns/nextdns
+
+APP="NextDNS"
+var_tags="${var_tags:-dns;adblock;network}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-2}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+var_unprivileged="${var_unprivileged:-1}"
+export var_nextdns_profile="${var_nextdns_profile:-}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -x /usr/bin/nextdns ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  $STD apt update
+  $STD apt install -y nextdns
+  msg_ok "Updated ${APP}"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}NextDNS is configured and serving DNS on:${CL}"
+echo -e "${GATEWAY}${BGN}${IP}:53${CL} ${YW}(TCP/UDP)${CL}"
+echo -e "${INFO}${YW}Profiles are managed at: https://my.nextdns.io${CL}"
+echo -e "${INFO}${YW}Point DHCP clients or your router upstream DNS at the container IP.${CL}"

--- a/install/nextdns-install.sh
+++ b/install/nextdns-install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nick Berardi (nberardi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://nextdns.io | https://github.com/nextdns/nextdns
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+setup_deb822_repo \
+  "nextdns" \
+  "https://repo.nextdns.io/nextdns.gpg" \
+  "https://repo.nextdns.io/deb" \
+  "stable" \
+  "main"
+
+msg_info "Installing NextDNS"
+$STD apt install -y nextdns
+msg_ok "Installed NextDNS"
+
+if [[ -z "${var_nextdns_profile:-}" ]]; then
+  echo -e "${INFO}${YW}Get your profile ID from: https://my.nextdns.io${CL}"
+  read -r -p "${TAB3}NextDNS Profile ID: " var_nextdns_profile
+fi
+var_nextdns_profile="${var_nextdns_profile//[[:space:]]/}"
+if [[ -z "${var_nextdns_profile}" ]]; then
+  msg_error "NextDNS Profile ID is required (set var_nextdns_profile or enter it when prompted)"
+  exit 1
+fi
+
+msg_info "Configuring NextDNS"
+nextdns install \
+  -profile "${var_nextdns_profile}" \
+  -report-client-info \
+  -setup-router
+msg_ok "Configured NextDNS (profile ${var_nextdns_profile})"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/nextdns.json
+++ b/json/nextdns.json
@@ -1,0 +1,66 @@
+{
+  "name": "NextDNS",
+  "slug": "nextdns",
+  "categories": [
+    5
+  ],
+  "date_created": "2026-08-23",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/nextdns/nextdns/wiki",
+  "website": "https://nextdns.io/",
+  "repository": "https://github.com/nextdns/nextdns",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/nextdns.webp",
+  "description": "NextDNS is a DNS-over-HTTPS (DoH) client and resolver that blocks ads, trackers and malware using cloud-managed profiles. This script installs a minimal Debian LXC with the official NextDNS CLI from the NextDNS apt repository, prompts for your profile ID, and configures router mode so DNS is served on TCP/UDP port 53.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/nextdns.sh",
+      "config_path": "/etc/nextdns.conf",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 2,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "app_vars": [
+    {
+      "name": "var_nextdns_profile",
+      "label": "NextDNS Profile ID",
+      "type": "text",
+      "required": true,
+      "help": "From https://my.nextdns.io — used with nextdns install -profile … -report-client-info -setup-router"
+    }
+  ],
+  "notes": [
+    {
+      "text": "During install you will be asked for your NextDNS profile ID (or pass var_nextdns_profile). The script runs: nextdns install -profile <id> -report-client-info -setup-router",
+      "type": "info"
+    },
+    {
+      "text": "Create or copy your profile ID from https://my.nextdns.io before running the script.",
+      "type": "info"
+    },
+    {
+      "text": "After install, NextDNS listens on TCP/UDP port 53. Point DHCP clients at the container IP:53, or set the container as upstream DNS on your router. There is no local web UI (profiles are managed at my.nextdns.io).",
+      "type": "info"
+    },
+    {
+      "text": "Router mode (-setup-router) makes this LXC the DNS server for your network.",
+      "type": "info"
+    },
+    {
+      "text": "Updates use the official NextDNS apt repository (repo.nextdns.io). Run the container update script or apt upgrade inside the LXC.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.**

## ✍️ Description  
Adds a minimal Debian 13 LXC for [NextDNS](https://nextdns.io) CLI:

- Installs the official package from `repo.nextdns.io` via `setup_deb822_repo`
- Prompts for the NextDNS Profile ID during install (or accepts `var_nextdns_profile` for unattended runs)
- Runs `nextdns install -profile <id> -report-client-info -setup-router` so the CT is fully configured when setup finishes
- Serves DNS on TCP/UDP port 53 (no local web UI; profiles managed at https://my.nextdns.io)
- Resources: 1 CPU / 512 MB RAM / 2 GB disk — category 5 (Adblock and DNS)

## 🔗 Related PR / Issue  

Link: N/A (new script)

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [x] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**  
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**  
- [x] **No hardcoded credentials**  
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [x] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)  

Test on Proxmox:

```bash
COMMUNITY_SCRIPTS_URL=https://raw.githubusercontent.com/nberardi/ProxmoxVED/feat/nextdns-lxc \
bash -c "$(curl -fsSL https://raw.githubusercontent.com/nberardi/ProxmoxVED/feat/nextdns-lxc/ct/nextdns.sh)"
```

Unattended profile: set `var_nextdns_profile=<id>` for the run.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.  
> Pull requests that do not meet these requirements may be closed without review.
- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- https://nextdns.io/
- https://github.com/nextdns/nextdns
- https://github.com/nextdns/nextdns/wiki/Debian-Based-Distribution
- https://repo.nextdns.io/
