### PR TITLE
add: tvheadend

### DIFF
--- a/ct/tvheadend.sh
+++ b/ct/tvheadend.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nicolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://tvheadend.org/ | Github: https://github.com/tvheadend/tvheadend
+
+APP="Tvheadend"
+var_tags="${var_tags:-media;pvr;tv;dvr}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+
+export var_admin_user="${var_admin_user:-admin}"
+export var_admin_pass="${var_admin_pass:-$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /var/lib/tvheadend ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  $STD apt update
+  $STD apt install -y tvheadend
+  msg_ok "Updated ${APP}"
+
+  msg_info "Restarting Service"
+  systemctl restart tvheadend
+  msg_ok "Restarted Service"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:9981${CL}"
+echo -e "${INFO}${YW}Admin Username: ${var_admin_user}${CL}"
+echo -e "${INFO}${YW}Admin Password: ${var_admin_pass}${CL}"

--- a/install/tvheadend-install.sh
+++ b/install/tvheadend-install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nicolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://tvheadend.org/ | Github: https://github.com/tvheadend/tvheadend
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+setup_deb822_repo \
+  "tvheadend" \
+  "https://dl.cloudsmith.io/public/tvheadend/tvheadend/gpg.C6CC06BD69B430C6.key" \
+  "https://dl.cloudsmith.io/public/tvheadend/tvheadend/deb/debian" \
+  "$(get_os_info codename)" \
+  "main"
+
+msg_info "Installing Tvheadend"
+echo "tvheadend tvheadend/admin_username string ${var_admin_user}" | debconf-set-selections
+echo "tvheadend tvheadend/admin_password password ${var_admin_pass}" | debconf-set-selections
+$STD apt install -y tvheadend
+msg_ok "Installed Tvheadend"
+
+msg_info "Starting Service"
+systemctl enable -q --now tvheadend
+msg_ok "Started Service"
+
+msg_info "Saving Credentials"
+cat <<EOF >~/tvheadend.creds
+Tvheadend Admin Credentials
+Username: ${var_admin_user}
+Password: ${var_admin_pass}
+EOF
+msg_ok "Saved Credentials"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/tvheadend.json
+++ b/json/tvheadend.json
@@ -1,0 +1,47 @@
+{
+  "name": "Tvheadend",
+  "slug": "tvheadend",
+  "categories": [13],
+  "date_created": "2026-08-24",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 9981,
+  "documentation": "https://docs.tvheadend.org",
+  "website": "https://tvheadend.org/",
+  "repository": "https://github.com/tvheadend/tvheadend",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/tvheadend.webp",
+  "description": "Tvheadend is a TV streaming server and Digital Video Recorder for Linux, supporting DVB-S/S2, DVB-C, DVB-T/T2, ATSC, IPTV, SAT>IP and HDHomeRun as input sources, with HTSP and HTTP streaming output.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/tvheadend.sh",
+      "config_path": "/var/lib/tvheadend",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": "auto-generated"
+  },
+  "notes": [
+    {
+      "text": "The admin account is created by the Debian package itself during install and cannot be changed from within Tvheadend afterwards — only by re-running the install with new var_admin_user/var_admin_pass values.",
+      "type": "info"
+    },
+    {
+      "text": "IPTV, SAT>IP and HDHomeRun (network) sources work without extra container configuration. A physical DVB/USB tuner requires passing the device through to the container yourself (e.g. bind-mounting /dev/dvb) — this script does not automate hardware passthrough.",
+      "type": "info"
+    }
+  ],
+  "app_vars": [
+    { "name": "var_admin_user", "label": "Admin Username", "type": "text", "default": "admin" },
+    { "name": "var_admin_pass", "label": "Admin Password", "type": "password", "secret": true }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.**

## ✍️ Description

Adds Tvheadend, a TV streaming server and DVR for Linux (DVB-S/S2, DVB-C,
DVB-T/T2, ATSC, IPTV, SAT>IP, HDHomeRun sources; HTSP/HTTP output).

Built primarily with AI assistance (Claude Sonnet 5, standard reasoning
effort), following `AGENTS.md` and `.github/agents/pve-script-creator.agent.md`.
The output was reviewed and corrected by the author across several real
install/update runs on a live Proxmox VE 9.2.6 host — not just syntax-checked.

Two things worth a reviewer's attention:

- **Distribution model**: Tvheadend isn't distributed via GitHub releases —
  it ships through its own Cloudsmith-hosted APT repository. The install
  script uses `setup_deb822_repo` + `apt install`, and updates are a plain
  `apt update && apt install -y tvheadend`, matching the pattern already used
  by `elasticsearch.sh`/`nomad.sh` in this repo for the same kind of
  vendor-repo distribution.
- **Debconf credentials**: the Debian package itself prompts for an admin
  username/password via debconf during install (the account can't be changed
  from inside Tvheadend afterwards). Under this project's noninteractive
  install, that prompt would otherwise be silently skipped and leave a
  **blank, unusable** superuser account — caught by actually logging in after
  a real install, not by any static check. The script preseeds debconf with
  `var_admin_user`/`var_admin_pass` (defaults: `admin` / auto-generated) so
  the account works immediately; credentials are saved to `~/tvheadend.creds`
  and echoed once at the end of setup.

## 🔗 Related PR / Issue

This PR addresses the existing script request: [Tvheadend LXC #1440](https://github.com/community-scripts/ProxmoxVE/discussions/1440).

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

Tested on a live Proxmox VE 9.2.6 host, from a local checkout and via the
public-fork `curl` one-liner (`docs/guides/source-origin.md` variant 1),
including a fresh install and a re-run of the update path. Login to the web
UI verified with the generated credentials each time.

Official release tarballs: Tvheadend has essentially no active GitHub
Releases history (one tag, from 2017). I checked that requirement below on
the basis that its real official distribution — the Cloudsmith APT repository
this script installs from — is versioned and reproducible the same way a
release tarball would be, just not hosted as a GitHub release. Flagging this
explicitly so a reviewer can make their own call rather than assuming I
overlooked it.

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [X] The application is **at least 6 months old**
- [X] The application is **actively maintained**
- [X] The application has **600+ GitHub stars**
- [X] Official **release tarballs** are published
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- Upstream: https://github.com/tvheadend/tvheadend
- Website / docs: https://tvheadend.org/ · https://docs.tvheadend.org
- Package repository: https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/

