### PR TITLE
add: teamspeak

### DIFF
--- a/ct/teamspeak.sh
+++ b/ct/teamspeak.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nicolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.teamspeak.com/
+
+APP="TeamSpeak"
+var_tags="${var_tags:-voice;chat;communication}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-1024}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+var_arm64="${var_arm64:-no}" # TeamSpeak publishes no arm64 Linux binary
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/teamspeak ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  TS_URL=$(curl -fsSL "https://www.teamspeak.com/en/downloads/" | grep -oE 'https://[^"]*teamspeak3-server_linux_amd64-[0-9.]+\.tar\.bz2' | head -1)
+  TS_VERSION=$(echo "$TS_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+  if [[ "$TS_VERSION" == "$(cat ~/.teamspeak 2>/dev/null)" ]]; then
+    msg_ok "No update required. ${APP} is already at v${TS_VERSION}"
+    exit
+  fi
+
+  msg_info "Stopping Service"
+  systemctl stop teamspeak
+  msg_ok "Stopped Service"
+
+  curl -fsSL "$TS_URL" | tar -xjf - -C /opt/teamspeak --strip-components=1
+  echo "${TS_VERSION}" >~/.teamspeak
+
+  msg_info "Starting Service"
+  systemctl start teamspeak
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Voice port (UDP): ${CL}${BGN}${IP}:9987${CL}"
+echo -e "${INFO}${YW}ServerAdmin privilege key saved to ~/teamspeak.creds${CL}"

--- a/install/teamspeak-install.sh
+++ b/install/teamspeak-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nicolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.teamspeak.com/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+TS_URL=$(curl -fsSL "https://www.teamspeak.com/en/downloads/" | grep -oE 'https://[^"]*teamspeak3-server_linux_amd64-[0-9.]+\.tar\.bz2' | head -1)
+TS_VERSION=$(echo "$TS_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+msg_info "Installing TeamSpeak"
+mkdir -p /opt/teamspeak
+curl -fsSL "$TS_URL" | tar -xjf - -C /opt/teamspeak --strip-components=1
+echo "${TS_VERSION}" >~/.teamspeak
+msg_ok "Installed TeamSpeak"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/teamspeak.service
+[Unit]
+Description=TeamSpeak Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/teamspeak
+ExecStart=/opt/teamspeak/ts3server license_accepted=1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now teamspeak
+msg_ok "Created Service"
+
+msg_info "Waiting for Initial Startup"
+LOGFILE=""
+for i in $(seq 1 20); do
+  LOGFILE=$(grep -l "privilege key" /opt/teamspeak/logs/ts3server_*.log 2>/dev/null | tail -1 || true)
+  if [[ -n "$LOGFILE" ]]; then
+    break
+  fi
+  sleep 1
+done
+msg_ok "Started"
+
+msg_info "Saving Credentials"
+{ grep -A2 "privilege key" "$LOGFILE" 2>/dev/null || true; } >~/teamspeak.creds
+msg_ok "Saved Credentials"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/teamspeak.json
+++ b/json/teamspeak.json
@@ -1,0 +1,52 @@
+{
+  "name": "TeamSpeak",
+  "slug": "teamspeak",
+  "categories": [22],
+  "date_created": "2026-08-24",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 9987,
+  "documentation": "https://www.teamspeak.com/en/support/",
+  "website": "https://www.teamspeak.com/",
+  "repository": "https://www.teamspeak.com/en/downloads/",
+  "architectures": ["amd64"],
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/teamspeak.webp",
+  "description": "TeamSpeak is a proprietary voice and text chat server for online communities and gaming groups, connected to via the official TeamSpeak client.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/teamspeak.sh",
+      "config_path": "/etc/systemd/system/teamspeak.service",
+      "resources": {
+        "cpu": 1,
+        "ram": 1024,
+        "hdd": 4,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "There is no admin username/password to log in with. Connect using the TeamSpeak client, then use the ServerAdmin privilege key saved to /root/teamspeak.creds (Client > Use Privilege Key) to claim admin rights on the server.",
+      "type": "info"
+    },
+    {
+      "text": "Default ports: 9987/udp (voice), 30033/tcp (file transfer), 10011/tcp (ServerQuery). No arm64 build is published upstream.",
+      "type": "info"
+    },
+    {
+      "text": "TeamSpeak Server is closed-source, distributed only as an official binary by TeamSpeak Systems GmbH; this script downloads it directly from teamspeak.com and accepts the license non-interactively (license_accepted=1), the same mechanism used by TeamSpeak's own official Docker image.",
+      "type": "info"
+    },
+    {
+      "text": "Without a paid license key, TeamSpeak runs free with 1 virtual server and up to 32 slots — plenty for personal/community use.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.**

## ✍️ Description

Adds TeamSpeak Server, a voice/text chat server for online communities and
gaming groups — in continuous use since the early 2000s and still one of the
most widely deployed platforms of its kind.

Built primarily with AI assistance (Claude Sonnet 5, standard reasoning
effort), following `AGENTS.md` and `.github/agents/pve-script-creator.agent.md`.
Reviewed and corrected across several real install/update runs on a live
Proxmox VE 9.2.6 host — three real bugs only surfaced by actually installing
and connecting a client, not by static checks:

- **`fetch_and_deploy_from_url` doesn't handle bzip2** (`file` reports
  `bzip2 compressed data`, which its type-detection doesn't match). TeamSpeak
  only ships `.tar.bz2`. Worked around with a direct `curl | tar -xjf`
  extraction — no other core helper covers this format, so this isn't
  reinventing an existing one.
- **`grep` with no match exits 1**, and under this project's `catch_errors`
  (which enables `pipefail`), that's treated as a fatal script error even
  though "no match yet" is the expected state while polling for the server's
  first-boot log line. Guarded every such check with `|| true`.
- **The credentials the script originally tried to capture don't exist** in
  this version. Older TeamSpeak docs describe a "ServerQuery Admin Account
  created" log block with a password — current 3.13.8 never prints it on a
  fresh single-virtual-server install. Only the "ServerAdmin privilege key"
  (used once, in the client, to claim admin) actually appears. Adjusted the
  script, JSON notes and default_credentials to match observed reality
  instead of outdated documentation.

Other notable points for review:

- **No GitHub release API** — TeamSpeak is closed-source with no public
  source repo, distributed only from teamspeak.com. The install/update
  scripts resolve the current download URL and version by reading that page
  at run time (regex against the direct download link), since no version API
  exists. This is a real fragility trade-off, discussed and accepted over
  hardcoding a version (which would make `updateable: true` misleading and
  go stale immediately per this repo's own guidance against pinned versions).
- **License acceptance is automated** (`license_accepted=1` passed to
  `ts3server`), the same non-interactive mechanism used by TeamSpeak's own
  official Docker image (`TS3SERVER_LICENSE=accept`) — confirmed against
  their published Dockerfile/entrypoint before using it.
- **No arm64**: confirmed by inspecting the actual downloads page — only
  `linux_amd64`, `linux_x86`, and `freebsd_amd64` builds are published.
- Free tier (no license key) runs 1 virtual server with up to 32 slots —
  no account/payment needed for typical community use.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [ ] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [X] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 📋 Additional Information (optional)

Tested on a live Proxmox VE 9.2.6 host via the public-fork `curl` one-liner
(`docs/guides/source-origin.md` variant 1): fresh install, service/port
verification (9987/udp, 10011/tcp, 30033/tcp), a forced update run (old
version marker → real re-download → restart), and confirmed the virtual
server's database/config survive an update (no new privilege key generated
on the update restart, meaning existing data wasn't wiped).

**600+ stars**: TeamSpeak Server has no public source repository (closed-source),
so there's no GitHub star count to check — noting this explicitly rather than
leaving the box ambiguous. Judging by real-world adoption instead: it's one
of the most widely deployed voice platforms in gaming, in continuous use for
over two decades.

## 🌐 Source
- Website / downloads: https://www.teamspeak.com/en/downloads/
- TeamSpeak 6 (beta) note: they do publish a real GitHub repo for the
  next-gen server (github.com/teamspeak/teamspeak6-server) with proper
  releases, but its server licensing is still marked "Coming Soon" on their
  own site — deliberately not building on that yet.
