### PR TITLE
New script: JumpServer

### DIFF
--- a/ct/jumpserver.sh
+++ b/ct/jumpserver.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nícolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.jumpserver.org/ | Github: https://github.com/jumpserver/jumpserver
+
+APP="JumpServer"
+var_tags="${var_tags:-bastion-host;pam}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-8192}"
+var_disk="${var_disk:-50}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; koko/lion ship arm64 binaries and guacd builds fine on arm64, but the combined stack has not actually been run on arm64
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/jumpserver ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "jumpserver" "jumpserver/jumpserver" "" "" "v4."; then
+    msg_info "Stopping Services"
+    systemctl stop jumpserver koko lion
+    msg_ok "Stopped Services"
+
+    create_backup /opt/jumpserver/config.yml /opt/jumpserver/data/media /opt/koko/config.yml /opt/lion/config.yml
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "jumpserver" "jumpserver/jumpserver" "tarball" "latest" "" "" "v4."
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "koko" "jumpserver/koko" "prebuild" "latest" "/opt/koko" "koko-v4.*-linux-$(arch_resolve amd64 arm64).tar.gz" "v4."
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "lion" "jumpserver/lion-release" "prebuild" "latest" "/opt/lion" "lion-v*-linux-$(arch_resolve amd64 arm64).tar.gz"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "lina" "jumpserver/lina" "prebuild" "latest" "/opt/lina" "lina-v4.*.tar.gz" "v4."
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "luna" "jumpserver/luna" "prebuild" "latest" "/opt/luna" "luna-v4.*.tar.gz" "v4."
+
+    restore_backup
+
+    msg_info "Updating Python Environment"
+    cd /opt/jumpserver
+    $STD bash requirements/static_files.sh
+    $STD uv venv --python 3.14
+    $STD uv pip install -r pyproject.toml
+    JMS_GALAXY_RETRIES=3
+    until ANSIBLE_COLLECTIONS_PATHS="/opt/jumpserver/.venv/lib/python3.14/site-packages/ansible_collections" $STD .venv/bin/ansible-galaxy collection install -r requirements/collections.yml --force --ignore-certs; do
+      JMS_GALAXY_RETRIES=$((JMS_GALAXY_RETRIES - 1))
+      if ((JMS_GALAXY_RETRIES <= 0)); then
+        msg_error "ansible-galaxy collection install failed after 3 attempts (Ansible Galaxy may be unreachable)"
+        exit 1
+      fi
+      sleep 15
+    done
+    msg_ok "Updated Python Environment"
+
+    msg_info "Starting Services"
+    systemctl start jumpserver koko lion
+    msg_ok "Started Services"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}${CL}"
+echo -e "${INFO}${YW}SSH bastion (character protocols): ${CL}${BGN}ssh -p 2222 <user>@${IP}${CL}"
+echo -e "${INFO}${YW}Login credentials: ~/jumpserver.creds (inside the container)${CL}"

--- a/install/jumpserver-install.sh
+++ b/install/jumpserver-install.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Nícolas Pastorello (opastorello)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://www.jumpserver.org/ | Github: https://github.com/jumpserver/jumpserver
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  build-essential \
+  pkg-config \
+  default-libmysqlclient-dev \
+  freetds-dev \
+  gettext \
+  locales \
+  libkrb5-dev \
+  libldap2-dev \
+  libsasl2-dev \
+  libcairo2-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  uuid-dev \
+  libavcodec-dev \
+  libavformat-dev \
+  libavutil-dev \
+  libswscale-dev \
+  freerdp3-dev \
+  libwinpr3-dev \
+  libpango1.0-dev \
+  libssh2-1-dev \
+  libtelnet-dev \
+  libvncserver-dev \
+  libwebsockets-dev \
+  libpulse-dev \
+  libssl-dev \
+  libvorbis-dev \
+  libwebp-dev \
+  redis-server \
+  nginx
+msg_ok "Installed Dependencies"
+
+PG_VERSION="16" setup_postgresql
+PG_DB_NAME="jumpserver" PG_DB_USER="jumpserver" setup_postgresql_db
+
+msg_info "Starting Redis"
+systemctl enable -q --now redis-server
+msg_ok "Started Redis"
+
+PYTHON_VERSION="3.14" setup_uv
+
+fetch_and_deploy_from_url "https://dlcdn.apache.org/guacamole/1.5.5/source/guacamole-server-1.5.5.tar.gz" "/opt/guacamole-server"
+
+msg_info "Building guacd"
+cd /opt/guacamole-server
+find . -exec touch -t 202401010000 {} +
+touch -t 202401010001 configure.ac aclocal.m4 config.h.in
+touch -t 202401010002 configure
+find . -name "Makefile.in" -exec touch -t 202401010003 {} +
+$STD ./configure --with-systemd-dir=/etc/systemd/system --disable-guacenc
+$STD make -j"$(nproc)"
+$STD make install
+$STD ldconfig
+systemctl enable -q --now guacd
+msg_ok "Built guacd"
+
+fetch_and_deploy_gh_release "jumpserver" "jumpserver/jumpserver" "tarball" "latest" "" "" "v4."
+
+JMS_BOOTSTRAP_TOKEN=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-32)
+
+msg_info "Configuring JumpServer Core"
+cat <<EOF >/opt/jumpserver/config.yml
+SECRET_KEY: $(openssl rand -base64 64 | tr -dc 'a-zA-Z0-9' | cut -c1-49)
+BOOTSTRAP_TOKEN: ${JMS_BOOTSTRAP_TOKEN}
+DB_ENGINE: postgresql
+DB_HOST: 127.0.0.1
+DB_PORT: 5432
+DB_USER: jumpserver
+DB_PASSWORD: ${PG_DB_PASS}
+DB_NAME: jumpserver
+REDIS_HOST: 127.0.0.1
+REDIS_PORT: 6379
+HTTP_BIND_HOST: 0.0.0.0
+HTTP_LISTEN_PORT: 8080
+WS_LISTEN_PORT: 8070
+LOG_LEVEL: ERROR
+EOF
+cd /opt/jumpserver
+$STD bash requirements/static_files.sh
+$STD uv venv --python 3.14
+$STD uv pip install -r pyproject.toml
+JMS_GALAXY_RETRIES=3
+until ANSIBLE_COLLECTIONS_PATHS="/opt/jumpserver/.venv/lib/python3.14/site-packages/ansible_collections" $STD .venv/bin/ansible-galaxy collection install -r requirements/collections.yml --force --ignore-certs; do
+  JMS_GALAXY_RETRIES=$((JMS_GALAXY_RETRIES - 1))
+  if ((JMS_GALAXY_RETRIES <= 0)); then
+    msg_error "ansible-galaxy collection install failed after 3 attempts (Ansible Galaxy may be unreachable)"
+    exit 1
+  fi
+  sleep 15
+done
+msg_ok "Configured JumpServer Core"
+
+msg_info "Creating Core Service"
+cat <<EOF >/etc/systemd/system/jumpserver.service
+[Unit]
+Description=JumpServer Core Service
+After=network.target postgresql.service redis-server.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/jumpserver
+Environment=ANSIBLE_COLLECTIONS_PATHS=/opt/jumpserver/.venv/lib/python3.14/site-packages/ansible_collections
+Environment=PATH=/opt/jumpserver/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/opt/jumpserver/.venv/bin/python3 /opt/jumpserver/jms start all
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now jumpserver
+msg_ok "Created Core Service"
+
+msg_info "Securing Admin Account"
+for _ in $(seq 1 90); do
+  curl -fsS -o /dev/null http://127.0.0.1:8080/api/health/ 2>/dev/null && break
+  sleep 5
+done
+JMS_ADMIN_PASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-16)
+PYTHONPATH=/opt/jumpserver/apps DJANGO_SETTINGS_MODULE=jumpserver.settings $STD .venv/bin/python3 -c "
+import django
+django.setup()
+from users.models import User
+u = User.objects.get(username='admin')
+u.set_password('${JMS_ADMIN_PASS}')
+u.need_update_password = False
+u.save()
+"
+cat <<EOF >~/jumpserver.creds
+JumpServer Admin Credentials
+Username: admin
+Password: ${JMS_ADMIN_PASS}
+EOF
+msg_ok "Secured Admin Account"
+
+fetch_and_deploy_gh_release "koko" "jumpserver/koko" "prebuild" "latest" "/opt/koko" "koko-v4.*-linux-$(arch_resolve amd64 arm64).tar.gz" "v4."
+
+msg_info "Configuring KoKo"
+cat <<EOF >/opt/koko/config.yml
+CORE_HOST: http://127.0.0.1:8080
+BOOTSTRAP_TOKEN: ${JMS_BOOTSTRAP_TOKEN}
+REDIS_HOST: 127.0.0.1
+REDIS_PORT: 6379
+EOF
+cat <<EOF >/etc/systemd/system/koko.service
+[Unit]
+Description=JumpServer KoKo Service
+After=network.target jumpserver.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/koko
+ExecStart=/opt/koko/koko
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now koko
+msg_ok "Configured KoKo"
+
+fetch_and_deploy_gh_release "lion" "jumpserver/lion-release" "prebuild" "latest" "/opt/lion" "lion-v*-linux-$(arch_resolve amd64 arm64).tar.gz"
+
+msg_info "Configuring Lion"
+cat <<EOF >/opt/lion/config.yml
+CORE_HOST: http://127.0.0.1:8080
+BOOTSTRAP_TOKEN: ${JMS_BOOTSTRAP_TOKEN}
+GUA_HOST: 127.0.0.1
+GUA_PORT: 4822
+REDIS_HOST: 127.0.0.1
+REDIS_PORT: 6379
+EOF
+cat <<EOF >/etc/systemd/system/lion.service
+[Unit]
+Description=JumpServer Lion Service
+After=network.target guacd.service jumpserver.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/lion
+ExecStart=/opt/lion/lion
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now lion
+msg_ok "Configured Lion"
+
+fetch_and_deploy_gh_release "lina" "jumpserver/lina" "prebuild" "latest" "/opt/lina" "lina-v4.*.tar.gz" "v4."
+fetch_and_deploy_gh_release "luna" "jumpserver/luna" "prebuild" "latest" "/opt/luna" "luna-v4.*.tar.gz" "v4."
+
+msg_info "Configuring Nginx"
+rm -f /etc/nginx/sites-enabled/default
+cat <<EOF >/etc/nginx/sites-available/jumpserver
+server {
+    listen 80 default_server;
+    client_max_body_size 4096m;
+
+    location / {
+        rewrite ^/(.*)\$ /ui/\$1 last;
+    }
+
+    location /ui/ {
+        try_files \$uri / /index.html;
+        alias /opt/lina/;
+    }
+
+    location /luna/ {
+        try_files \$uri / /index.html;
+        alias /opt/luna/;
+    }
+
+    location /static/ {
+        root /opt/jumpserver/data/;
+    }
+
+    location /private-media/ {
+        internal;
+        alias /opt/jumpserver/data/media/;
+    }
+
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/(core|api|media)/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_ignore_client_abort on;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 6000;
+    }
+
+    location /koko/ {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_ignore_client_abort on;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 6000;
+    }
+
+    location /lion/ {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_ignore_client_abort on;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 6000;
+    }
+}
+EOF
+ln -sf /etc/nginx/sites-available/jumpserver /etc/nginx/sites-enabled/jumpserver
+systemctl enable -q nginx
+systemctl restart nginx
+msg_ok "Configured Nginx"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/jumpserver.json
+++ b/json/jumpserver.json
@@ -1,0 +1,51 @@
+{
+  "name": "JumpServer",
+  "slug": "jumpserver",
+  "categories": [6],
+  "date_created": "2026-08-25",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 80,
+  "documentation": "https://docs.jumpserver.org/",
+  "website": "https://www.jumpserver.org/",
+  "repository": "https://github.com/jumpserver/jumpserver",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/jumpserver.webp",
+  "description": "JumpServer is an open-source PAM (Privileged Access Management) / bastion host that provides unified, audited access to SSH, RDP, VNC, Telnet, Kubernetes and database assets through a single web console, with full session recording and playback.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/jumpserver.sh",
+      "config_path": "/opt/jumpserver/config.yml",
+      "resources": {
+        "cpu": 4,
+        "ram": 8192,
+        "hdd": 50,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "The generated admin password is saved to ~/jumpserver.creds inside the container. This script sets it directly (bypassing upstream's own admin/ChangeMe default) because logging in with that default currently crashes with a server error on JumpServer v4.10.19 — its own weak-password check raises an exception the API can't render.",
+      "type": "info"
+    },
+    {
+      "text": "The SSH bastion (character-protocol) endpoint is on port 2222, e.g. ssh -p 2222 <user>@<container-ip> — this is separate from the web console on port 80.",
+      "type": "info"
+    },
+    {
+      "text": "First start takes several minutes: the core service runs database migrations, downloads a GeoIP database, and installs built-in RDP applets on its own before the web UI becomes reachable.",
+      "type": "info"
+    },
+    {
+      "text": "This is a large, multi-service stack (core, KoKo, Lion + guacd, PostgreSQL, Redis, Nginx) — the default 4 vCPU / 8GB RAM / 50GB disk sizing reflects that, not a typical single-service app.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description
Adds JumpServer (open-source PAM / bastion host), fully native — no Docker anywhere. Core (Python 3.14/uv), KoKo, Lion + guacd (compiled from Apache's release tarball), Lina/Luna, PostgreSQL, Redis and Nginx all run as systemd services in one LXC.

A prior attempt at this script (now under `ct/deferred/jumpserver.sh`) used upstream's own `jmsctl.sh` installer, which uses Docker Compose under the hood — that's why it was deferred. This is a from-scratch native rebuild.

## 🔗 Related PR / Issue

Link: #

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No breaking changes** – Existing functionality remains intact.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support

- [x] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.

---

## 🛠️ Type of Change

- [x] 🆕 **New script** – A fully functional and tested script or script set.

---

## 🔍 Code & Security Review

- [x] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [x] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [x] **No hardcoded credentials**
- [x] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [x] **No git pull** – Updates use `fetch_and_deploy_gh_release` / `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance

- [x] **AI was used** – I confirm the scripts were built using `AGENTS.md` and `.github/agents/pve-script-creator.agent.md` as guidance, and the output has been reviewed and corrected to match those guidelines. Built with Claude (Sonnet 5); every bug listed below was found and fixed by actually running the install on a real Proxmox host, repeatedly, until it came up clean with zero service restarts.

---

## 📋 Additional Information

**Tested end-to-end on a real Proxmox 9.2 host** (repeated clean installs, not just `bash -n`). Bugs found and fixed along the way:
- `freerdp3-dev` is the correct Debian 13 package name, not `libfreerdp3-dev`
- guacd's release tarball needs its autotools timestamps normalized after extraction (`touch` in stages, dependency order), or `make` tries to regenerate `configure` via `aclocal`/`autoconf`, which aren't installed
- `--disable-guacenc` — Debian 13's newer libavcodec breaks guacenc's build under `-Werror` on a deprecated API; guacenc (recording→video conversion) isn't used by Lion anyway
- `jumpserver`/`koko`/`lina`/`luna` all publish two parallel release lines (3.10.x and 4.10.x), and 3.10.x was republished *after* 4.10.x on GitHub — so `check_for_gh_release`/`fetch_and_deploy_gh_release`'s default "latest" picked the wrong (Python 3.11/Poetry) line. Fetches are scoped to the 4.x line via the `tag_prefix` argument
- `requirements/static_files.sh` (shipped in the jumpserver tarball itself) must run before first start, or core crash-loops forever on a missing `leak_passwords.db`
- the systemd unit needs `.venv/bin` on `PATH`, or `jms start` can't find `gunicorn`/`celery`/`daphne`
- JumpServer v4.10.19's own `admin`/`ChangeMe` default currently 500s on login — an upstream bug in its weak-password check throws an exception the DRF error handler can't render. Worked around by setting a strong generated admin password directly via the Django ORM during install, saved to `~/jumpserver.creds`
- `galaxy.ansible.com` intermittently 502s during `ansible-galaxy collection install`; added a 3-attempt retry

**One intentional deviation worth flagging for review:** guacd is pinned to `1.5.5` (fetched via `fetch_and_deploy_from_url` from Apache's dist server) instead of tracking "latest". This is deliberate, not an oversight — it's the exact version upstream's own `jumpserver/lion` Dockerfile builds against (`FROM jumpserver/guacd:1.5.5-trixie`), and Apache Guacamole doesn't publish releases through a GitHub Releases API, so there's no `fetch_and_deploy_gh_release`-compatible way to auto-track it.

## 🌐 Source
- https://github.com/jumpserver/jumpserver
- https://github.com/jumpserver/koko
- https://github.com/jumpserver/lion-release
- https://github.com/jumpserver/lina
- https://github.com/jumpserver/luna
- https://guacamole.apache.org/

## 📦 Application Requirements (for new scripts)

- [x] The application is **at least 6 months old**
- [x] The application is **actively maintained**
- [x] The application has **600+ GitHub stars**
- [x] Official **release tarballs** are published
- [x] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG