### PR TITLE
Add OpenViking

### DIFF
--- a/ct/openviking.sh
+++ b/ct/openviking.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Marcos Felipe (mfelipe)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/volcengine/OpenViking
+
+APP="OpenViking"
+var_tags="${var_tags:-ai;memory;rag}"
+var_arm64="${var_arm64:-yes}"
+var_unprivileged="${var_unprivileged:-1}"
+if [[ -z "${var_os:-}" ]] && command -v pveversion >/dev/null 2>&1; then
+  var_os=$(msg_menu "Choose the container OS" \
+    "debian" "Debian 13 (recommended)" \
+    "alpine" "Alpine 3.24 (smaller footprint)")
+fi
+
+if [[ "${var_os:-}" == "alpine" ]]; then
+  var_cpu="${var_cpu:-1}"
+  var_ram="${var_ram:-1024}"
+  var_disk="${var_disk:-8}"
+  var_version="${var_version:-3.24}"
+else
+  var_cpu="${var_cpu:-2}"
+  var_ram="${var_ram:-2048}"
+  var_disk="${var_disk:-8}"
+  var_version="${var_version:-13}"
+fi
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+update_deb_based() {
+  if [[ ! -d /opt/openviking ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating Debian Packages"
+  $STD apt update
+  $STD apt -y upgrade
+  msg_ok "Updated Debian Packages"
+
+  if check_for_gh_release "openviking-server" "volcengine/OpenViking"; then
+    msg_info "Stopping Service"
+    systemctl stop openviking
+    msg_ok "Stopped Service"
+
+    msg_info "Updating ${APP}"
+    $STD uv pip install --python /opt/openviking/bin/python --upgrade openviking
+    msg_ok "Updated ${APP}"
+
+    msg_info "Starting Service"
+    systemctl start openviking
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+}
+
+update_alpine() {
+  if [[ ! -d /opt/openviking ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating Alpine Packages"
+  $STD apk -U upgrade
+  msg_ok "Updated Alpine Packages"
+
+  if check_for_gh_release "openviking-server" "volcengine/OpenViking"; then
+    msg_info "Stopping Service"
+    $STD rc-service openviking stop
+    msg_ok "Stopped Service"
+
+    msg_info "Updating ${APP}"
+    $STD uv pip install --python /opt/openviking/bin/python --upgrade openviking
+    msg_ok "Updated ${APP}"
+
+    msg_info "Starting Service"
+    $STD rc-service openviking start
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+}
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  run_os_update
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:1933/studio${CL}"
+echo -e "${INFO}${YW}Root API Key:${CL}"
+echo -e "${TAB}${DGN}$(pct exec "$CTID" -- sed -n 's/.*"root_api_key": "\([^"]*\)".*/\1/p' /opt/openviking_data/ov.conf)${CL}"
+echo -e "${INFO}${YW}Model API keys are configured in /opt/openviking_data/ov.conf${CL}"
+echo -e "${TAB}${DGN}Edit the file and restart the openviking service afterwards${CL}"

--- a/install/openviking-install.sh
+++ b/install/openviking-install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Marcos Felipe (mfelipe)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/volcengine/OpenViking
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+_ov_install_server() {
+  PYTHON_VERSION="3.12" setup_uv
+
+  msg_info "Installing OpenViking"
+  $STD uv venv --python 3.12 /opt/openviking
+  $STD uv pip install --python /opt/openviking/bin/python openviking
+  cat <<EOF >~/.openviking-server
+$(get_latest_github_release "volcengine/OpenViking")
+EOF
+  msg_ok "Installed OpenViking"
+
+  msg_info "Configuring OpenViking"
+  ROOT_API_KEY=$(openssl rand -hex 32)
+  mkdir -p /opt/openviking_data
+  cat <<EOF >/opt/openviking_data/ov.conf
+{
+  "server": {
+    "host": "0.0.0.0",
+    "port": 1933,
+    "root_api_key": "${ROOT_API_KEY}",
+    "cors_origins": ["*"]
+  },
+  "storage": {
+    "workspace": "/opt/openviking_data/data",
+    "agfs": { "backend": "local" },
+    "vectordb": { "backend": "local" }
+  },
+  "embedding": {
+    "dense": {
+      "api_base": "https://api.openai.com/v1",
+      "api_key": "REPLACE_WITH_YOUR_EMBEDDING_API_KEY",
+      "provider": "openai",
+      "dimension": 1536,
+      "model": "text-embedding-3-small"
+    }
+  },
+  "vlm": {
+    "api_base": "https://api.openai.com/v1",
+    "api_key": "REPLACE_WITH_YOUR_VLM_API_KEY",
+    "provider": "openai",
+    "model": "gpt-4o"
+  }
+}
+EOF
+  chmod 600 /opt/openviking_data/ov.conf
+  msg_ok "Configured OpenViking"
+}
+
+_ov_wait_ready() {
+  local ready=0
+  for _ in {1..30}; do
+    if curl -fsS -o /dev/null "http://127.0.0.1:1933/health"; then
+      ready=1
+      break
+    fi
+    sleep 2
+  done
+  if [[ "$ready" -ne 1 ]]; then
+    msg_error "OpenViking did not become healthy within 60 seconds — check 'systemctl status openviking' (Debian) or 'rc-service openviking status' (Alpine)"
+    exit 1
+  fi
+}
+
+setup_deb_based() {
+  msg_info "Installing Dependencies"
+  $STD apt install -y openssl
+  msg_ok "Installed Dependencies"
+
+  _ov_install_server
+
+  msg_info "Creating Service"
+  cat <<EOF >/etc/systemd/system/openviking.service
+[Unit]
+Description=OpenViking HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/openviking_data
+Environment="OPENVIKING_CONFIG_FILE=/opt/openviking_data/ov.conf"
+ExecStart=/opt/openviking/bin/openviking-server
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl enable -q --now openviking
+  _ov_wait_ready
+  msg_ok "Created Service"
+}
+
+setup_alpine() {
+  msg_info "Installing Dependencies"
+  $STD apk add openssl
+  msg_ok "Installed Dependencies"
+
+  _ov_install_server
+
+  msg_info "Creating Service"
+  cat <<'EOF' >/etc/init.d/openviking
+#!/sbin/openrc-run
+name="OpenViking"
+description="OpenViking - a self-evolving context database for AI agents"
+
+command="/opt/openviking/bin/openviking-server"
+command_user="root"
+supervisor=supervise-daemon
+output_log="/var/log/openviking.log"
+error_log="/var/log/openviking.log"
+pidfile="/run/${RC_SVCNAME}.pid"
+respawn_delay=10
+
+depend() {
+  need net
+  after firewall
+}
+
+start_pre() {
+  checkpath -d -m 0750 -o root:root /opt/openviking_data
+  checkpath -f -m 0640 "$output_log"
+}
+EOF
+  chmod +x /etc/init.d/openviking
+  cat <<EOF >/etc/conf.d/openviking
+export OPENVIKING_CONFIG_FILE=/opt/openviking_data/ov.conf
+EOF
+  $STD rc-update add openviking default
+  $STD rc-service openviking start
+  _ov_wait_ready
+  msg_ok "Created Service"
+}
+
+run_os_setup
+
+msg_info "Running OpenViking Doctor"
+if OPENVIKING_CONFIG_FILE=/opt/openviking_data/ov.conf /opt/openviking/bin/openviking-server doctor >/dev/null 2>&1; then
+  msg_ok "Doctor check passed"
+else
+  msg_warn "Doctor check reported warnings — configure the model API keys in /opt/openviking_data/ov.conf and restart the service"
+fi
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/openviking.json
+++ b/json/openviking.json
@@ -1,0 +1,61 @@
+{
+  "name": "OpenViking",
+  "slug": "openviking",
+  "categories": [
+    20
+  ],
+  "date_created": "2026-08-25",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "architectures": [
+    "amd64",
+    "arm64"
+  ],
+  "interface_port": 1933,
+  "documentation": "https://docs.openviking.ai/",
+  "website": "https://www.openviking.ai/",
+  "repository": "https://github.com/volcengine/OpenViking",
+  "logo": "https://raw.githubusercontent.com/volcengine/OpenViking/main/web-studio/public/icon-512.png",
+  "description": "OpenViking is a self-evolving context database for AI agents that unifies agent memory, knowledge RAG and skills. Run it as a standalone HTTP server and connect any client (Python SDK, CLI, or the bundled Web Studio).",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/openviking.sh",
+      "config_path": "/opt/openviking_data/ov.conf",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    },
+    {
+      "type": "alpine",
+      "script": "ct/openviking.sh",
+      "config_path": "/opt/openviking_data/ov.conf",
+      "resources": {
+        "cpu": 1,
+        "ram": 1024,
+        "hdd": 8,
+        "os": "Alpine",
+        "version": "3.24"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Model API keys must be configured in /opt/openviking_data/ov.conf (embedding and VLM sections) before the server can store or retrieve memory. Edit the file and restart the service afterwards.",
+      "type": "warning"
+    },
+    {
+      "text": "A root API key is generated during install and printed at the end of the setup; it is also stored as server.root_api_key in /opt/openviking_data/ov.conf.",
+      "type": "info"
+    }
+  ]
+}


### PR DESCRIPTION
## **Scripts which are clearly AI generated and not further revised by the Author of this PR (in terms of Coding Standards and Script Layout) may be closed without review. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.**

## ✍️ Description
Adds **OpenViking** ([volcengine/OpenViking](https://github.com/volcengine/OpenViking)) — a self-evolving context database for AI agents that unifies agent memory, knowledge RAG and skills — as a new Proxmox VE LXC application.

- **`ct/openviking.sh`** — single dual-OS CT script supporting **Debian 13** and **Alpine 3.24** (OS picker via `msg_menu`, resource defaults per OS, update path via `run_os_update`). Updates use `check_for_gh_release` + `uv pip install --upgrade` with the service stopped/restarted.
- **`install/openviking-install.sh`** — bare-metal install into a uv-managed venv at `/opt/openviking`; the OpenViking HTTP server (port 1933, Web Studio at `/studio`). Persistent config + data live in `/opt/openviking_data` (outside the app dir, so updates need no backup step). Systemd unit (Debian) and OpenRC service (Alpine). Waits on the `/health` liveness probe (silent) before reporting success, then runs `openviking-server doctor`.
- **`json/openviking.json`** — metadata with both install methods (Debian + Alpine) pointing at the same script (based on the existing Valkey community script).

A root API key is generated at install and printed at the end; the server auto-selects `api_key` auth mode because `root_api_key` is set.

## 🔗 Related PR / Issue

Link: # — none (new script submission)

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected. *(Alpine 3.24 and Debian 13 verified on real hardware — see Additional Information.)*
- [X] **No breaking changes** – Existing functionality remains intact.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🏗️ arm64 Support (**X** in brackets)

- [ ] **arm64 supported** - Tested and supported on arm64.
- [X] **arm64 not tested** - Assumed to work on arm64, but testing has not been done.
- [ ] **arm64 not supported** - Confirmed upstream dependencies or binaries do not support arm64.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🔍 Code & Security Review  (**X** in brackets)

- [X] **Follows `CODE-AUDIT.md` & `CONTRIBUTING.md` guidelines**
- [X] **Uses correct script structure (`AppName.sh`, `AppName-install.sh`, `AppName.json`)**
- [X] **No hardcoded credentials**
- [X] **No Docker / Docker Compose** – The application is installed bare-metal; Docker is not used.
- [X] **No git pull** – Updates use `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release`, `fetch_and_deploy_gl_release`, or `fetch_and_deploy_from_url` instead of `git pull`.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.
  > Assisted by **Cline (high reasoning)** — all three files were reviewed against the project's coding standards and corrected accordingly.

---

## 📋 Additional Information (optional)

- **arm64 note:** `var_arm64=yes` and `architectures: ["amd64","arm64"]` are set because the upstream project publishes arm64 wheels/artifacts, but this has **not been hardware-verified on arm64 yet** — happy to adjust if the maintainers prefer the *unset/ask* state until it's run.
- **Update mechanism note:** OpenViking ships on **PyPI**, not GitHub release assets, so updates use `uv pip install --upgrade` gated by `check_for_gh_release "openviking-server" "volcengine/OpenViking"` (version tracked in `~/.openviking-server`). No `fetch_and_deploy_*` applies here; no `git pull` is used.
- **Testing status:** Alpine 3.24 and Debian 13 install verified end-to-end on Proxmox VE 9 (CT created, service up, `/health` OK, Web Studio reachable).

---

## 📦 Application Requirements (for new scripts)

> ⚠️ Do not remove this section.
> It is used by automated PR validation checks.
> If this PR is not a new script submission, leave the checkboxes unchecked.

> Required for **🆕 New script** submissions.
> Pull requests that do not meet these requirements may be closed without review.
- [X] The application is **at least 6 months old** *(created 2026-01-05)*
- [X] The application is **actively maintained** *(pushed 2026-08-25; releases v0.4.x weekly)*
- [X] The application has **600+ GitHub stars** *(+33K ⭐)*
- [X] Official **release tarballs** are published *(e.g. v0.4.16; also distributed via PyPI)*
- [X] I understand that not all scripts will be accepted due to various reasons and criteria by the community-scripts ORG

## 🌐 Source
- Repository: https://github.com/volcengine/OpenViking
- Documentation: https://docs.openviking.ai/
- Website: https://www.openviking.ai/