### PR TITLE
Add Proxfy

### DIFF
--- a/ct/proxfy.sh
+++ b/ct/proxfy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Engine comes from community-scripts/core; this repo only ships the scripts.
+# A local core checkout wins (COMMUNITY_SCRIPTS_CORE_DIR, else a sibling ../core),
+# so a fork or branch of core can be tested without editing this file.
+_cs_boot="${COMMUNITY_SCRIPTS_CORE_DIR:-$(dirname "${BASH_SOURCE[0]}")/../../core}/core/build.func"
+source "$_cs_boot" 2>/dev/null || source <(curl -fsSL "${COMMUNITY_SCRIPTS_CORE_URL:-https://raw.githubusercontent.com/community-scripts/core/main}/core/build.func")
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Justin Tröbinger (bonderaustria)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/bonderaustria/proxfy
+
+APP="Proxfy"
+var_tags="${var_tags:-backup;verification;proxmox}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-1024}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+#var_arm64="${var_arm64:-no}" # unset = ask the user; set yes/no only when verified
+
+# Proxfy drives the hypervisor over SSH, so it needs to know where it is and
+# needs its public key in the host's authorized_keys. The address is required.
+# The password is optional and only used once, to place that key; it is never
+# written to disk.
+export var_pve_host="${var_pve_host:-}"
+export var_pve_password="${var_pve_password:-}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+if [[ -n "${mode:-}" && -z "${var_pve_host}" ]]; then
+  msg_error "var_pve_host is required for unattended installs."
+  exit 1
+fi
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /opt/proxfy/config.yaml ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "proxfy" "bonderaustria/proxfy"; then
+    msg_info "Stopping Services"
+    systemctl stop proxfy proxfy-auth
+    msg_ok "Stopped Services"
+
+    create_backup /opt/proxfy/config.yaml /opt/proxfy/auth.env \
+      /opt/proxfy/proxfy.db /opt/proxfy/auth.db
+
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "proxfy" "bonderaustria/proxfy" "tarball"
+
+    restore_backup
+
+    msg_info "Rebuilding Login Service"
+    cd /opt/proxfy/auth
+    $STD npm install --omit=dev --no-audit --no-fund
+    msg_ok "Rebuilt Login Service"
+
+    msg_info "Starting Services"
+    systemctl start proxfy-auth
+    systemctl start proxfy
+    msg_ok "Started Services"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW}Access it using the following URL:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:8099${CL}"
+echo -e "${INFO}${YW}Open it now and create the first account - until one exists,${CL}"
+echo -e "${INFO}${YW}anyone who can reach the address could create it.${CL}"

--- a/install/proxfy-install.sh
+++ b/install/proxfy-install.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Justin Tröbinger (bonderaustria)
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# Source: https://github.com/bonderaustria/proxfy
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  python3-yaml \
+  openssh-client
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+fetch_and_deploy_gh_release "proxfy" "bonderaustria/proxfy" "tarball"
+
+if [[ -z "${var_pve_host:-}" ]]; then
+  read -rp "${TAB3}Address of the Proxmox host Proxfy should verify backups on: " var_pve_host
+fi
+if [[ -z "${var_pve_host}" ]]; then
+  msg_error "No Proxmox host given - Proxfy cannot reach a hypervisor."
+  exit 1
+fi
+
+msg_info "Creating SSH Key"
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+ssh-keygen -t ed25519 -N '' -C "proxfy@$(hostname)" -f /root/.ssh/id_proxfy -q
+ssh-keyscan -H "${var_pve_host}" >>/root/.ssh/known_hosts 2>/dev/null
+chmod 600 /root/.ssh/known_hosts
+msg_ok "Created SSH Key"
+
+# The key has to end up in the hypervisor's authorized_keys. With a password we
+# can place it here; without one the user does it afterwards and the public key
+# is printed at the end. The password is used once and never stored.
+AUTHORIZED=0
+if [[ -n "${var_pve_password:-}" ]]; then
+  msg_info "Authorizing Key on ${var_pve_host}"
+  $STD apt install -y sshpass
+  if SSHPASS="${var_pve_password}" sshpass -e ssh-copy-id -i /root/.ssh/id_proxfy.pub \
+    -o StrictHostKeyChecking=accept-new "root@${var_pve_host}" >/dev/null 2>&1; then
+    AUTHORIZED=1
+    msg_ok "Authorized Key on ${var_pve_host}"
+  else
+    msg_error "Could not authorize the key - the public key is printed at the end."
+  fi
+  $STD apt purge -y sshpass
+fi
+
+# Storages are selectable per run in the interface; these are only the
+# preselection. Asking the hypervisor works once the key is authorized.
+BACKUP_STORE="PBS"
+TARGET_STORE="local-lvm"
+if [[ "$AUTHORIZED" = "1" ]]; then
+  DETECTED=$(ssh -o BatchMode=yes -i /root/.ssh/id_proxfy "root@${var_pve_host}" \
+    "pvesm status --content backup 2>/dev/null | awk 'NR>1 {print \$1; exit}'" 2>/dev/null)
+  BACKUP_STORE="${DETECTED:-$BACKUP_STORE}"
+  DETECTED=$(ssh -o BatchMode=yes -i /root/.ssh/id_proxfy "root@${var_pve_host}" \
+    "pvesm status --content images 2>/dev/null | awk 'NR>1 {print \$1; exit}'" 2>/dev/null)
+  TARGET_STORE="${DETECTED:-$TARGET_STORE}"
+fi
+
+msg_info "Configuring Proxfy"
+cat <<EOF >/opt/proxfy/config.yaml
+# Backup source, target storage and cluster node are selectable per run in the
+# interface; the values here are only the preselection.
+host:
+  host: ${var_pve_host}
+  user: root
+  key_file: /root/.ssh/id_proxfy
+
+restore:
+  backup_storage: ${BACKUP_STORE}
+  target_storage: ${TARGET_STORE}
+  isolated_bridge: vmbr9
+  lan_bridge: vmbr0
+  boot_timeout: 300
+  agent_timeout: 240
+
+auth:
+  env_file: /opt/proxfy/auth.env
+  port: 8100
+
+# Only enable behind a reverse proxy. Otherwise any caller could invent an
+# origin address in a header and walk around the login lockout.
+trust_forwarded_for: false
+
+# Only used by the collective run on the command line. Triggers nothing by
+# itself - there is no built-in schedule.
+targets: []
+EOF
+
+umask 077
+cat <<EOF >/opt/proxfy/auth.env
+BETTER_AUTH_SECRET=$(openssl rand -base64 36 | tr -d '\n')
+PROXFY_INTERNAL_SECRET=$(openssl rand -hex 32)
+BETTER_AUTH_URL=http://${LOCAL_IP}:8099
+PROXFY_BASE_ORIGINS=http://${LOCAL_IP}:8099,http://$(hostname):8099,http://localhost:8099
+PROXFY_TRUSTED_ORIGINS=http://${LOCAL_IP}:8099,http://$(hostname):8099,http://localhost:8099
+PROXFY_AUTH_DB=/opt/proxfy/auth.db
+PROXFY_AUTH_PORT=8100
+EOF
+chmod 600 /opt/proxfy/auth.env
+umask 022
+msg_ok "Configured Proxfy"
+
+msg_info "Setting up Login Service"
+cd /opt/proxfy/auth
+$STD npm install --omit=dev --no-audit --no-fund
+set -a
+. /opt/proxfy/auth.env
+set +a
+$STD npx --yes auth@latest migrate --yes
+msg_ok "Set up Login Service"
+
+msg_info "Creating Services"
+cat <<EOF >/etc/systemd/system/proxfy-auth.service
+[Unit]
+Description=Proxfy Login Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/proxfy/auth
+EnvironmentFile=/opt/proxfy/auth.env
+ExecStart=/usr/bin/node server.js
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/proxfy.service
+[Unit]
+Description=Proxfy Restore Verification
+After=network-online.target proxfy-auth.service
+Wants=network-online.target proxfy-auth.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/proxfy
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 -m proxfy.cli --config /opt/proxfy/config.yaml serve --port 8099 --db /opt/proxfy/proxfy.db
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now proxfy-auth
+systemctl enable -q --now proxfy
+msg_ok "Created Services"
+
+if [[ "$AUTHORIZED" != "1" ]]; then
+  msg_error "Proxfy cannot reach ${var_pve_host} yet. Run this on the Proxmox host:"
+  echo -e "\n  echo '$(cat /root/.ssh/id_proxfy.pub)' >> /root/.ssh/authorized_keys\n"
+fi
+
+motd_ssh
+customize
+cleanup_lxc

--- a/json/proxfy.json
+++ b/json/proxfy.json
@@ -1,0 +1,71 @@
+{
+  "name": "Proxfy",
+  "slug": "proxfy",
+  "categories": [
+    7,
+    1
+  ],
+  "date_created": "2026-08-26",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 8099,
+  "documentation": "https://github.com/bonderaustria/proxfy#readme",
+  "website": "https://github.com/bonderaustria/proxfy",
+  "repository": "https://github.com/bonderaustria/proxfy",
+  "architectures": [
+    "amd64"
+  ],
+  "logo": "https://cdn.jsdelivr.net/gh/bonderaustria/proxfy@main/proxfy/static/logo.png",
+  "description": "Verifies that Proxmox backups actually restore. Proxmox Backup Server checks chunk checksums, which proves the bytes are intact but not that a working machine comes out of them. Proxfy restores a backup to a throwaway VMID, boots it, runs real checks against the application inside, records the result and removes the guest again. VMs and LXC containers, isolated or on a fixed LAN address.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/proxfy.sh",
+      "config_path": "/opt/proxfy/config.yaml",
+      "resources": {
+        "cpu": 2,
+        "ram": 1024,
+        "hdd": 8,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "app_vars": [
+    {
+      "name": "var_pve_host",
+      "label": "Proxmox Host Address",
+      "type": "text",
+      "required": true
+    },
+    {
+      "name": "var_pve_password",
+      "label": "Proxmox Root Password (optional, used once to authorize the key)",
+      "type": "password",
+      "secret": true
+    }
+  ],
+  "notes": [
+    {
+      "text": "Open the interface right after installation and create the first account. Until one exists, anyone who can reach the address could create it. The first account is the super admin.",
+      "type": "warning"
+    },
+    {
+      "text": "Proxfy drives the hypervisor over SSH and needs its public key in the host's /root/.ssh/authorized_keys. Give the root password of the Proxmox host and the installer places it once, without storing it. Leave it empty and the installer prints the public key with a ready-made command to run on the host.",
+      "type": "info"
+    },
+    {
+      "text": "Test guests are created only in VMID range 9000-9099 and every destructive operation checks that range again. No schedule is created during installation - nothing runs until someone starts a run or creates a schedule in the interface.",
+      "type": "info"
+    },
+    {
+      "text": "The interface uses unencrypted HTTP. Keep it on a trusted network or put a reverse proxy with TLS in front of it before exposing it.",
+      "type": "warning"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds **Proxfy** — restore verification for Proxmox Backup Server.

PBS checks chunk checksums. That proves the bytes are intact; it does not prove
a working machine comes out of them. Proxfy restores a backup to a throwaway
VMID, boots it, runs real checks against the application inside, records the
result and removes the guest again. VMs and LXC containers, either isolated on
a bridge without uplink or on a fixed LAN address for tests that need to reach
something.

- Repository: https://github.com/bonderaustria/proxfy
- License: MIT
- Web interface on port 8099, accounts with TOTP second factor, roles

Nothing runs by itself: there is no built-in schedule and installation creates
none. A guest is only verified when someone starts a run or creates a schedule.
Test guests exist only in VMID range 9000-9099, and every destructive operation
checks that range again before acting.

## Files

- `ct/proxfy.sh`
- `install/proxfy-install.sh`
- `json/proxfy.json`

## The one unusual part

Proxfy drives the hypervisor over SSH, so it needs its public key in the host's
`authorized_keys` — and the install script runs inside the container, which
cannot place it there.

Both ways out are offered, per the `app_vars` pattern:

- `var_pve_host` (required) — where the hypervisor is.
- `var_pve_password` (optional) — used once with `ssh-copy-id` to authorize the
  generated key, then `sshpass` is purged again. Never written to disk.

Left empty, the install prints the public key with a ready-made command to run
on the host. Storage detection falls back to sensible defaults when the key is
not authorized yet; both are selectable per run in the interface anyway.

## Tested

Proxmox VE 9.2.11, Debian 13 container, amd64.

- Container created, both services active after install
- `/login` and `/api/me` answer `HTTP 200`
- Deployed version matches the latest release (`1.0.1`)
- The container reaches the hypervisor over the generated key (`pvesm status`
  returns the PBS storage)

`var_arm64` is deliberately left unset — it has never been run on arm64, and
`architectures` in the JSON says `["amd64"]` to match.

## Checklist

- [x] No Docker
- [x] `fetch_and_deploy_gh_release` with explicit `"tarball"` mode
- [x] `check_for_gh_release` for the update check
- [x] `NODE_VERSION="22" setup_nodejs` (Better Auth requires 22; Debian ships 20)
- [x] `tools.func` functions not wrapped in `msg_info`/`msg_ok`
- [x] `$STD` on apt and npm, `apt` not `apt-get`
- [x] No core packages listed as dependencies
- [x] Update function present, with `create_backup`/`restore_backup` covering
      config, secrets and both databases
- [x] `motd_ssh`, `customize`, `cleanup_lxc` at the end
- [x] JSON metadata in `json/proxfy.json`
